### PR TITLE
Enforce fine-grained form and flow validation

### DIFF
--- a/common/utils.ts
+++ b/common/utils.ts
@@ -74,6 +74,7 @@ export function toWorkspaceFlow(
 /**
  * Validates the UI workflow state.
  * Note we don't have to validate connections since that is done via input/output handlers.
+ * But we need to validate there are no open connections
  */
 export function validateWorkspaceFlow(
   workspaceFlow: WorkspaceFlowState

--- a/public/pages/workflow_detail/component_details/component_details.tsx
+++ b/public/pages/workflow_detail/component_details/component_details.tsx
@@ -13,6 +13,7 @@ import { EmptyComponentInputs } from './empty_component_inputs';
 import '../workspace/workspace-styles.scss';
 
 interface ComponentDetailsProps {
+  onFormChange: () => void;
   selectedComponent?: ReactFlowComponent;
 }
 
@@ -31,7 +32,10 @@ export function ComponentDetails(props: ComponentDetailsProps) {
       <EuiFlexItem>
         <EuiPanel paddingSize="m">
           {props.selectedComponent ? (
-            <ComponentInputs selectedComponent={props.selectedComponent} />
+            <ComponentInputs
+              selectedComponent={props.selectedComponent}
+              onFormChange={props.onFormChange}
+            />
           ) : (
             <EmptyComponentInputs />
           )}

--- a/public/pages/workflow_detail/component_details/component_inputs.tsx
+++ b/public/pages/workflow_detail/component_details/component_inputs.tsx
@@ -10,6 +10,7 @@ import { ReactFlowComponent } from '../../../../common';
 
 interface ComponentInputsProps {
   selectedComponent: ReactFlowComponent;
+  onFormChange: () => void;
 }
 
 export function ComponentInputs(props: ComponentInputsProps) {
@@ -19,7 +20,10 @@ export function ComponentInputs(props: ComponentInputsProps) {
         <h2>{props.selectedComponent.data.label || ''}</h2>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <InputFieldList selectedComponent={props.selectedComponent} />
+      <InputFieldList
+        selectedComponent={props.selectedComponent}
+        onFormChange={props.onFormChange}
+      />
     </>
   );
 }

--- a/public/pages/workflow_detail/component_details/input_field_list.tsx
+++ b/public/pages/workflow_detail/component_details/input_field_list.tsx
@@ -15,6 +15,7 @@ import { ReactFlowComponent } from '../../../../common';
 
 interface InputFieldListProps {
   selectedComponent: ReactFlowComponent;
+  onFormChange: () => void;
 }
 
 export function InputFieldList(props: InputFieldListProps) {
@@ -30,6 +31,7 @@ export function InputFieldList(props: InputFieldListProps) {
                 <TextField
                   field={field}
                   componentId={props.selectedComponent.id}
+                  onFormChange={props.onFormChange}
                 />
                 <EuiSpacer size="s" />
               </EuiFlexItem>
@@ -42,6 +44,7 @@ export function InputFieldList(props: InputFieldListProps) {
                 <SelectField
                   field={field}
                   componentId={props.selectedComponent.id}
+                  onFormChange={props.onFormChange}
                 />
               </EuiFlexItem>
             );

--- a/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
@@ -36,6 +36,7 @@ const existingIndices = [
 interface SelectFieldProps {
   field: IComponentField;
   componentId: string;
+  onFormChange: () => void;
 }
 
 /**
@@ -59,6 +60,7 @@ export function SelectField(props: SelectFieldProps) {
                 field.onChange(option);
                 form.setFieldValue(formField, option);
               }}
+              onBlur={() => props.onFormChange()}
               isInvalid={isFieldInvalid(
                 props.componentId,
                 props.field.name,

--- a/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
@@ -57,10 +57,9 @@ export function SelectField(props: SelectFieldProps) {
               options={options}
               valueOfSelected={field.value || getInitialValue(props.field.type)}
               onChange={(option) => {
-                field.onChange(option);
                 form.setFieldValue(formField, option);
+                props.onFormChange();
               }}
-              onBlur={() => props.onFormChange()}
               isInvalid={isFieldInvalid(
                 props.componentId,
                 props.field.name,

--- a/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
@@ -48,6 +48,10 @@ export function TextField(props: TextFieldProps) {
               compressed={false}
               value={field.value || getInitialValue(props.field.type)}
               onChange={(e) => form.setFieldValue(formField, e.target.value)}
+              // This is a design decision to only trigger form updates onBlur() instead
+              // of onChange(). This is to rate limit the number of updates & re-renders made, as users
+              // typically rapidly type things into a text box, which would consequently trigger
+              // onChange() much more often.
               onBlur={() => props.onFormChange()}
             />
           </EuiFormRow>

--- a/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
@@ -17,6 +17,7 @@ import {
 interface TextFieldProps {
   field: IComponentField;
   componentId: string;
+  onFormChange: () => void;
 }
 
 /**
@@ -46,6 +47,8 @@ export function TextField(props: TextFieldProps) {
               placeholder={props.field.placeholder || ''}
               compressed={false}
               value={field.value || getInitialValue(props.field.type)}
+              onChange={(e) => form.setFieldValue(formField, e.target.value)}
+              onBlur={() => props.onFormChange()}
             />
           </EuiFormRow>
         );

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -33,21 +33,9 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
         )
       }
       rightSideItems={[
-        // TODO: add launch logic
-        <EuiButton fill={false} onClick={() => {}}>
-          Launch
-        </EuiButton>,
-        <EuiButton
-          fill={false}
-          disabled={!props.workflow || !isDirty}
-          // TODO: if isNewWorkflow is true, clear the workflow cache if saving is successful.
-          onClick={() => {
-            // @ts-ignore
-            saveWorkflow(props.workflow, reactFlowInstance);
-            dispatch(removeDirty());
-          }}
-        >
-          Save
+        // TODO: finalize if this is needed
+        <EuiButton fill={false} color="danger" onClick={() => {}}>
+          Delete
         </EuiButton>,
       ]}
       tabs={props.tabs}

--- a/public/pages/workflow_detail/utils/utils.ts
+++ b/public/pages/workflow_detail/utils/utils.ts
@@ -11,7 +11,7 @@ import {
   validateWorkspaceFlow,
 } from '../../../../common';
 
-export function saveWorkflow(workflow: Workflow, rfInstance: any): void {
+export function saveWorkflow(rfInstance: any, workflow?: Workflow): void {
   let curFlowState = rfInstance.toObject();
 
   curFlowState = {
@@ -26,7 +26,7 @@ export function saveWorkflow(workflow: Workflow, rfInstance: any): void {
       workspaceFlowState: curFlowState,
       workflows: toTemplateFlows(curFlowState),
     } as Workflow;
-    if (workflow.id) {
+    if (workflow && workflow.id) {
       // TODO: implement connection to update workflow API
     } else {
       // TODO: implement connection to create workflow API

--- a/public/pages/workflow_detail/utils/utils.ts
+++ b/public/pages/workflow_detail/utils/utils.ts
@@ -3,41 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  WorkspaceFlowState,
-  Workflow,
-  ReactFlowComponent,
-  toTemplateFlows,
-  validateWorkspaceFlow,
-} from '../../../../common';
+import { Workflow, ReactFlowComponent } from '../../../../common';
 
-export function saveWorkflow(rfInstance: any, workflow?: Workflow): void {
-  let curFlowState = rfInstance.toObject();
-
-  curFlowState = {
-    ...curFlowState,
-    nodes: processNodes(curFlowState.nodes),
-  };
-
-  const isValid = validateWorkspaceFlow(curFlowState);
-  if (isValid) {
-    const updatedWorkflow = {
-      ...workflow,
-      workspaceFlowState: curFlowState,
-      workflows: toTemplateFlows(curFlowState),
-    } as Workflow;
-    if (workflow && workflow.id) {
-      // TODO: implement connection to update workflow API
-    } else {
-      // TODO: implement connection to create workflow API
-    }
+export function saveWorkflow(workflow?: Workflow): void {
+  if (workflow && workflow.id) {
+    // TODO: implement connection to update workflow API
   } else {
-    return;
+    // TODO: implement connection to create workflow API
   }
 }
 
 // Process the raw ReactFlow nodes to only persist the fields we need
-function processNodes(nodes: ReactFlowComponent[]): ReactFlowComponent[] {
+export function processNodes(
+  nodes: ReactFlowComponent[]
+): ReactFlowComponent[] {
   return nodes
     .map((node: ReactFlowComponent) => {
       return Object.fromEntries(

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -98,22 +98,11 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
 
   // On initial load:
   // - fetch workflow, if there is an existing workflow ID
-  // - add a window listener to warn users if they exit/refresh
-  //   without saving latest changes
   useEffect(() => {
     if (!isNewWorkflow) {
       // TODO: can optimize to only fetch a single workflow
       dispatch(searchWorkflows({ query: { match_all: {} } }));
     }
-
-    // TODO: below has the following issue:
-    // 1. user starts to create new unsaved workflow changes
-    // 2. user navigates to other parts of the plugin without refreshing - no warning happens
-    // 3. user refreshes at any later time: if isDirty is still true, shows browser warning
-    // tune to only handle the check if still on the workflow details page, or consider adding a check / warning
-    // if navigating away from the details page without refreshing (where it is currently not being triggered)
-    // window.onbeforeunload = (e) =>
-    //   isDirty || isNewWorkflow ? true : undefined;
   }, []);
 
   const tabs = [
@@ -156,7 +145,10 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
             tabs={tabs}
           />
           {selectedTabId === WORKFLOW_DETAILS_TAB.EDITOR && (
-            <ResizableWorkspace workflow={workflow} />
+            <ResizableWorkspace
+              isNewWorkflow={isNewWorkflow}
+              workflow={workflow}
+            />
           )}
           {selectedTabId === WORKFLOW_DETAILS_TAB.LAUNCHES && <Launches />}
           {selectedTabId === WORKFLOW_DETAILS_TAB.PROTOTYPE && (

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -6,7 +6,7 @@
 import React, { useRef, useState, useEffect, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useOnSelectionChange } from 'reactflow';
-import { Form, Formik } from 'formik';
+import { Form, Formik, useFormikContext } from 'formik';
 import * as yup from 'yup';
 import { cloneDeep } from 'lodash';
 import { EuiButton, EuiPageHeader, EuiResizableContainer } from '@elastic/eui';
@@ -19,7 +19,7 @@ import {
   componentDataToFormik,
   getComponentSchema,
 } from '../../../../common';
-import { AppState, removeDirty, rfContext } from '../../../store';
+import { AppState, removeDirty, setDirty, rfContext } from '../../../store';
 import { Workspace } from './workspace';
 import { ComponentDetails } from '../component_details';
 import { saveWorkflow } from '../utils';
@@ -139,6 +139,16 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setFormSchema(updatedSchema);
   }
 
+  /**
+   * Function to pass down to the Formik <Form> components as a listener to propagate
+   * form changes to this parent component to re-enable save button, etc.
+   */
+  function onFormChange() {
+    if (!isDirty) {
+      dispatch(setDirty());
+    }
+  }
+
   return (
     <Formik
       enableReinitialize={true}
@@ -209,7 +219,10 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                     paddingSize="s"
                     onToggleCollapsedInternal={() => onToggleChange()}
                   >
-                    <ComponentDetails selectedComponent={selectedComponent} />
+                    <ComponentDetails
+                      selectedComponent={selectedComponent}
+                      onFormChange={onFormChange}
+                    />
                   </EuiResizablePanel>
                 </>
               );

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -102,7 +102,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   });
 
   // Hook to update the workflow's flow state, if applicable. It may not exist if
-  // it is a backend-only-created workflow, or a new, unsaved workflow
+  // it is a backend-only-created workflow, or a new, unsaved workflow. If so,
+  // generate a default one based on the 'workflows' JSON field.
   useEffect(() => {
     const workflowCopy = { ...props.workflow } as Workflow;
     if (workflowCopy) {

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -21,7 +21,6 @@ import {
   IComponentData,
   ReactFlowComponent,
   Workflow,
-  toWorkspaceFlow,
 } from '../../../../common';
 import { generateId, initComponentData } from '../../../utils';
 import { WorkspaceComponent } from '../workspace_component';
@@ -116,20 +115,10 @@ export function Workspace(props: WorkspaceProps) {
     [reactFlowInstance]
   );
 
-  // Initialization. Set the nodes and edges to an existing workflow,
-  // if applicable.
+  // Initialization. Set the nodes and edges to an existing workflow state,
   useEffect(() => {
     const workflow = { ...props.workflow };
-    if (workflow) {
-      if (!workflow.workspaceFlowState) {
-        // No existing workspace state. This could be due to it being a backend-only-created
-        // workflow, or a new, unsaved workflow
-        // @ts-ignore
-        workflow.workspaceFlowState = toWorkspaceFlow(workflow.workflows);
-        console.debug(
-          `There is no saved UI flow for workflow: ${workflow.name}. Generating a default one.`
-        );
-      }
+    if (workflow && workflow.workspaceFlowState) {
       setNodes(workflow.workspaceFlowState.nodes);
       setEdges(workflow.workspaceFlowState.edges);
     }

--- a/public/pages/workflows/workflows.test.tsx
+++ b/public/pages/workflows/workflows.test.tsx
@@ -40,7 +40,7 @@ const renderWithRouter = () => ({
 
 describe('Workflows', () => {
   test('renders the page', () => {
-    const { getByText } = renderWithRouter();
-    expect(getByText('Workflows')).not.toBeNull();
+    const { getAllByText } = renderWithRouter();
+    expect(getAllByText('Workflows').length).toBeGreaterThan(0);
   });
 });

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -58,20 +58,14 @@ export function Workflows(props: WorkflowsProps) {
   ] as WORKFLOWS_TAB;
   const [selectedTabId, setSelectedTabId] = useState<WORKFLOWS_TAB>(tabFromUrl);
 
-  // If there is no selected tab or invalid tab, default to a tab depending
-  // on if user has existing created workflows or not.
+  // If there is no selected tab or invalid tab, default to manage tab
   useEffect(() => {
     if (
       !selectedTabId ||
       !Object.values(WORKFLOWS_TAB).includes(selectedTabId)
     ) {
-      if (Object.keys(workflows).length > 0) {
-        setSelectedTabId(WORKFLOWS_TAB.MANAGE);
-        replaceActiveTab(WORKFLOWS_TAB.MANAGE, props);
-      } else {
-        setSelectedTabId(WORKFLOWS_TAB.CREATE);
-        replaceActiveTab(WORKFLOWS_TAB.CREATE, props);
-      }
+      setSelectedTabId(WORKFLOWS_TAB.MANAGE);
+      replaceActiveTab(WORKFLOWS_TAB.MANAGE, props);
     }
   }, [selectedTabId, workflows]);
 


### PR DESCRIPTION
### Description

This PR improves the overall validation logic on the workflow editor:
- moves the save/launch buttons from the global page to embedded within the editor, and adds a delete button at the global level. This is a placeholder and may be modified or removed in the future pending final UX design.
- integrates the form state in each drag-and-drop component as part of the overall validation when clicking `Save` button. This is done by propagating callback fn `onFormChange` to the low-level form components, and performing form validation and submission when clicking `Save` button
- adds callouts if something is invalid. separate messaging for form state vs. flow state is supported (final design/wording is TBD)
- refactors the generation of the `workspaceFlowState` from `workspace` to parent component `resizableWorkspace`. This allows us to perform validation in a consistent way, and pass the same, updated workflow to all downstream components.
- cleans up and simplifies `saveWorkflow` to perform only save/update

Additional changes:
- nit change to always default to 'manage' tab on base Workflows page for consistency
- remove placeholder `Submit` button since we have the logic available in the `Save` button now

Note that the _form_ validation logic is complete - however, the _flow_ validation logic is still in TODO state; for now, it always succeeds / is valid.


#### Screenshots:
Form validation:

![Screenshot 2024-03-26 at 11 45 02 AM](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/24de59e2-33a0-445f-b8f2-f8d04c136b41)

Flow validation:

![Screenshot 2024-03-26 at 11 44 26 AM](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/bea06658-a064-453b-b105-1389d5b1728e)

#### Demo videos:
Form validation integrated with `Save` button being disabled/enabled depending on unsaved changes. Note that on submitting / clicking `Save`, all invalid fields are highlighted appropriately, across all components. And, once everything is valid, the callout does not appear when saving.

[screen-capture (18).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/db9c38fb-21c9-4914-8d33-c13b779aaab0)

Flow validation integrated with `Save` button being disabled/enabled depending on unsaved changes. Ignore the callout as that logic is still a placeholder.

[screen-capture (19).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/d5e2c1d3-e5fd-4269-8e74-e9e6ee5fe9dd)

### Issues Resolved

Resolves #5 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
