### PR TITLE
Integrate with workflow timestamp fields

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -37,3 +37,5 @@ export const GET_PRESET_WORKFLOWS_NODE_API_PATH = `${BASE_WORKFLOW_NODE_API_PATH
 export const NEW_WORKFLOW_ID_URL = 'new';
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
+export const DATE_FORMAT_PATTERN = 'MM/DD/YY hh:mm A';
+export const EMPTY_FIELD_STRING = '--';

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import moment from 'moment';
 import {
   WorkspaceFlowState,
   ReactFlowComponent,
@@ -13,6 +14,7 @@ import {
   ReactFlowEdge,
   TemplateFlows,
   WorkflowTemplate,
+  DATE_FORMAT_PATTERN,
 } from './';
 
 // TODO: implement this and remove hardcoded return values
@@ -90,4 +92,8 @@ export function validateWorkflowTemplate(
   workflowTemplate: WorkflowTemplate
 ): boolean {
   return true;
+}
+
+export function toFormattedDate(timestampMillis: number): String {
+  return moment(new Date(timestampMillis)).format(DATE_FORMAT_PATTERN);
 }

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -5,7 +5,12 @@
 
 import React from 'react';
 import { EuiLink } from '@elastic/eui';
-import { PLUGIN_ID, Workflow } from '../../../../common';
+import {
+  EMPTY_FIELD_STRING,
+  PLUGIN_ID,
+  Workflow,
+  toFormattedDate,
+} from '../../../../common';
 
 export const columns = (actions: any[]) => [
   {
@@ -30,11 +35,19 @@ export const columns = (actions: any[]) => [
     field: 'lastUpdated',
     name: 'Last updated',
     sortable: true,
+    render: (lastUpdated: number) =>
+      lastUpdated !== undefined
+        ? toFormattedDate(lastUpdated)
+        : EMPTY_FIELD_STRING,
   },
   {
     field: 'lastLaunched',
     name: 'Last launched',
     sortable: true,
+    render: (lastLaunched: number) =>
+      lastLaunched !== undefined
+        ? toFormattedDate(lastLaunched)
+        : EMPTY_FIELD_STRING,
   },
   {
     name: 'Actions',

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -30,9 +30,8 @@ function toWorkflowObj(workflowHit: any): Workflow {
     description: hitSource.description || '',
     version: hitSource.version,
     workflows: hitSource.workflows,
-    // TODO: this needs to be persisted by backend. Tracking issue:
-    // https://github.com/opensearch-project/flow-framework/issues/548
-    lastUpdated: 1234,
+    lastUpdated: hitSource.last_updated_time,
+    lastLaunched: hitSource.last_provisioned_time,
   } as Workflow;
 }
 
@@ -57,9 +56,6 @@ export function getWorkflowsFromResponses(
         ...workflowDict[workflowHit._id],
         // @ts-ignore
         state: WORKFLOW_STATE[workflowState],
-        // TODO: this needs to be persisted by backend. Tracking issue:
-        // https://github.com/opensearch-project/flow-framework/issues/548
-        lastLaunched: 1234,
       };
     }
   });


### PR DESCRIPTION
### Description

As a follow up to https://github.com/opensearch-project/flow-framework/pull/551, this PR integrates with those fields by adding the parsing logic on the server-side to persist them.

Also updates the workflow list to remove the hardcoded placeholders and render the timestamps appropriately.

Screenshot highlighting 2 un-provisioned workflows and one provisioned workflow:

![Screenshot 2024-03-26 at 3 13 19 PM](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/354495bd-59ba-4cf7-aea4-19cf35dfdbc7)

### Issues Resolved

none

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
