### PR TITLE
Add multi-filtering to tables; refactor details pages into tabs

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -76,9 +76,29 @@ export type Workflow = {
   workspaceFlowState?: WorkspaceFlowState;
   template: UseCaseTemplate;
   lastUpdated: number;
+  state: WORKFLOW_STATE;
 };
 
 export enum USE_CASE {
   SEMANTIC_SEARCH = 'semantic_search',
   CUSTOM = 'custom',
+}
+
+/**
+ ********** MISC TYPES/INTERFACES ************
+ */
+
+// TODO: finalize how we have the launch data model
+export type WorkflowLaunch = {
+  id: string;
+  state: WORKFLOW_STATE;
+  lastUpdated: number;
+};
+
+// TODO: finalize list of possible workflow states from backend
+export enum WORKFLOW_STATE {
+  SUCCEEDED = 'Succeeded',
+  FAILED = 'Failed',
+  IN_PROGRESS = 'In progress',
+  NOT_STARTED = 'Not started',
 }

--- a/public/general_components/general-component-styles.scss
+++ b/public/general_components/general-component-styles.scss
@@ -1,0 +1,5 @@
+.multi-select-filter {
+  &--width {
+    width: 150px;
+  }
+}

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { MultiSelectFilter } from './multi_select_filter';

--- a/public/general_components/multi_select_filter.tsx
+++ b/public/general_components/multi_select_filter.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiFilterSelectItem,
+  EuiFilterGroup,
+  EuiPopover,
+  EuiFilterButton,
+  EuiFlexItem,
+} from '@elastic/eui';
+
+// styling
+import './general-component-styles.scss';
+
+interface MultiSelectFilterProps {
+  title: string;
+  filters: EuiFilterSelectItem[];
+  setSelectedFilters: (filters: EuiFilterSelectItem[]) => void;
+}
+
+/**
+ * A general multi-select filter.
+ */
+export function MultiSelectFilter(props: MultiSelectFilterProps) {
+  const [filters, setFilters] = useState(props.filters);
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+
+  function onButtonClick() {
+    setIsPopoverOpen(!isPopoverOpen);
+  }
+  function onPopoverClose() {
+    setIsPopoverOpen(false);
+  }
+
+  function updateFilter(index: number) {
+    if (!filters[index]) {
+      return;
+    }
+    const newFilters = [...filters];
+    // @ts-ignore
+    newFilters[index].checked =
+      // @ts-ignore
+      newFilters[index].checked === 'on' ? undefined : 'on';
+
+    setFilters(newFilters);
+    props.setSelectedFilters(
+      // @ts-ignore
+      newFilters.filter((filter) => filter.checked === 'on')
+    );
+  }
+
+  return (
+    <EuiFlexItem grow={false} className="multi-select-filter--width">
+      <EuiFilterGroup>
+        <EuiPopover
+          button={
+            <EuiFilterButton
+              iconType="arrowDown"
+              onClick={onButtonClick}
+              isSelected={isPopoverOpen}
+              numFilters={filters.length}
+              hasActiveFilters={
+                // @ts-ignore
+                !!filters.find((filter) => filter.checked === 'on')
+              }
+              numActiveFilters={
+                // @ts-ignore
+                filters.filter((filter) => filter.checked === 'on').length
+              }
+            >
+              {props.title}
+            </EuiFilterButton>
+          }
+          isOpen={isPopoverOpen}
+          closePopover={onPopoverClose}
+          panelPaddingSize="none"
+        >
+          <div className="euiFilterSelect__items multi-select-filter--width">
+            {filters.map((filter, index) => (
+              <EuiFilterSelectItem
+                // @ts-ignore
+                checked={filter.checked}
+                key={index}
+                onClick={() => updateFilter(index)}
+              >
+                {/* @ts-ignore */}
+                {filter.name}
+              </EuiFilterSelectItem>
+            ))}
+          </div>
+        </EuiPopover>
+      </EuiFilterGroup>
+    </EuiFlexItem>
+  );
+}

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -11,6 +11,7 @@ import { saveWorkflow } from '../utils';
 import { rfContext, AppState, removeDirty } from '../../../store';
 
 interface WorkflowDetailHeaderProps {
+  tabs: any[];
   workflow?: Workflow;
 }
 
