### PR TITLE
Add option to select and provision pretrained text embedding models

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  MODEL_ALGORITHM,
   PRETRAINED_MODEL_FORMAT,
   PretrainedSentenceTransformer,
   WORKFLOW_STATE,
@@ -68,6 +69,7 @@ export const ROBERTA_SENTENCE_TRANSFORMER = {
   shortenedName: 'all-distilroberta-v1',
   description: 'A sentence transformer from Hugging Face',
   format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  algorithm: MODEL_ALGORITHM.TEXT_EMBEDDING,
   version: '1.0.1',
   vectorDimensions: 768,
 } as PretrainedSentenceTransformer;
@@ -77,6 +79,7 @@ export const MPNET_SENTENCE_TRANSFORMER = {
   shortenedName: 'all-mpnet-base-v2',
   description: 'A sentence transformer from Hugging Face',
   format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  algorithm: MODEL_ALGORITHM.TEXT_EMBEDDING,
   version: '1.0.1',
   vectorDimensions: 768,
 } as PretrainedSentenceTransformer;
@@ -86,6 +89,7 @@ export const BERT_SENTENCE_TRANSFORMER = {
   shortenedName: 'msmarco-distilbert-base-tas-b',
   description: 'A sentence transformer from Hugging Face',
   format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  algorithm: MODEL_ALGORITHM.TEXT_EMBEDDING,
   version: '1.0.2',
   vectorDimensions: 768,
 } as PretrainedSentenceTransformer;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WORKFLOW_STATE } from './interfaces';
+import { PretrainedSentenceTransformer, WORKFLOW_STATE } from './interfaces';
 
 export const PLUGIN_ID = 'flow-framework';
 
@@ -52,6 +52,22 @@ export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
  */
 export const CREATE_INGEST_PIPELINE_STEP_TYPE = 'create_ingest_pipeline';
 export const CREATE_INDEX_STEP_TYPE = 'create_index';
+
+/**
+ * ML PLUGIN PRETRAINED MODELS
+ * (based off of https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/#sentence-transformers)
+ */
+export const ROBERTA_SENTENCE_TRANSFORMER = {
+  name: 'huggingface/sentence-transformers/all-distilroberta-v1',
+  shortenedName: 'all-distilroberta-v1',
+  vectorDimensions: 768,
+} as PretrainedSentenceTransformer;
+
+export const BERT_SENTENCE_TRANSFORMER = {
+  name: 'huggingface/sentence-transformers/msmarco-distilbert-base-tas-b',
+  shortenedName: 'msmarco-distilbert-base-tas-b',
+  vectorDimensions: 768,
+} as PretrainedSentenceTransformer;
 
 /**
  * MISCELLANEOUS

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TemplateNode, WORKFLOW_STATE } from './interfaces';
+import { WORKFLOW_STATE } from './interfaces';
 
 export const PLUGIN_ID = 'flow-framework';
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PretrainedSentenceTransformer, WORKFLOW_STATE } from './interfaces';
+import {
+  PRETRAINED_MODEL_FORMAT,
+  PretrainedSentenceTransformer,
+  WORKFLOW_STATE,
+} from './interfaces';
 
 export const PLUGIN_ID = 'flow-framework';
 
@@ -52,6 +56,8 @@ export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
  */
 export const CREATE_INGEST_PIPELINE_STEP_TYPE = 'create_ingest_pipeline';
 export const CREATE_INDEX_STEP_TYPE = 'create_index';
