### PR TITLE
[Workflow list] Add delete modal; add empty list msg

### DIFF
--- a/public/general_components/delete_workflow_modal.tsx
+++ b/public/general_components/delete_workflow_modal.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiText,
+} from '@elastic/eui';
+import { Workflow } from '../../common';
+
+interface DeleteWorkflowModalProps {
+  workflow: Workflow;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * A general delete workflow modal.
+ */
+export function DeleteWorkflowModal(props: DeleteWorkflowModalProps) {
+  return (
+    <EuiModal onClose={props.onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Delete ${props.workflow.name}?`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText>The workflow will be permanently deleted.</EuiText>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={props.onConfirm} fill={true} color="danger">
+          Confirm
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { MultiSelectFilter } from './multi_select_filter';
+export { DeleteWorkflowModal } from './delete_workflow_modal';

--- a/public/pages/workflows/empty_list_message.tsx
+++ b/public/pages/workflows/empty_list_message.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+
+interface EmptyListMessageProps {
+  onClickNewWorkflow: () => void;
+}
+
+export function EmptyListMessage(props: EmptyListMessageProps) {
+  return (
+    <EuiFlexGroup direction="column" alignItems="center" gutterSize="m">
+      <EuiFlexItem>
+        <EuiSpacer size="m" />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiTitle size="s">
+          <h3>No workflows found</h3>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText size="s">
+          Create a workflow to start building and testing your application.
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiButton fill={false} onClick={props.onClickNewWorkflow}>
+          New workflow
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -20,6 +20,7 @@ import { getCore } from '../../services';
 import { WorkflowList } from './workflow_list';
 import { NewWorkflow } from './new_workflow';
 import { AppState, searchWorkflows } from '../../store';
+import { EmptyListMessage } from './empty_list_message';
 
 export interface WorkflowsRouterProps {}
 
@@ -48,7 +49,9 @@ function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
  */
 export function Workflows(props: WorkflowsProps) {
   const dispatch = useDispatch();
-  const { workflows } = useSelector((state: AppState) => state.workflows);
+  const { workflows, loading } = useSelector(
+    (state: AppState) => state.workflows
+  );
 
   const tabFromUrl = queryString.parse(useLocation().search)[
     ACTIVE_TAB_PARAM
@@ -130,6 +133,16 @@ export function Workflows(props: WorkflowsProps) {
           <EuiSpacer size="m" />
           {selectedTabId === WORKFLOWS_TAB.MANAGE && <WorkflowList />}
           {selectedTabId === WORKFLOWS_TAB.CREATE && <NewWorkflow />}
+          {selectedTabId === WORKFLOWS_TAB.MANAGE &&
+            Object.values(workflows).length === 0 &&
+            !loading && (
+              <EmptyListMessage
+                onClickNewWorkflow={() => {
+                  setSelectedTabId(WORKFLOWS_TAB.CREATE);
+                  replaceActiveTab(WORKFLOWS_TAB.CREATE, props);
+                }}
+              />
+            )}
         </EuiPageContent>
       </EuiPageBody>
     </EuiPage>


### PR DESCRIPTION
### Description

This PR improves the Workflow List page and makes consistent with the mocks in a few ways:
- adds a confirmation model before workflow deletion. This will be expanded upon in the future to list out associated resources, optionally deprovision, show for all versions, etc. Making a standalone component so it can be shared across pages if needed (e.g., deleting within the details pages)
- enhances the empty list message to include an actionable button that navigates to the 'create workflow' tab

Demo:
[video.webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/fd236209-4c9a-4959-8472-4337cbd671f9)

### Issues Resolved
Resolves #92 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