@@ -22,7 +23,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   return (
     <EuiPageHeader
       pageTitle={props.workflow ? props.workflow.name : ''}
-      description={props.workflow ? props.workflow.description : ''}
       rightSideItems={[
         <EuiButton fill={false} onClick={() => {}}>
           Prototype
@@ -39,6 +39,8 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
           Save
         </EuiButton>,
       ]}
+      tabs={props.tabs}
+      bottomBorder={true}
     />
   );
 }

--- a/public/pages/workflow_detail/launches/columns.tsx
+++ b/public/pages/workflow_detail/launches/columns.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const columns = [
+  {
+    field: 'id',
+    name: 'Launch ID',
+    sortable: true,
+  },
+  {
+    field: 'state',
+    name: 'Status',
+    sortable: true,
+  },
+  {
+    field: 'lastUpdatedTime',
+    name: 'Last updated time',
+    sortable: true,
+  },
+];

--- a/public/pages/workflow_detail/launches/index.ts
+++ b/public/pages/workflow_detail/launches/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { LaunchList } from './launch_list';

--- a/public/pages/workflow_detail/launches/launch_details.tsx
+++ b/public/pages/workflow_detail/launches/launch_details.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+
+interface LaunchDetailsProps {}
+
+export function LaunchDetails(props: LaunchDetailsProps) {
+  return <EuiText>TODO: add selected launch details here</EuiText>;
+}

--- a/public/pages/workflow_detail/launches/launch_list.tsx
+++ b/public/pages/workflow_detail/launches/launch_list.tsx
@@ -4,36 +4,41 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import { debounce } from 'lodash';
 import {
   EuiInMemoryTable,
   Direction,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFilterSelectItem,
   EuiFieldSearch,
+  EuiFilterSelectItem,
 } from '@elastic/eui';
-import { AppState } from '../../../store';
-import { Workflow } from '../../../../common';
+import { WORKFLOW_STATE, WorkflowLaunch } from '../../../../common';
 import { columns } from './columns';
 import { MultiSelectFilter } from '../../../general_components';
 import { getStateOptions } from '../../../utils';
 
-interface WorkflowListProps {}
-
-const sorting = {
-  sort: {
-    field: 'name',
-    direction: 'asc' as Direction,
-  },
-};
+interface LaunchListProps {}
 
 /**
- * The searchable list of created workflows.
+ * The searchable list of launches for this particular workflow.
  */