+export const REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE =
+  'register_local_pretrained_model';
 
 /**
  * ML PLUGIN PRETRAINED MODELS
@@ -60,12 +66,27 @@ export const CREATE_INDEX_STEP_TYPE = 'create_index';
 export const ROBERTA_SENTENCE_TRANSFORMER = {
   name: 'huggingface/sentence-transformers/all-distilroberta-v1',
   shortenedName: 'all-distilroberta-v1',
+  description: 'A sentence transformer from Hugging Face',
+  format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  version: '1.0.1',
+  vectorDimensions: 768,
+} as PretrainedSentenceTransformer;
+
+export const MPNET_SENTENCE_TRANSFORMER = {
+  name: 'huggingface/sentence-transformers/all-mpnet-base-v2',
+  shortenedName: 'all-mpnet-base-v2',
+  description: 'A sentence transformer from Hugging Face',
+  format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  version: '1.0.1',
   vectorDimensions: 768,
 } as PretrainedSentenceTransformer;
 
 export const BERT_SENTENCE_TRANSFORMER = {
   name: 'huggingface/sentence-transformers/msmarco-distilbert-base-tas-b',
   shortenedName: 'msmarco-distilbert-base-tas-b',
+  description: 'A sentence transformer from Hugging Face',
+  format: PRETRAINED_MODEL_FORMAT.TORCH_SCRIPT,
+  version: '1.0.2',
   vectorDimensions: 768,
 } as PretrainedSentenceTransformer;
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -82,6 +82,16 @@ export type CreateIndexNode = TemplateNode & {
   };
 };
 
+export type RegisterPretrainedModelNode = TemplateNode & {
+  user_inputs: {
+    name: string;
+    description: string;
+    model_format: string;
+    version: string;
+    deploy: boolean;
+  };
+};
+
 export type TemplateEdge = {
   source: string;
   dest: string;
@@ -147,9 +157,16 @@ export enum MODEL_CATEGORY {
   PRETRAINED = 'Pretrained',
 }
 
+export enum PRETRAINED_MODEL_FORMAT {
+  TORCH_SCRIPT = 'TORCH_SCRIPT',
+}
+
 export type PretrainedModel = {
   name: string;
   shortenedName: string;
+  description: string;
+  format: PRETRAINED_MODEL_FORMAT;
+  version: string;
 };
 
 export type PretrainedSentenceTransformer = PretrainedModel & {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -152,6 +152,28 @@ export enum MODEL_STATE {
   DEPLOY_FAILED = 'Deploy failed',
 }
 
+// Based off of https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/FunctionName.java
+export enum MODEL_ALGORITHM {
+  LINEAR_REGRESSION = 'Linear regression',
+  KMEANS = 'K-means',
+  AD_LIBSVM = 'AD LIBSVM',
+  SAMPLE_ALGO = 'Sample algorithm',
+  LOCAL_SAMPLE_CALCULATOR = 'Local sample calculator',
+  FIT_RCF = 'Fit RCF',
+  BATCH_RCF = 'Batch RCF',
+  ANOMALY_LOCALIZATION = 'Anomaly localization',
+  RCF_SUMMARIZE = 'RCF summarize',
+  LOGISTIC_REGRESSION = 'Logistic regression',
+  TEXT_EMBEDDING = 'Text embedding',
+  METRICS_CORRELATION = 'Metrics correlation',
+  REMOTE = 'Remote',
+  SPARSE_ENCODING = 'Sparse encoding',
+  SPARSE_TOKENIZE = 'Sparse tokenize',
+  TEXT_SIMILARITY = 'Text similarity',
+  QUESTION_ANSWERING = 'Question answering',
+  AGENT = 'Agent',
+}
+
 export enum MODEL_CATEGORY {
   DEPLOYED = 'Deployed',
   PRETRAINED = 'Pretrained',
@@ -166,6 +188,7 @@ export type PretrainedModel = {
   shortenedName: string;
   description: string;
   format: PRETRAINED_MODEL_FORMAT;
+  algorithm: MODEL_ALGORITHM;
   version: string;
 };
 
@@ -181,7 +204,7 @@ export type ModelConfig = {
 export type Model = {
   id: string;
   name: string;
-  algorithm: string;
+  algorithm: MODEL_ALGORITHM;
   state: MODEL_STATE;
   modelConfig?: ModelConfig;
 };
@@ -193,6 +216,7 @@ export type ModelDict = {
 export type ModelFormValue = {
   id: string;
   category?: MODEL_CATEGORY;
+  algorithm?: MODEL_ALGORITHM;
 };
 
 /**

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -130,9 +130,52 @@ export enum USE_CASE {
 /**
  ********** ML PLUGIN TYPES/INTERFACES **********
  */
+
+// Based off of https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/model/MLModelState.java
+export enum MODEL_STATE {
+  REGISTERED = 'Registered',
+  REGISTERING = 'Registering',
+  DEPLOYING = 'Deploying',
+  DEPLOYED = 'Deployed',
+  PARTIALLY_DEPLOYED = 'Partially deployed',
+  UNDEPLOYED = 'Undeployed',
+  DEPLOY_FAILED = 'Deploy failed',
+}
+
+export enum MODEL_CATEGORY {
+  DEPLOYED = 'Deployed',
+  PRETRAINED = 'Pretrained',
+}
+
+export type PretrainedModel = {
+  name: string;
+  shortenedName: string;
+};
+
+export type PretrainedSentenceTransformer = PretrainedModel & {
+  vectorDimensions: number;
+};
+
+export type ModelConfig = {
+  modelType?: string;
+  embeddingDimension?: number;
+};
+
 export type Model = {
   id: string;
+  name: string;
   algorithm: string;
+  state: MODEL_STATE;
+  modelConfig?: ModelConfig;
+};
+
+export type ModelDict = {
+  [modelId: string]: Model;
+};
+
+export type ModelFormValue = {
+  id: string;
+  category?: MODEL_CATEGORY;
 };
 
 /**
@@ -170,8 +213,4 @@ export enum WORKFLOW_RESOURCE_TYPE {
 
 export type WorkflowDict = {
   [workflowId: string]: Workflow;
-};
-
-export type ModelDict = {
-  [modelId: string]: Model;
 };

--- a/public/app.tsx
+++ b/public/app.tsx
@@ -62,12 +62,21 @@ export const FlowFrameworkDashboardsApp = (props: Props) => {
             <Workflows {...routeProps} />
           )}
         />
-        {/* Defaulting to Workflows page */}
+        {/*
+        Defaulting to Workflows page. The pathname will need to be updated
+        to handle the redirection and get the router props consistent.
+        */}
         <Route
           path={`${APP_PATH.HOME}`}
