### PR TITLE
Configure unit test environment; add build & test CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,12 +48,12 @@ jobs:
         uses: codecov/codecov-action@v1
 
   # TODO: once github actions supports windows and macos docker containers, we can
-  # merge these in to the above step's matrix.
+  # merge these in to the above step's matrix, including adding windows support
   build-and-test-windows-macos:
     name: Build & test
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       # Enable longer filenames for windows

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,98 @@
+name: Build & test
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+env:
+  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+
+jobs:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch-dashboards
+
+  build-and-test-linux:
+    needs: Get-CI-Image-Tag
+    name: Build & test (ubuntu latest)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: --user root
+
+    steps:
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          path: OpenSearch-Dashboards
+      - name: Checkout plugin
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards/plugins/dashboards-flow-framework
+      - name: Bootstrap / build / unit test the plugin
+        run: |
+          chown -R 1000:1000 `pwd`
+          cd ./OpenSearch-Dashboards/
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+                               cd ./plugins/dashboards-flow-framework &&
+                               whoami && yarn osd bootstrap && yarn build && yarn run test:jest --coverage"
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+
+  # TODO: once github actions supports windows and macos docker containers, we can
+  # merge these in to the above step's matrix.
+  build-and-test-windows-macos:
+    name: Build & test
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Enable longer filenames for windows
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          path: OpenSearch-Dashboards
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: './OpenSearch-Dashboards/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install Yarn
+        # Need to use bash to avoid having a windows/linux specific step
+        shell: bash
+        run: |
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          echo "Installing yarn@$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
+      - run: node -v
+      - run: yarn -v
+      - name: Checkout plugin
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards/plugins/dashboards-flow-framework
+      - name: Bootstrap the plugin
+        run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-flow-framework
+          yarn osd bootstrap
+      - name: Build the plugin
+        run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-flow-framework
+          yarn build
+      - name: Run unit tests
+        run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-flow-framework
+          yarn run test:jest --coverage
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,11 @@ jobs:
 
   build-and-test-linux:
     needs: Get-CI-Image-Tag
-    name: Build & test (ubuntu-latest)
-    runs-on: ubuntu-latest
+    name: Build & test
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     container:
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       options: --user root

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
 
   build-and-test-linux:
     needs: Get-CI-Image-Tag
-    name: Build & test (ubuntu latest)
+    name: Build & test (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = {
+  presets: [
+    require('@babel/preset-env'),
+    require('@babel/preset-react'),
+    require('@babel/preset-typescript'),
+  ],
+  plugins: [
+    ['@babel/plugin-transform-modules-commonjs', { allowTopLevelThis: true }],
+    [require('@babel/plugin-transform-runtime'), { regenerator: true }],
+  ],
+};

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -4,9 +4,7 @@
   "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,
-  "requiredBundles": [
-    "opensearchDashboardsUtils"
-  ],
+  "requiredBundles": [],
   "requiredPlugins": [
     "navigation"
   ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "opensearch": "../../scripts/use_node ../../scripts/opensearch",
     "lint:es": "../../scripts/use_node ../../scripts/eslint -c eslintrc.json",
     "lint:es:precommit": "yarn lint:es common/* public/* server/*",
+    "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
     "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip"
   },
   "repository": {

--- a/public/pages/workflows/workflows.test.tsx
+++ b/public/pages/workflows/workflows.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import {
+  BrowserRouter as Router,
+  RouteComponentProps,
+  Route,
+  Switch,
+} from 'react-router-dom';
+import { store } from '../../store';
+import { Workflows } from './workflows';
+
+jest.mock('../../services', () => {
+  const { mockCoreServices } = require('../../../test');
+  return {
+    ...jest.requireActual('../../services'),
+    ...mockCoreServices,
+  };
+});
+
+const renderWithRouter = () => ({
+  ...render(
+    <Provider store={store}>
+      <Router>
+        <Switch>
+          <Route
+            render={(props: RouteComponentProps) => <Workflows {...props} />}
+          />
+        </Switch>
+      </Router>
+    </Provider>
+  ),
+});
+
+describe('Workflows', () => {
+  test('renders the page', () => {
+    const { getByText } = renderWithRouter();
+    expect(getByText('Workflows')).not.toBeNull();
+  });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './mocks';

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = {
+  rootDir: '../',
+  roots: ['<rootDir>'],
+  coverageDirectory: './coverage',
+  // we mock any style-related files and return an empty module. This is needed due to errors
+  // when jest tries to interpret these types of files.
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/test/mocks/style_mock.ts',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+  coverageReporters: ['lcov', 'text', 'cobertura'],
+  testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
+  collectCoverageFrom: [
+    '**/*.ts',
+    '**/*.tsx',
+    '**/*.js',
+    '**/*.jsx',
+    '!**/models/**',
+    '!**/node_modules/**',
+    '!**/index.js',
+    '!<rootDir>/public/app.js',
+    '!<rootDir>/index.js',
+    '!<rootDir>/babel.config.js',
+    '!<rootDir>/test/**',
+    '!<rootDir>/server/**',
+    '!<rootDir>/coverage/**',
+    '!<rootDir>/scripts/**',
+    '!<rootDir>/build/**',
+    '!**/vendor/**',
+  ],
+  clearMocks: true,
+  modulePathIgnorePatterns: ['<rootDir>/offline-module-cache/'],
+  testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  transformIgnorePatterns: ['<rootDir>/node_modules'],
+};

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { mockCoreServices } from './mock_core_services';

--- a/test/mocks/mock_core_services.ts
+++ b/test/mocks/mock_core_services.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const mockCoreServices = {
+  getCore: () => {
+    return {
+      chrome: {
+        setBreadcrumbs: jest.fn(),
+      },
+    };
+  },
+  getNotifications: () => {
+    return {
+      toasts: {
+        addDanger: jest.fn().mockName('addDanger'),
+        addSuccess: jest.fn().mockName('addSuccess'),
+      },
+    };
+  },
+};

--- a/test/mocks/style_mock.ts
+++ b/test/mocks/style_mock.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export default {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,7 @@
     "public/**/*.ts",
     "public/**/*.tsx",
     "server/**/*.ts",
+    "test/**/*",
     "../../typings/**/*"
   ],
   "exclude": ["node_modules", "*/node_modules/"]


### PR DESCRIPTION
### Description

This PR sets up the initial test coverage configuration and initial build-and-test CI to run on every pull request and push to all branches. It includes all necessary mocks for core services, redux store, and CSS files as demonstrated by the sample unit test added `workflows.test.tsx`.

Consistent with other plugins, this adds a script `test:jest` which is used to execute tests.

Check out the incredible coverage!
```
yarn test:jest
yarn run v1.22.19
warning package.json: License should be a valid SPDX license expression
$ ../../node_modules/.bin/jest --config ./test/jest.config.js
 PASS  public/pages/workflows/workflows.test.tsx
  Workflows
    ✓ renders the page (155 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.356 s
Ran all test suites.
```

### Issues Resolved

Resolves #103 
Resolves #105 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