-export function WorkflowList(props: WorkflowListProps) {
-  const { workflows } = useSelector((state: AppState) => state.workflows);
+export function LaunchList(props: LaunchListProps) {
+  // TODO: finalize how we persist launches for a particular workflow.
+  // We may just add UI metadata tags to group workflows under a single, overall "workflow"
+  // const { workflows } = useSelector((state: AppState) => state.workflows);
+  const workflowLaunches = [
+    {
+      id: 'Launch_1',
+      state: WORKFLOW_STATE.IN_PROGRESS,
+      lastUpdated: 12345678,
+    },
+    {
+      id: 'Launch_2',
+      state: WORKFLOW_STATE.FAILED,
+      lastUpdated: 12345677,
+    },
+  ] as WorkflowLaunch[];
 
   // search bar state
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -45,16 +50,23 @@ export function WorkflowList(props: WorkflowListProps) {
   const [selectedStates, setSelectedStates] = useState<EuiFilterSelectItem[]>(
     getStateOptions()
   );
-  const [filteredWorkflows, setFilteredWorkflows] = useState<Workflow[]>(
-    workflows || []
+  const [filteredLaunches, setFilteredLaunches] = useState<WorkflowLaunch[]>(
+    workflowLaunches
   );
 
-  // When a filter selection or search query changes, update the list
+  // When a filter selection or search query changes, update the filtered launches
   useEffect(() => {
-    setFilteredWorkflows(
-      fetchFilteredWorkflows(workflows, selectedStates, searchQuery)
+    setFilteredLaunches(
+      fetchFilteredLaunches(workflowLaunches, selectedStates, searchQuery)
     );
   }, [selectedStates, searchQuery]);
+
+  const sorting = {
+    sort: {
+      field: 'id',
+      direction: 'asc' as Direction,
+    },
+  };
 
   return (
     <EuiFlexGroup direction="column">
@@ -63,7 +75,7 @@ export function WorkflowList(props: WorkflowListProps) {
           <EuiFlexItem grow={true}>
             <EuiFieldSearch
               fullWidth={true}
-              placeholder="Search workflows..."
+              placeholder="Search launches..."
               onChange={(e) => debounceSearchQuery(e.target.value)}
             />
           </EuiFlexItem>
@@ -75,33 +87,33 @@ export function WorkflowList(props: WorkflowListProps) {
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiInMemoryTable<Workflow>
-          items={filteredWorkflows}
-          rowHeader="name"
+        <EuiInMemoryTable<WorkflowLaunch>
+          items={filteredLaunches}
+          rowHeader="id"
           columns={columns}
           sorting={sorting}
           pagination={true}
-          message={'No existing workflows found'}
+          message={'No existing launches found'}
         />
       </EuiFlexItem>
     </EuiFlexGroup>
   );
 }
 
-// Collect the final workflow list after applying all filters
-function fetchFilteredWorkflows(
-  allWorkflows: Workflow[],
+// Collect the final launch list after applying all filters
+function fetchFilteredLaunches(
+  allLaunches: WorkflowLaunch[],
   stateFilters: EuiFilterSelectItem[],
   searchQuery: string
-): Workflow[] {
+): WorkflowLaunch[] {
   // @ts-ignore
   const stateFilterStrings = stateFilters.map((filter) => filter.name);
-  const filteredWorkflows = allWorkflows.filter((workflow) =>
-    stateFilterStrings.includes(workflow.state)
+  const filteredLaunches = allLaunches.filter((launch) =>
+    stateFilterStrings.includes(launch.state)
   );
   return searchQuery.length === 0
-    ? filteredWorkflows
-    : filteredWorkflows.filter((workflow) =>
-        workflow.name.toLowerCase().includes(searchQuery.toLowerCase())
+    ? filteredLaunches
+    : filteredLaunches.filter((launch) =>
+        launch.id.toLowerCase().includes(searchQuery.toLowerCase())
       );
 }

--- a/public/pages/workflow_detail/launches/launches.tsx
+++ b/public/pages/workflow_detail/launches/launches.tsx
@@ -4,7 +4,13 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageContent,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { LaunchList } from './launch_list';
 import { LaunchDetails } from './launch_details';
@@ -18,13 +24,19 @@ interface LaunchesProps {
  */
 export function Launches(props: LaunchesProps) {
   return (
-    <EuiFlexGroup direction="row">
-      <EuiFlexItem>
-        <LaunchList />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <LaunchDetails />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <EuiPageContent>
+      <EuiTitle>
+        <h2>Launches</h2>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup direction="row">
+        <EuiFlexItem>
+          <LaunchList />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <LaunchDetails />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageContent>
   );
 }

--- a/public/pages/workflow_detail/launches/launches.tsx
+++ b/public/pages/workflow_detail/launches/launches.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { Workflow } from '../../../../common';
+import { LaunchList } from './launch_list';
+import { LaunchDetails } from './launch_details';
+
+interface LaunchesProps {
+  workflow?: Workflow;
+}
+
+/**
+ * The launches page to browse launch history and view individual launch details.
+ */
+export function Launches(props: LaunchesProps) {
+  return (
+    <EuiFlexGroup direction="row">
+      <EuiFlexItem>
+        <LaunchList />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <LaunchDetails />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/prototype/index.ts
+++ b/public/pages/workflow_detail/prototype/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { Launches } from './launches';
+export { Prototype } from './prototype';

--- a/public/pages/workflow_detail/prototype/prototype.tsx
+++ b/public/pages/workflow_detail/prototype/prototype.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexItem, EuiText } from '@elastic/eui';
+import { Workflow } from '../../../../common';
+
+interface PrototypeProps {
+  workflow?: Workflow;
+}
+
+/**
+ * The prototype page. Dedicated for testing out a launched workflow.
+ * Will have default simple interfaces for common application types, such as
+ * conversational chatbots.
+ */
+export function Prototype(props: PrototypeProps) {
+  return (
+    <EuiFlexItem>
+      <EuiText>TODO: add prototype page</EuiText>
+    </EuiFlexItem>
+  );
+}

--- a/public/pages/workflow_detail/prototype/prototype.tsx
+++ b/public/pages/workflow_detail/prototype/prototype.tsx
@@ -4,7 +4,13 @@
  */
 
 import React from 'react';
-import { EuiFlexItem, EuiText } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  EuiPageContent,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { Workflow } from '../../../../common';
 
 interface PrototypeProps {
@@ -18,8 +24,14 @@ interface PrototypeProps {
  */
 export function Prototype(props: PrototypeProps) {
   return (
-    <EuiFlexItem>
-      <EuiText>TODO: add prototype page</EuiText>
-    </EuiFlexItem>
+    <EuiPageContent>
+      <EuiTitle>
+        <h2>Prototype</h2>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiFlexItem>
+        <EuiText>TODO: add prototype page</EuiText>
+      </EuiFlexItem>
+    </EuiPageContent>
   );
 }

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -21,21 +21,18 @@ export interface WorkflowDetailRouterProps {
   workflowId: string;
 }
 
-export interface WorkflowDetailProps
+interface WorkflowDetailProps
   extends RouteComponentProps<WorkflowDetailRouterProps> {}
 
-export enum WORKFLOW_DETAILS_TAB {
+enum WORKFLOW_DETAILS_TAB {
   EDITOR = 'editor',
   LAUNCHES = 'launches',
   PROTOTYPE = 'prototype',
 }
 
-export const ACTIVE_TAB_PARAM = 'tab';
+const ACTIVE_TAB_PARAM = 'tab';
 
-export function replaceActiveTab(
-  activeTab: string,
-  props: WorkflowDetailProps
-) {
+function replaceActiveTab(activeTab: string, props: WorkflowDetailProps) {
   props.history.replace({
     ...history,
     search: queryString.stringify({
@@ -64,9 +61,12 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     tabFromUrl
   );
 
-  // Default to editor tab if there is none specified via url.
+  // Default to editor tab if there is none or invalid tab ID specified via url.
   useEffect(() => {
-    if (!selectedTabId) {
+    if (
+      !selectedTabId ||
+      !Object.values(WORKFLOW_DETAILS_TAB).includes(selectedTabId)
+    ) {
       setSelectedTabId(WORKFLOW_DETAILS_TAB.EDITOR);
       replaceActiveTab(WORKFLOW_DETAILS_TAB.EDITOR, props);
     }

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -141,7 +141,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
         <Form>
           <EuiResizableContainer
             direction="horizontal"
-            style={{ marginLeft: '-14px' }}
+            style={{ marginLeft: '-8px', marginTop: '-8px' }}
           >
             {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
               if (togglePanel) {
@@ -151,7 +151,12 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
 
               return (
                 <>
-                  <EuiResizablePanel mode="main" initialSize={75} minSize="50%">
+                  <EuiResizablePanel
+                    mode="main"
+                    initialSize={75}
+                    minSize="50%"
+                    paddingSize="s"
+                  >
                     <Workspace
                       workflow={props.workflow}
                       onNodesChange={onNodesChange}
@@ -163,6 +168,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                     mode="collapsible"
                     initialSize={25}
                     minSize="10%"
+                    paddingSize="s"
                     onToggleCollapsedInternal={() => onToggleChange()}
                   >
                     <ComponentDetails selectedComponent={selectedComponent} />

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -26,4 +26,9 @@ export const columns = [
     name: 'Description',
     sortable: false,
   },
+  {
+    field: 'state',
+    name: 'Status',
+    sortable: true,
+  },
 ];

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -30,7 +30,7 @@ enum WORKFLOWS_TAB {
   CREATE = 'create',
 }
 
-const ACTIVE_TAB_PARAM = 'active_tab';
+const ACTIVE_TAB_PARAM = 'tab';
 
 function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
   props.history.replace({
@@ -100,6 +100,7 @@ export function Workflows(props: WorkflowsProps) {
               },
             },
           ]}
+          bottomBorder={true}
         />
 
         <EuiPageContent>

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -54,10 +54,13 @@ export function Workflows(props: WorkflowsProps) {
   ] as WORKFLOWS_TAB;
   const [selectedTabId, setSelectedTabId] = useState<WORKFLOWS_TAB>(tabFromUrl);
 
-  // If there is no selected tab, default to a tab depending on if user
-  // has existing created workflows or not.
+  // If there is no selected tab or invalid tab, default to a tab depending
+  // on if user has existing created workflows or not.
   useEffect(() => {
-    if (!selectedTabId) {
+    if (
+      !selectedTabId ||
+      !Object.values(WORKFLOWS_TAB).includes(selectedTabId)
+    ) {
       if (workflows?.length > 0) {
         setSelectedTabId(WORKFLOWS_TAB.MANAGE);
         replaceActiveTab(WORKFLOWS_TAB.MANAGE, props);

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -12,6 +12,7 @@ import {
   TextEmbeddingProcessor,
   generateId,
   initComponentData,
+  WORKFLOW_STATE,
 } from '../../../common';
 
 // TODO: remove after fetching from server-side
@@ -46,6 +47,7 @@ const initialState = {
       name: 'Workflow-1',
       id: 'workflow-1-id',
       description: 'description for workflow 1',
+      state: WORKFLOW_STATE.SUCCEEDED,
       workspaceFlowState: {
         nodes: dummyNodes,
         edges: [] as ReactFlowEdge[],
@@ -56,6 +58,7 @@ const initialState = {
       name: 'Workflow-2',
       id: 'workflow-2-id',
       description: 'description for workflow 2',
+      state: WORKFLOW_STATE.FAILED,
       workspaceFlowState: {
         nodes: dummyNodes,
         edges: [] as ReactFlowEdge[],

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -13,7 +13,9 @@ import {
   IComponentData,
   IComponentField,
   WorkspaceFormValues,
+  WORKFLOW_STATE,
 } from '../../common';
+import { EuiFilterSelectItem } from '@elastic/eui';
 
 // Append 16 random characters
 export function generateId(prefix: string): string {
@@ -123,4 +125,29 @@ function getFieldSchema(field: IComponentField): Schema {
   return field.optional
     ? baseSchema.optional()
     : baseSchema.required('Required');
+}
+
+export function getStateOptions(): EuiFilterSelectItem[] {
+  return [
+    // @ts-ignore
+    {
+      name: WORKFLOW_STATE.SUCCEEDED,
+      checked: 'on',
+    } as EuiFilterSelectItem,
+    // @ts-ignore
+    {
+      name: WORKFLOW_STATE.NOT_STARTED,
+      checked: 'on',
+    } as EuiFilterSelectItem,
+    // @ts-ignore
+    {
+      name: WORKFLOW_STATE.IN_PROGRESS,
+      checked: 'on',
+    } as EuiFilterSelectItem,
+    // @ts-ignore
+    {
+      name: WORKFLOW_STATE.FAILED,
+      checked: 'on',
+    } as EuiFilterSelectItem,
+  ];
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { FormikErrors, FormikTouched, FormikValues } from 'formik';
+import { EuiFilterSelectItem } from '@elastic/eui';
 import { Schema, ObjectSchema } from 'yup';
 import * as yup from 'yup';
 import {
@@ -15,7 +16,6 @@ import {
   WorkspaceFormValues,
   WORKFLOW_STATE,
 } from '../../common';
-import { EuiFilterSelectItem } from '@elastic/eui';
 
 // Append 16 random characters
 export function generateId(prefix: string): string {


### PR DESCRIPTION
### Description

This PR achieves 4 main things:
1. Adds a general & reusable `MultiSelectFilter` component that can be added to tables for filtering by subset of available options (e.g., workflow status).
2. Enhance existing workflow list table with the added filter, + with a debouncing search bar
3. Refactor the workflow details page into 3 main tabs- Editor, Launches, and Prototype, with the url path persisting the selected tab
4. Implements a basic launches table with similar multi-select filtering and debounced searching capabilities. This is added under the Launches tab. Note I've added dummy data there for testing & demo purposes.

With the refactoring, this also does some minor styling & padding changes for consistency, and adds boilerplate pages for the unfinished Launches and Prototypes pages under their respective tabs


Demo video (table enhancements):

[screen-capture (21).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/b0bb4328-be4c-48df-91fc-f90094cee4e7)

Demo video (new workflow details tabs):

[screen-capture (22).webm](https://github.com/opensearch-project/opensearch-ai-flow-dashboards/assets/62119629/b6b1cb12-432e-43ca-b67c-0ccc766d4f66)

### Issues Resolved

Makes progress on #8, #13, #15

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