-          render={(routeProps: RouteComponentProps<WorkflowsRouterProps>) => (
-            <Workflows {...routeProps} />
-          )}
+          render={(routeProps: RouteComponentProps<WorkflowsRouterProps>) => {
+            if (props.history.location.pathname !== APP_PATH.WORKFLOWS) {
+              props.history.replace({
+                ...history,
+                pathname: APP_PATH.WORKFLOWS,
+              });
+            }
+            return <Workflows {...routeProps} />;
+          }}
         />
       </Switch>
     </EuiPageTemplate>

--- a/public/component_types/interfaces.ts
+++ b/public/component_types/interfaces.ts
@@ -10,7 +10,7 @@ import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../utils';
 /**
  * ************ Types *************************
  */
-export type FieldType = 'string' | 'json' | 'select';
+export type FieldType = 'string' | 'json' | 'select' | 'model';
 export type SelectType = 'model';
 export type FieldValue = string | {};
 export type ComponentFormValues = FormikValues;

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -19,14 +19,6 @@ export class TextEmbeddingTransformer extends MLTransformer {
     this.inputs = [];
     this.createFields = [
       {
-        label: 'Ingest Pipeline',
-        id: 'ingestPipelineName',
-        type: 'string',
-        helpText:
-          'The name of the ingest pipeline configured with the text embedding transformer',
-        helpLink: 'https://opensearch.org/docs/latest/ingest-pipelines/',
-      },
-      {
         label: 'Model',
         id: 'model',
         type: 'model',

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -19,11 +19,10 @@ export class TextEmbeddingTransformer extends MLTransformer {
     this.inputs = [];
     this.createFields = [
       {
-        label: 'Model ID',
-        id: 'modelId',
-        type: 'select',
-        selectType: 'model',
-        helpText: 'The deployed text embedding model to use for embedding.',
+        label: 'Model',
+        id: 'model',
+        type: 'model',
+        helpText: 'A text embedding model for embedding text.',
         helpLink:
           'https://opensearch.org/docs/latest/ml-commons-plugin/integrating-ml-models/#choosing-a-model',
       },

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -19,7 +19,7 @@ export class TextEmbeddingTransformer extends MLTransformer {
     this.inputs = [];
     this.createFields = [
       {
-        label: 'Model',
+        label: 'Text Embedding Model',
         id: 'model',
         type: 'model',
         helpText: 'A text embedding model for embedding text.',

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -35,7 +35,6 @@ export class TextEmbeddingTransformer extends MLTransformer {
         helpLink:
           'https://opensearch.org/docs/latest/ingest-pipelines/processors/text-embedding/',
       },
-
       {
         label: 'Vector Field',
         id: 'vectorField',

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -19,6 +19,14 @@ export class TextEmbeddingTransformer extends MLTransformer {
     this.inputs = [];
     this.createFields = [
       {
+        label: 'Ingest Pipeline',
+        id: 'ingestPipelineName',
+        type: 'string',
+        helpText:
+          'The name of the ingest pipeline configured with the text embedding transformer',
+        helpLink: 'https://opensearch.org/docs/latest/ingest-pipelines/',
+      },
+      {
         label: 'Model',
         id: 'model',
         type: 'model',

--- a/public/pages/workflow_detail/component_details/component_details.tsx
+++ b/public/pages/workflow_detail/component_details/component_details.tsx
@@ -28,9 +28,12 @@ interface ComponentDetailsProps {
 export function ComponentDetails(props: ComponentDetailsProps) {
   return (
     <EuiPanel paddingSize="m">
-      {props.isDeprovisionable ? (
+      {/* TODO: determine if we need this view if we want the workspace to remain
+      readonly once provisioned */}
+      {/* {props.isDeprovisionable ? (
         <ProvisionedComponentInputs />
-      ) : props.selectedComponent ? (
+      ) : */}
+      {props.selectedComponent ? (
         <ComponentInputs
           selectedComponent={props.selectedComponent}
           onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/component_details/component_inputs.tsx
+++ b/public/pages/workflow_detail/component_details/component_inputs.tsx
@@ -55,6 +55,9 @@ export function ComponentInputs(props: ComponentInputsProps) {
         <EuiTitle size="m">
           <h2>{props.selectedComponent.data.label || ''}</h2>
         </EuiTitle>
+        <EuiText color="subdued">
+          {props.selectedComponent.data.description}
+        </EuiText>
         <NewOrExistingTabs
           selectedTabId={selectedTabId}
           setSelectedTabId={setSelectedTabId}

--- a/public/pages/workflow_detail/component_details/input_field_list.tsx
+++ b/public/pages/workflow_detail/component_details/input_field_list.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { TextField, JsonField, SelectField } from './input_fields';
+import { TextField, JsonField, SelectField, ModelField } from './input_fields';
 import { IComponentField } from '../../../../common';
 
 /**
@@ -45,6 +45,19 @@ export function InputFieldList(props: InputFieldListProps) {
             el = (
               <EuiFlexItem key={idx}>
                 <SelectField
+                  field={field}
+                  componentId={props.componentId}
+                  onFormChange={props.onFormChange}
+                />
+                <EuiSpacer size={INPUT_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'model': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <ModelField
                   field={field}
                   componentId={props.componentId}
                   onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/component_details/input_fields/index.ts
+++ b/public/pages/workflow_detail/component_details/input_fields/index.ts
@@ -6,3 +6,4 @@
 export { TextField } from './text_field';
 export { JsonField } from './json_field';
 export { SelectField } from './select_field';
+export { ModelField } from './model_field';

--- a/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
@@ -25,6 +25,7 @@ import {
   isFieldInvalid,
   ModelFormValue,
   MODEL_CATEGORY,
+  MPNET_SENTENCE_TRANSFORMER,
 } from '../../../../../common';
 import { AppState } from '../../../../store';
 
@@ -32,16 +33,6 @@ interface ModelFieldProps {
   field: IComponentField;
   componentId: string;
   onFormChange: () => void;
-}
-
-enum MODEL_TYPE {
-  CUSTOM = 'Custom',
-  PRETRAINED = 'Pretrained',
-}
-
-enum RADIO_ID {
-  DEPLOYED = 'Deployed',
-  PRETRAINED = 'Pretrained',
 }
 
 type ModelItem = ModelFormValue & {
@@ -109,6 +100,11 @@ export function ModelField(props: ModelFieldProps) {
         category: MODEL_CATEGORY.PRETRAINED,
       },
       {
+        id: MPNET_SENTENCE_TRANSFORMER.name,
+        name: MPNET_SENTENCE_TRANSFORMER.shortenedName,
+        category: MODEL_CATEGORY.PRETRAINED,
+      },
+      {
         id: BERT_SENTENCE_TRANSFORMER.name,
         name: BERT_SENTENCE_TRANSFORMER.shortenedName,
         category: MODEL_CATEGORY.PRETRAINED,
@@ -171,7 +167,7 @@ export function ModelField(props: ModelFieldProps) {
                 options={selectableModels.map(
                   (option) =>
                     ({
-                      value: option.name,
+                      value: option.id,
                       inputDisplay: (
                         <>
                           <EuiText size="xs">{option.name}</EuiText>

--- a/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Field, FieldProps, useFormikContext } from 'formik';
+import {
+  EuiFormRow,
+  EuiLink,
+  EuiRadioGroup,
+  EuiRadioGroupOption,
+  EuiSpacer,
+  EuiSuperSelect,
+  EuiSuperSelectOption,
+  EuiText,
+} from '@elastic/eui';
+import {
+  BERT_SENTENCE_TRANSFORMER,
+  IComponentField,
+  MODEL_STATE,
+  ROBERTA_SENTENCE_TRANSFORMER,
+  WorkspaceFormValues,
+  isFieldInvalid,
+  ModelFormValue,
+  MODEL_CATEGORY,
+} from '../../../../../common';
+import { AppState } from '../../../../store';
+
+interface ModelFieldProps {
+  field: IComponentField;
+  componentId: string;
+  onFormChange: () => void;
+}
+
+enum MODEL_TYPE {
+  CUSTOM = 'Custom',
+  PRETRAINED = 'Pretrained',
+}
+
+enum RADIO_ID {
+  DEPLOYED = 'Deployed',
+  PRETRAINED = 'Pretrained',
+}
+
+type ModelItem = ModelFormValue & {
+  name: string;
+};
+
+// TODO: there is no concrete UX for model selection and model provisioning. This component is TBD
+// and simply provides the ability to select existing models, or deploy some pretrained ones,
+// and persist all of this in form state.
+/**
+ * A specific field for selecting existing deployed models, or available pretrained models.
+ */
+export function ModelField(props: ModelFieldProps) {
+  // Initial store is fetched when loading base <DetectorDetail /> page. We don't
+  // re-fetch here as it could overload client-side if user clicks back and forth /
+  // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
+  const models = useSelector((state: AppState) => state.models.models);
+
+  const formField = `${props.componentId}.${props.field.id}`;
+  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+
+  // Deployed models state
+  const [deployedModels, setDeployedModels] = useState<ModelItem[]>([]);
+  const [pretrainedModels, setPretrainedModels] = useState<ModelItem[]>([]);
+  const [selectableModels, setSelectableModels] = useState<ModelItem[]>([]);
+
+  // Radio options state
+  const radioOptions = [
+    {
+      id: MODEL_CATEGORY.DEPLOYED,
+      label: 'Existing deployed models',
+    },
+    {
+      id: MODEL_CATEGORY.PRETRAINED,
+      label: 'Pretrained models',
+    },
+  ] as EuiRadioGroupOption[];
+  const [selectedRadioId, setSelectedRadioId] = useState<
+    MODEL_CATEGORY | undefined
+  >(undefined);
+
+  // Initialize available deployed models
+  useEffect(() => {
+    if (models) {
+      const modelItems = [] as ModelItem[];
+      Object.keys(models).forEach((modelId) => {
+        if (models[modelId].state === MODEL_STATE.DEPLOYED) {
+          modelItems.push({
+            id: modelId,
+            name: models[modelId].name,
+            category: MODEL_CATEGORY.DEPLOYED,
+          } as ModelItem);
+        }
+      });
+      setDeployedModels(modelItems);
+    }
+  }, [models]);
+
+  // Initialize available pretrained models
+  useEffect(() => {
+    const modelItems = [
+      {
+        id: ROBERTA_SENTENCE_TRANSFORMER.name,
+        name: ROBERTA_SENTENCE_TRANSFORMER.shortenedName,
+        category: MODEL_CATEGORY.PRETRAINED,
+      },
+      {
+        id: BERT_SENTENCE_TRANSFORMER.name,
+        name: BERT_SENTENCE_TRANSFORMER.shortenedName,
+        category: MODEL_CATEGORY.PRETRAINED,
+      },
+    ];
+    setPretrainedModels(modelItems);
+  }, []);
+
+  // Update the valid available models when the radio selection changes.
+  // e.g., only show deployed models when 'deployed' button is selected
+  useEffect(() => {
+    if (selectedRadioId !== undefined) {
+      if (selectedRadioId === MODEL_CATEGORY.DEPLOYED) {
+        setSelectableModels(deployedModels);
+      } else {
+        setSelectableModels(pretrainedModels);
+      }
+    }
+  }, [selectedRadioId, deployedModels, pretrainedModels]);
+
+  return (
+    <Field name={formField}>
+      {({ field, form }: FieldProps) => {
+        // a hook to update the model category and trigger reloading
+        // of valid models to select from
+        useEffect(() => {
+          setSelectedRadioId(field.value.category);
+        }, [field.value.category]);
+        return (
+          <EuiFormRow
+            label={props.field.label}
+            labelAppend={
+              props.field.helpLink ? (
+                <EuiText size="xs">
+                  <EuiLink href={props.field.helpLink} target="_blank">
+                    Learn more
+                  </EuiLink>
+                </EuiText>
+              ) : undefined
+            }
+            helpText={props.field.helpText || undefined}
+          >
+            <>
+              <EuiRadioGroup
+                options={radioOptions}
+                idSelected={field.value.category}
+                onChange={(radioId) => {
+                  // if user selects a new category:
+                  // 1. clear the saved ID
+                  // 2. update the field category
+                  form.setFieldValue(formField, {
+                    id: '',
+                    category: radioId,
+                  } as ModelFormValue);
+                  props.onFormChange();
+                }}
+              ></EuiRadioGroup>
+              <EuiSpacer size="s" />
+              <EuiSuperSelect
+                options={selectableModels.map(
+                  (option) =>
+                    ({
+                      value: option.name,
+                      inputDisplay: (
+                        <>
+                          <EuiText size="xs">{option.name}</EuiText>
+                          <EuiText size="xs" color="subdued">
+                            {option.category}
+                          </EuiText>
+                        </>
+                      ),
+                      disabled: false,
+                    } as EuiSuperSelectOption<string>)
+                )}
+                valueOfSelected={field.value.id || ''}
+                onChange={(option: string) => {
+                  form.setFieldValue(formField, {
+                    id: option,
+                    category: selectedRadioId,
+                  } as ModelFormValue);
+                  props.onFormChange();
+                }}
+                isInvalid={isFieldInvalid(
+                  props.componentId,
+                  props.field.id,
+                  errors,
+                  touched
+                )}
+              />
+            </>
+          </EuiFormRow>
+        );
+      }}
+    </Field>
+  );
+}

--- a/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/model_field.tsx
@@ -84,6 +84,7 @@ export function ModelField(props: ModelFieldProps) {
             id: modelId,
             name: models[modelId].name,
             category: MODEL_CATEGORY.DEPLOYED,
+            algorithm: models[modelId].algorithm,
           } as ModelItem);
         }
       });
@@ -98,16 +99,19 @@ export function ModelField(props: ModelFieldProps) {
         id: ROBERTA_SENTENCE_TRANSFORMER.name,
         name: ROBERTA_SENTENCE_TRANSFORMER.shortenedName,
         category: MODEL_CATEGORY.PRETRAINED,
+        algorithm: ROBERTA_SENTENCE_TRANSFORMER.algorithm,
       },
       {
         id: MPNET_SENTENCE_TRANSFORMER.name,
         name: MPNET_SENTENCE_TRANSFORMER.shortenedName,
         category: MODEL_CATEGORY.PRETRAINED,
+        algorithm: MPNET_SENTENCE_TRANSFORMER.algorithm,
       },
       {
         id: BERT_SENTENCE_TRANSFORMER.name,
         name: BERT_SENTENCE_TRANSFORMER.shortenedName,
         category: MODEL_CATEGORY.PRETRAINED,
+        algorithm: BERT_SENTENCE_TRANSFORMER.algorithm,
       },
     ];
     setPretrainedModels(modelItems);
@@ -170,9 +174,17 @@ export function ModelField(props: ModelFieldProps) {
                       value: option.id,
                       inputDisplay: (
                         <>
-                          <EuiText size="xs">{option.name}</EuiText>
+                          <EuiText size="s">{option.name}</EuiText>
+                        </>
+                      ),
+                      dropdownDisplay: (
+                        <>
+                          <EuiText size="s">{option.name}</EuiText>
                           <EuiText size="xs" color="subdued">
                             {option.category}
+                          </EuiText>
+                          <EuiText size="xs" color="subdued">
+                            {option.algorithm}
                           </EuiText>
                         </>
                       ),

--- a/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/component_details/input_fields/select_field.tsx
@@ -19,7 +19,6 @@ import {
   getInitialValue,
   isFieldInvalid,
 } from '../../../../../common';
-import { AppState } from '../../../../store';
 
 interface SelectFieldProps {
   field: IComponentField;
@@ -32,21 +31,15 @@ interface SelectFieldProps {
  * options.
  */
 export function SelectField(props: SelectFieldProps) {
-  // Redux store state
-  // Initial store is fetched when loading base <DetectorDetail /> page. We don't
-  // re-fetch here as it could overload client-side if user clicks back and forth /
-  // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
-  const models = useSelector((state: AppState) => state.models.models);
-
   // Options state
   const [options, setOptions] = useState<string[]>([]);
 
   // Populate options depending on the select type
   useEffect(() => {
-    if (props.field.selectType === 'model' && models) {
-      setOptions(Object.keys(models));
+    // TODO: figure out how we want to utilize select types to customize the options
+    if (props.field.selectType === 'model') {
     }
-  }, [models]);
+  }, []);
 
   const formField = `${props.componentId}.${props.field.id}`;
   const { errors, touched } = useFormikContext<WorkspaceFormValues>();

--- a/public/pages/workflow_detail/resources/resource_list.tsx
+++ b/public/pages/workflow_detail/resources/resource_list.tsx
@@ -23,10 +23,16 @@ interface ResourceListProps {
 export function ResourceList(props: ResourceListProps) {
   const [allResources, setAllResources] = useState<WorkflowResource[]>([]);
 
-  // Hook to initialize all resources
+  // Hook to initialize all resources. Reduce to unique IDs, since
+  // the backend resources may include the same resource multiple times
+  // (e.g., register and deploy steps persist the same model ID resource)
   useEffect(() => {
     if (props.workflow?.resourcesCreated) {
-      setAllResources(props.workflow.resourcesCreated);
+      const resourcesMap = {} as { [id: string]: WorkflowResource };
+      props.workflow.resourcesCreated.forEach((resource) => {
+        resourcesMap[resource.id] = resource;
+      });
+      setAllResources(Object.values(resourcesMap));
     }
   }, [props.workflow?.resourcesCreated]);
 

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -28,6 +28,7 @@ import {
   MPNET_SENTENCE_TRANSFORMER,
   BERT_SENTENCE_TRANSFORMER,
   REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE,
+  generateId,
 } from '../../../../common';
 
 /**
@@ -128,18 +129,15 @@ function toIngestPipelineNodes(flowNode: ReactFlowComponent): TemplateNode[] {
   switch (flowNode.data.type) {
     case COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER:
     default: {
-      const {
-        ingestPipelineName,
-        model,
-        inputField,
-        vectorField,
-      } = componentDataToFormik(flowNode.data) as {
-        ingestPipelineName: string;
+      const { model, inputField, vectorField } = componentDataToFormik(
+        flowNode.data
+      ) as {
         model: ModelFormValue;
         inputField: string;
         vectorField: string;
       };
       const modelId = model.id;
+      const ingestPipelineName = generateId('ingest_pipeline');
 
       let registerModelStep = undefined as
         | RegisterPretrainedModelNode

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -128,9 +128,17 @@ function toIngestPipelineNodes(flowNode: ReactFlowComponent): TemplateNode[] {
   switch (flowNode.data.type) {
     case COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER:
     default: {
-      const { model, inputField, vectorField } = componentDataToFormik(
-        flowNode.data
-      ) as { model: ModelFormValue; inputField: string; vectorField: string };
+      const {
+        ingestPipelineName,
+        model,
+        inputField,
+        vectorField,
+      } = componentDataToFormik(flowNode.data) as {
+        ingestPipelineName: string;
+        model: ModelFormValue;
+        inputField: string;
+        vectorField: string;
+      };
       const modelId = model.id;
 
       let registerModelStep = undefined as
@@ -174,8 +182,7 @@ function toIngestPipelineNodes(flowNode: ReactFlowComponent): TemplateNode[] {
               [REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE]: 'model_id',
             },
             user_inputs: {
-              // TODO: expose as customizable
-              pipeline_id: 'test-pipeline',
+              pipeline_id: ingestPipelineName,
               model_id: `\${{${REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE}.model_id}}`,
               input_field: inputField,
               output_field: vectorField,
@@ -202,8 +209,7 @@ function toIngestPipelineNodes(flowNode: ReactFlowComponent): TemplateNode[] {
             id: flowNode.data.id,
             type: CREATE_INGEST_PIPELINE_STEP_TYPE,
             user_inputs: {
-              // TODO: expose as customizable
-              pipeline_id: 'test-pipeline',
+              pipeline_id: ingestPipelineName,
               model_id: modelId,
               input_field: inputField,
               output_field: vectorField,

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -117,6 +117,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     props.workflow !== undefined &&
     !props.isNewWorkflow &&
     props.workflow?.state !== WORKFLOW_STATE.NOT_STARTED;
+  // TODO: maybe remove this field. It depends on final UX if we want the
+  // workspace to be readonly once provisioned or not.
   const readonly = props.workflow === undefined || isDeprovisionable;
 
   // Loading state
@@ -321,6 +323,17 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
               components.
             </EuiCallOut>
           )}
+          {isDeprovisionable && isDirty && (
+            <EuiCallOut
+              title="The configured flow has been provisioned"
+              color="warning"
+              iconType="alert"
+              style={{ marginBottom: '16px' }}
+            >
+              Changes cannot be saved until the flow has first been
+              deprovisioned.
+            </EuiCallOut>
+          )}
           <EuiPageHeader
             style={{ marginBottom: '8px' }}
             rightSideItems={[
@@ -458,7 +471,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                         <Workspace
                           id="ingest"
                           workflow={workflow}
-                          readonly={readonly}
+                          readonly={false}
                           onNodesChange={onNodesChange}
                           onSelectionChange={onSelectionChange}
                         />

--- a/public/pages/workflow_detail/workspace/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/workspace/resizable_workspace.tsx
@@ -33,6 +33,7 @@ import {
   processNodes,
   reduceToTemplate,
   ReactFlowEdge,
+  APP_PATH,
 } from '../../../../common';
 import { validateWorkspaceFlow, toTemplateFlows } from '../utils';
 import {
@@ -168,7 +169,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       props.workflow && !props.workflow?.ui_metadata?.workspace_flow;
     const missingCachedWorkflow = props.isNewWorkflow && !props.workflow;
     if (missingUiFlow || missingCachedWorkflow) {
-      history.replace('/workflows');
+      history.replace(APP_PATH.WORKFLOWS);
       if (missingCachedWorkflow) {
         getCore().notifications.toasts.addWarning('No workflow found');
       } else {
@@ -410,7 +411,9 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                           .unwrap()
                           .then((result) => {
                             const { workflow } = result;
-                            history.replace(`/workflows/${workflow.id}`);
+                            history.replace(
+                              `${APP_PATH.WORKFLOWS}/${workflow.id}`
+                            );
                             history.go(0);
                           })
                           .catch((error: any) => {

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -13,7 +13,7 @@ import {
   EuiHorizontalRule,
   EuiButton,
 } from '@elastic/eui';
-import { NEW_WORKFLOW_ID_URL, PLUGIN_ID } from '../../../../common';
+import { APP_PATH, NEW_WORKFLOW_ID_URL, PLUGIN_ID } from '../../../../common';
 
 interface UseCaseProps {
   title: string;
@@ -44,7 +44,7 @@ export function UseCase(props: UseCaseProps) {
               disabled={false}
               isLoading={false}
               onClick={props.onClick}
-              href={`${PLUGIN_ID}#/workflows/${NEW_WORKFLOW_ID_URL}`}
+              href={`${PLUGIN_ID}#${APP_PATH.WORKFLOWS}/${NEW_WORKFLOW_ID_URL}`}
             >
               Go
             </EuiButton>

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -15,7 +15,7 @@ export enum APP_PATH {
 }
 
 export const BREADCRUMBS = Object.freeze({
-  FLOW_FRAMEWORK: { text: 'Flow Framework', href: '#/' },
+  FLOW_FRAMEWORK: { text: 'Flow Framework' },
   WORKFLOWS: { text: 'Workflows', href: `#${APP_PATH.WORKFLOWS}` },
 });
 

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -18,6 +18,7 @@ import {
   ReactFlowComponent,
   Workflow,
   WorkflowTemplate,
+  ModelFormValue,
 } from '../../common';
 
 // Append 16 random characters
@@ -82,6 +83,7 @@ export function reduceToTemplate(workflow: Workflow): WorkflowTemplate {
     lastUpdated,
     lastLaunched,
     state,
+    resourcesCreated,
     ...workflowTemplate
   } = workflow;
   return workflowTemplate;
@@ -95,6 +97,12 @@ export function getInitialValue(fieldType: FieldType): FieldValue {
     }
     case 'select': {
       return '';
+    }
+    case 'model': {
+      return {
+        id: '',
+        category: undefined,
+      } as ModelFormValue;
     }
     case 'json': {
       return {};
@@ -160,6 +168,13 @@ function getFieldSchema(field: IComponentField): Schema {
     case 'string':
     case 'select': {
       baseSchema = yup.string().min(1, 'Too short').max(70, 'Too long');
+      break;
+    }
+    case 'model': {
+      baseSchema = yup.object().shape({
+        id: yup.string().min(1, 'Too short').max(70, 'Too long').required(),
+        category: yup.string().required(),
+      });
       break;
     }
     case 'json': {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -102,6 +102,7 @@ export function getInitialValue(fieldType: FieldType): FieldValue {
       return {
         id: '',
         category: undefined,
+        algorithm: undefined,
       } as ModelFormValue;
     }
     case 'json': {

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -6,6 +6,7 @@
 import {
   DEFAULT_NEW_WORKFLOW_STATE_TYPE,
   INDEX_NOT_FOUND_EXCEPTION,
+  MODEL_STATE,
   Model,
   ModelDict,
   WORKFLOW_RESOURCE_TYPE,
@@ -85,13 +86,24 @@ export function getWorkflowsFromResponses(
 export function getModelsFromResponses(modelHits: any[]): ModelDict {
   const modelDict = {} as ModelDict;
   modelHits.forEach((modelHit: any) => {
-    const modelId = modelHit._source?.model_id;
-    // in case of schema changes from ML plugin, this may crash. That is ok, as the error
-    // produced will help expose the root cause
-    modelDict[modelId] = {
-      id: modelId,
-      algorithm: modelHit._source?.algorithm,
-    } as Model;
+    // search model API returns hits for each deployed model chunk. ignore these hits
+    if (modelHit._source.chunk_number === undefined) {
+      const modelId = modelHit._id;
+      // in case of schema changes from ML plugin, this may crash. That is ok, as the error
+      // produced will help expose the root cause
+      modelDict[modelId] = {
+        id: modelId,
+        name: modelHit._source?.name,
+        algorithm: modelHit._source?.algorithm,
+        // @ts-ignore
+        state: MODEL_STATE[modelHit._source?.model_state],
+        modelConfig: {
+          modelType: modelHit._source?.model_config?.model_type,
+          embeddingDimension:
+            modelHit._source?.model_config?.embedding_dimension,
+        },
+      } as Model;
+    }
   });
   return modelDict;
 }

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -6,6 +6,7 @@
 import {
   DEFAULT_NEW_WORKFLOW_STATE_TYPE,
   INDEX_NOT_FOUND_EXCEPTION,
+  MODEL_ALGORITHM,
   MODEL_STATE,
   Model,
   ModelDict,
@@ -94,7 +95,8 @@ export function getModelsFromResponses(modelHits: any[]): ModelDict {
       modelDict[modelId] = {
         id: modelId,
         name: modelHit._source?.name,
-        algorithm: modelHit._source?.algorithm,
+        // @ts-ignore
+        algorithm: MODEL_ALGORITHM[modelHit._source?.algorithm],
         // @ts-ignore
         state: MODEL_STATE[modelHit._source?.model_state],
         modelConfig: {


### PR DESCRIPTION
### Description

This PR adds the ability to select existing models, or select from available pretrained models, in the text embedding processor component. Specifically:
- adds and updates several ML commons interfaces and constants
- enhances search model logic on server-side to parse out more details from the API responses
- adds some pretrained model constants to be optionally used when building flows
- adds a `ModelField` field type to process all of the logic around model selection, including only showing valid deployed models, and available pretrained models. _Note: the final props and how customizable this field will need to be is TBD. For example, we can customize it to be tailored towards text embedding models vs. other types of models in the future_
- updates form state and form validation to persist more model info instead of just model ID (now model ID + model type (pretrained vs. existing/deployed) + open door for more)
- updates `toTemplateNodes` to dynamically handle the template node creation based on a pretrained vs. existing/deployed model. If a pretrained model is selected, we add a previous step to register and deploy that model, and use the produced model ID in the downstream `create_ingest_pipeline step`. Else, use the existing logic and just use the user/form-supplied model ID directly in a single `create_ingest_pipeline` step.


Misc:
- cleans up routing and URL logic when navigating to the plugin from the global sidebar, in addition to the default rerouting to the workflows page
- removes hyperlink in the base `Flow Framework` breadcrumb
- changes the provisioned workflow state slightly by removing the readonly guardrails and allowing the components to be selectable to see the details. Adds a warning callout when values are changed but the workflow is provisioned, and still enforces the workflow to be deprovisioned before changes can be saved. Adds TODOs if we want to revert this change
- enforces uniqueness on resource ID list to prevent duplicates which can happen on backend in certain edge cases (comments in code about it)

Demo video:
- creates workflow with pretrained model
- provisions workflow to create the model and use it in the downstream creation of an ingest pipeline
- views the workflow resources, including the newly created model


[screen-capture (29).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/23a4e12d-04b8-42a5-9f9e-efd3140d9023)


### Issues Resolved
Makes progress on #73 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
