### PR TITLE
Add deletion to Workflow List page table

### DIFF
--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { EuiLink } from '@elastic/eui';
 import { PLUGIN_ID, Workflow } from '../../../../common';
 
-export const columns = [
+export const columns = (actions: any[]) => [
   {
     field: 'name',
     name: 'Name',
@@ -35,5 +35,9 @@ export const columns = [
     field: 'lastLaunched',
     name: 'Last launched',
     sortable: true,
+  },
+  {
+    name: 'Actions',
+    actions,
   },
 ];

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { debounce } from 'lodash';
 import {
   EuiInMemoryTable,
@@ -13,8 +13,9 @@ import {
   EuiFlexItem,
   EuiFilterSelectItem,
   EuiFieldSearch,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
-import { AppState } from '../../../store';
+import { AppState, deleteWorkflow } from '../../../store';
 import { Workflow } from '../../../../common';
 import { columns } from './columns';
 import { MultiSelectFilter } from '../../../general_components';
@@ -33,7 +34,10 @@ const sorting = {
  * The searchable list of created workflows.
  */
 export function WorkflowList(props: WorkflowListProps) {
-  const { workflows } = useSelector((state: AppState) => state.workflows);
+  const dispatch = useDispatch();
+  const { workflows, loading } = useSelector(
+    (state: AppState) => state.workflows
+  );
 
   // search bar state
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -58,6 +62,19 @@ export function WorkflowList(props: WorkflowListProps) {
     );
   }, [selectedStates, searchQuery, workflows]);
 
+  const tableActions = [
+    {
+      name: 'Delete',
+      description: 'Delete this workflow',
+      type: 'icon',
+      icon: 'trash',
+      color: 'danger',
+      onClick: (item: Workflow) => {
+        dispatch(deleteWorkflow(item.id));
+      },
+    },
+  ];
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem>
@@ -80,10 +97,18 @@ export function WorkflowList(props: WorkflowListProps) {
         <EuiInMemoryTable<Workflow>
           items={filteredWorkflows}
           rowHeader="name"
-          columns={columns}
+          // @ts-ignore
+          columns={columns(tableActions)}
           sorting={sorting}
           pagination={true}
-          message={'No existing workflows found'}
+          message={
+            loading === true ? (
+              <EuiLoadingSpinner size="xl" />
+            ) : (
+              'No existing workflows found'
+            )
+          }
+          hasActions={true}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -72,6 +72,13 @@ export function Workflows(props: WorkflowsProps) {
     }
   }, [selectedTabId, workflows]);
 
+  // If the user navigates back to the manage tab, re-fetch workflows
+  useEffect(() => {
+    if (selectedTabId === WORKFLOWS_TAB.MANAGE) {
+      dispatch(searchWorkflows({ query: { match_all: {} } }));
+    }
+  }, [selectedTabId]);
+
   useEffect(() => {
     getCore().chrome.setBreadcrumbs([
       BREADCRUMBS.FLOW_FRAMEWORK,

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -233,12 +233,8 @@ const workflowsSlice = createSlice({
         state.errorMessage = '';
       })
       .addCase(deleteWorkflow.fulfilled, (state, action) => {
-        // TODO: add logic to mutate state
-        // const workflow = action.payload;
-        // state.workflows = {
-        //   ...state.workflows,
-        //   [workflow.id]: workflow,
-        // };
+        const workflowId = action.payload.id;
+        delete state.workflows[workflowId];
         state.loading = false;
         state.errorMessage = '';
       })

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -172,15 +172,12 @@ export class FlowFrameworkRoutesService {
       const response = await this.client
         .asScoped(req)
         .callAsCurrentUser('flowFramework.createWorkflow', { body });
-      console.log('response from create workflow: ', response);
-      // TODO: format response
-      return res.ok({ body: response });
+      return res.ok({ body: { id: response._id } });
     } catch (err: any) {
       return generateCustomError(res, err);
     }
   };
 
-  // TODO: test e2e
   deleteWorkflow = async (
     context: RequestHandlerContext,
     req: OpenSearchDashboardsRequest,
@@ -191,9 +188,7 @@ export class FlowFrameworkRoutesService {
       const response = await this.client
         .asScoped(req)
         .callAsCurrentUser('flowFramework.deleteWorkflow', { workflow_id });
-      console.log('response from delete workflow: ', response);
-      // TODO: format response
-      return res.ok({ body: response });
+      return res.ok({ body: { id: response._id } });
     } catch (err: any) {
       return generateCustomError(res, err);
     }

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -50,16 +50,18 @@ export function getWorkflowsFromResponses(
     const workflowStateHit = workflowStateHits.find(
       (workflowStateHit) => workflowStateHit._id === workflowHit._id
     );
-    const workflowState = workflowStateHit._source
-      .state as typeof WORKFLOW_STATE;
-    workflowDict[workflowHit._id] = {
-      ...workflowDict[workflowHit._id],
-      // @ts-ignore
-      state: WORKFLOW_STATE[workflowState],
-      // TODO: this needs to be persisted by backend. Tracking issue:
-      // https://github.com/opensearch-project/flow-framework/issues/548
-      lastLaunched: 1234,
-    };
+    if (workflowStateHit) {
+      const workflowState = workflowStateHit._source
+        .state as typeof WORKFLOW_STATE;
+      workflowDict[workflowHit._id] = {
+        ...workflowDict[workflowHit._id],
+        // @ts-ignore
+        state: WORKFLOW_STATE[workflowState],
+        // TODO: this needs to be persisted by backend. Tracking issue:
+        // https://github.com/opensearch-project/flow-framework/issues/548
+        lastLaunched: 1234,
+      };
+    }
   });
   return workflowDict;
 }


### PR DESCRIPTION
### Description

This PR adds a delete action to the table to delete the corresponding workflow, and a few other minor improvements to the table. Specifically:
- adds an `actions` column with delete functionality
- finalizes Delete Workflow API response processing and hooks it into the redux store
- edge case handling of missing workflow state doc
- adds loading state by using the `loading` redux field to display a spinner when fetching workflows
- refreshes list of workflows when navigating back to the 'manage' tab, which is the workflow list page

Demo video:

[demo-229.webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/f07362d1-9081-4a02-87b2-da44153eb739)

### Issues Resolved
Resolves #70 
Resolves #65 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
