### PR TITLE
Add error handling to top-level pages

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -64,3 +64,4 @@ export const FETCH_ALL_QUERY_BODY = {
   },
   size: 1000,
 };
+export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';

--- a/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/text_field.tsx
@@ -57,12 +57,10 @@ export function TextField(props: TextFieldProps) {
               placeholder={props.field.placeholder || ''}
               compressed={false}
               value={field.value || getInitialValue(props.field.type)}
-              onChange={(e) => form.setFieldValue(formField, e.target.value)}
-              // This is a design decision to only trigger form updates onBlur() instead
-              // of onChange(). This is to rate limit the number of updates & re-renders made, as users
-              // typically rapidly type things into a text box, which would consequently trigger
-              // onChange() much more often.
-              onBlur={() => props.onFormChange()}
+              onChange={(e) => {
+                form.setFieldValue(formField, e.target.value);
+                props.onFormChange();
+              }}
             />
           </EuiFormRow>
         );

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 import {
   EuiPageHeader,
   EuiButton,
-  EuiLoadingSpinner,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -26,13 +25,11 @@ interface WorkflowDetailHeaderProps {
 
 export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   function getTitle() {
-    return props.workflow ? (
-      props.workflow.name
-    ) : props.isNewWorkflow && !props.workflow ? (
-      DEFAULT_NEW_WORKFLOW_NAME
-    ) : (
-      <EuiLoadingSpinner size="xl" />
-    );
+    return props.workflow
+      ? props.workflow.name
+      : props.isNewWorkflow && !props.workflow
+      ? DEFAULT_NEW_WORKFLOW_NAME
+      : '';
   }
 
   function getState() {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -63,7 +63,7 @@ function replaceActiveTab(activeTab: string, props: WorkflowDetailProps) {
 
 export function WorkflowDetail(props: WorkflowDetailProps) {
   const dispatch = useAppDispatch();
-  const { workflows, cachedWorkflow } = useSelector(
+  const { workflows, cachedWorkflow, errorMessage } = useSelector(
     (state: AppState) => state.workflows
   );
 
@@ -114,6 +114,14 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     }
     dispatch(searchModels(FETCH_ALL_QUERY_BODY));
   }, []);
+
+  // Show a toast if an error message exists in state
+  useEffect(() => {
+    if (errorMessage) {
+      console.error(errorMessage);
+      getCore().notifications.toasts.addDanger(errorMessage);
+    }
+  }, [errorMessage]);
 
   const tabs = [
     {

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -343,8 +343,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                         setIsDeprovisioning(false);
                       })
                       .catch((error: any) => {
-                        // TODO: process error (toast msg?)
-                        console.log('error: ', error);
                         setIsDeprovisioning(false);
                       });
                   } else {
@@ -369,8 +367,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                         setIsProvisioning(false);
                       })
                       .catch((error: any) => {
-                        // TODO: process error (toast msg?)
-                        console.log('error: ', error);
                         setIsProvisioning(false);
                       });
                   } else {
@@ -407,8 +403,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                             setIsSaving(false);
                           })
                           .catch((error: any) => {
-                            // TODO: process error (toast msg?)
-                            console.log('error: ', error);
                             setIsSaving(false);
                           });
                       } else {
@@ -420,8 +414,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                             history.go(0);
                           })
                           .catch((error: any) => {
-                            // TODO: process error (toast msg?)
-                            console.log('error: ', error);
                             setIsSaving(false);
                           });
                       }

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -50,7 +50,7 @@ function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
  */
 export function Workflows(props: WorkflowsProps) {
   const dispatch = useAppDispatch();
-  const { workflows, loading } = useSelector(
+  const { workflows, loading, errorMessage } = useSelector(
     (state: AppState) => state.workflows
   );
 
@@ -83,6 +83,14 @@ export function Workflows(props: WorkflowsProps) {
       BREADCRUMBS.WORKFLOWS,
     ]);
   });
+
+  // Show a toast if an error message exists in state
+  useEffect(() => {
+    if (errorMessage) {
+      console.error(errorMessage);
+      getCore().notifications.toasts.addDanger(errorMessage);
+    }
+  }, [errorMessage]);
 
   // On initial render: fetch all workflows
   useEffect(() => {

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -25,6 +25,7 @@ import {
   UPDATE_WORKFLOW_NODE_API_PATH,
   WORKFLOW_STATE,
   Workflow,
+  WorkflowDict,
   WorkflowTemplate,
   validateWorkflowTemplate,
 } from '../../common';
@@ -32,6 +33,7 @@ import {
   generateCustomError,
   getWorkflowStateFromResponse,
   getWorkflowsFromResponses,
+  isIgnorableError,
 } from './helpers';
 
 /**
@@ -196,6 +198,9 @@ export class FlowFrameworkRoutesService {
       );
       return res.ok({ body: { workflows: workflowDict } });
     } catch (err: any) {
+      if (isIgnorableError(err)) {
+        return res.ok({ body: { workflows: {} as WorkflowDict } });
+      }
       return generateCustomError(res, err);
     }
   };

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -5,6 +5,7 @@
 
 import {
   DEFAULT_NEW_WORKFLOW_STATE_TYPE,
+  INDEX_NOT_FOUND_EXCEPTION,
   Model,
   ModelDict,
   WORKFLOW_STATE,
@@ -24,6 +25,11 @@ export function generateCustomError(res: any, err: any) {
       },
     },
   });
+}
+
+// Helper fn to filter out backend errors that we don't want to propagate on the frontend.
+export function isIgnorableError(error: any): boolean {
+  return error.body?.error?.type === INDEX_NOT_FOUND_EXCEPTION;
 }
 
 function toWorkflowObj(workflowHit: any): Workflow {


### PR DESCRIPTION
### Description

This PR improves error handling a few different ways:
- bubbles up persisted errors as toast notifications at the top-level `workflows` page and `workflow_detail` page
- filters out unnecessary backend errors and hide on the frontend when appropriate. currently, this just means not showing an `index_not_found_exception` when executing the search workflows API so we don't show errors on a fresh cluster when loading any of the pages, for example

Testing
- ensured index_not_found_exception is hidden appropriately
- ensured toasts show for create, save, update, delete workflow failures on the base pages
- ensured there is no multiple / re-rendering of the toasts (not triggering several toasts for the same error)

Misc
- improved save state. updating the form only on change for `text_field` to prevent clicking on the form, and clicking away to automatically set the page to dirty, even if no underlying values were changed
- improved loading state if rendering a page for a workflow ID that is not found

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
