### PR TITLE
Add a prototype tab; support ingest and search with guardrails

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -36,6 +36,7 @@ export const BASE_NODE_API_PATH = '/api/flow_framework';
 export const BASE_OPENSEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/opensearch`;
 export const CAT_INDICES_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/catIndices`;
 export const SEARCH_INDEX_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/search`;
+export const INGEST_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/ingest`;
 
 // Flow Framework node APIs
 export const BASE_WORKFLOW_NODE_API_PATH = `${BASE_NODE_API_PATH}/workflow`;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -35,6 +35,7 @@ export const BASE_NODE_API_PATH = '/api/flow_framework';
 // OpenSearch node APIs
 export const BASE_OPENSEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/opensearch`;
 export const CAT_INDICES_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/catIndices`;
+export const SEARCH_INDEX_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/search`;
 
 // Flow Framework node APIs
 export const BASE_WORKFLOW_NODE_API_PATH = `${BASE_NODE_API_PATH}/workflow`;

--- a/public/pages/workflow_detail/prototype/index.ts
+++ b/public/pages/workflow_detail/prototype/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './prototype';

--- a/public/pages/workflow_detail/prototype/prototype.tsx
+++ b/public/pages/workflow_detail/prototype/prototype.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageContent,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { Workflow } from '../../../../common';
+import { QueryExecutor } from './query_executor';
+
+interface PrototypeProps {
+  workflow?: Workflow;
+}
+
+/**
+ * A simple prototyping page to perform ingest and search.
+ */
+export function Prototype(props: PrototypeProps) {
+  return (
+    <EuiPageContent>
+      <EuiTitle>
+        <h2>Prototype</h2>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      {props.workflow?.resourcesCreated &&
+      props.workflow?.resourcesCreated.length > 0 ? (
+        <EuiFlexGroup direction="row">
+          <EuiFlexItem>
+            <QueryExecutor workflow={props.workflow} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : (
+        <EuiEmptyPrompt
+          iconType={'cross'}
+          title={<h2>No resources available</h2>}
+          titleSize="s"
+          body={
+            <>
+              <EuiText>
+                Provision the workflow to generate resources in order to start
+                prototyping.
+              </EuiText>
+            </>
+          }
+        />
+      )}
+    </EuiPageContent>
+  );
+}

--- a/public/pages/workflow_detail/prototype/prototype.tsx
+++ b/public/pages/workflow_detail/prototype/prototype.tsx
@@ -3,27 +3,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageContent,
   EuiSpacer,
+  EuiTab,
+  EuiTabs,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { QueryExecutor } from './query_executor';
+import { Ingestor } from './ingestor';
 
 interface PrototypeProps {
   workflow?: Workflow;
 }
 
+enum TAB_ID {
+  INGEST = 'ingest',
+  QUERY = 'query',
+}
+
+const inputTabs = [
+  {
+    id: TAB_ID.INGEST,
+    name: '1. Ingest Data',
+    disabled: false,
+  },
+  {
+    id: TAB_ID.QUERY,
+    name: '2. Query data',
+    disabled: false,
+  },
+];
+
 /**
  * A simple prototyping page to perform ingest and search.
  */
 export function Prototype(props: PrototypeProps) {
+  const [selectedTabId, setSelectedTabId] = useState<string>(TAB_ID.INGEST);
   return (
     <EuiPageContent>
       <EuiTitle>
@@ -32,11 +54,35 @@ export function Prototype(props: PrototypeProps) {
       <EuiSpacer size="m" />
       {props.workflow?.resourcesCreated &&
       props.workflow?.resourcesCreated.length > 0 ? (
-        <EuiFlexGroup direction="row">
-          <EuiFlexItem>
-            <QueryExecutor workflow={props.workflow} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <>
+          <EuiTabs size="m" expand={false}>
+            {inputTabs.map((tab, idx) => {
+              return (
+                <EuiTab
+                  onClick={() => setSelectedTabId(tab.id)}
+                  isSelected={tab.id === selectedTabId}
+                  disabled={tab.disabled}
+                  key={idx}
+                >
+                  {tab.name}
+                </EuiTab>
+              );
+            })}
+          </EuiTabs>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup direction="column">
+            {selectedTabId === TAB_ID.INGEST && (
+              <EuiFlexItem>
+                <Ingestor workflow={props.workflow} />
+              </EuiFlexItem>
+            )}
+            {selectedTabId === TAB_ID.QUERY && (
+              <EuiFlexItem>
+                <QueryExecutor workflow={props.workflow} />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </>
       ) : (
         <EuiEmptyPrompt
           iconType={'cross'}

--- a/public/pages/workflow_detail/prototype/query_executor.tsx
+++ b/public/pages/workflow_detail/prototype/query_executor.tsx
@@ -15,6 +15,7 @@ import {
 import {
   USE_CASE,
   Workflow,
+  getIndexName,
   getSemanticSearchValues,
 } from '../../../../common';
 
@@ -48,16 +49,18 @@ export function QueryExecutor(props: QueryExecutorProps) {
   // query state
   const [workflowValues, setWorkflowValues] = useState<WorkflowValues>();
   const [queryGeneratorFn, setQueryGeneratorFn] = useState<QueryGeneratorFn>();
+  const [indexName, setIndexName] = useState<string>();
   const [queryObj, setQueryObj] = useState<{}>({});
   const [userInput, setUserInput] = useState<string>('');
 
   // results state
   const [resultsObj, setResultsObj] = useState<{}>({});
 
-  // hook to set the appropriate values and query generator fn
+  // hook to set all of the workflow-related fields based on the use case
   useEffect(() => {
     setWorkflowValues(getWorkflowValues(props.workflow));
     setQueryGeneratorFn(getQueryGeneratorFn(props.workflow));
+    setIndexName(getIndexName(props.workflow));
   }, [props.workflow]);
 
   // hook to generate the query once all dependent input vars are available
@@ -67,9 +70,7 @@ export function QueryExecutor(props: QueryExecutorProps) {
     }
   }, [userInput, queryGeneratorFn, workflowValues]);
 
-  function onExecute() {
-    console.log('executing...');
-  }
+  function onExecute() {}
 
   return (
     <EuiFlexGroup direction="row">

--- a/public/pages/workflow_detail/prototype/query_executor.tsx
+++ b/public/pages/workflow_detail/prototype/query_executor.tsx
@@ -148,7 +148,7 @@ export function QueryExecutor(props: QueryExecutorProps) {
       <EuiFlexItem>
         <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexItem grow={false}>
-            <EuiText>Results</EuiText>
+            <EuiText size="s">Results</EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row">

--- a/public/pages/workflow_detail/prototype/query_executor.tsx
+++ b/public/pages/workflow_detail/prototype/query_executor.tsx
@@ -135,8 +135,6 @@ export function QueryExecutor(props: QueryExecutorProps) {
               readOnly={true}
               setOptions={{
                 fontSize: '14px',
-                //   enableBasicAutocompletion: true,
-                //   enableLiveAutocompletion: true,
               }}
               aria-label="Code Editor"
               tabSize={2}

--- a/public/pages/workflow_detail/prototype/query_executor.tsx
+++ b/public/pages/workflow_detail/prototype/query_executor.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  EuiButton,
+  EuiCodeEditor,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '@elastic/eui';
+import {
+  USE_CASE,
+  Workflow,
+  getSemanticSearchValues,
+} from '../../../../common';
+
+interface QueryExecutorProps {
+  workflow: Workflow;
+}
+
+type WorkflowValues = {
+  modelId: string;
+};
+
+type SemanticSearchValues = WorkflowValues & {
+  inputField: string;
+  vectorField: string;
+};
+
+type QueryGeneratorFn = (
+  queryText: string,
+  workflowValues: SemanticSearchValues
+) => {};
+
+/**
+ * A basic and flexible UI for executing queries against an index. Sets up guardrails to limit
+ * what is customized in the query, and setting readonly values based on the workflow's use case
+ * and details.
+ *
+ * For example, given a semantic search workflow configured on index A, with model B, input field C, and vector field D,
+ * the UI will enforce a semantic search neural query configured with B,C,D, and run it against A.
+ */
+export function QueryExecutor(props: QueryExecutorProps) {
+  // query state
+  const [workflowValues, setWorkflowValues] = useState<WorkflowValues>();
+  const [queryGeneratorFn, setQueryGeneratorFn] = useState<QueryGeneratorFn>();
+  const [queryObj, setQueryObj] = useState<{}>({});
+  const [userInput, setUserInput] = useState<string>('');
+
+  // results state
+  const [resultsObj, setResultsObj] = useState<{}>({});
+
+  // hook to set the appropriate values and query generator fn
+  useEffect(() => {
+    setWorkflowValues(getWorkflowValues(props.workflow));
+    setQueryGeneratorFn(getQueryGeneratorFn(props.workflow));
+  }, [props.workflow]);
+
+  // hook to generate the query once all dependent input vars are available
+  useEffect(() => {
+    if (queryGeneratorFn && workflowValues) {
+      setQueryObj(queryGeneratorFn(userInput, workflowValues));
+    }
+  }, [userInput, queryGeneratorFn, workflowValues]);
+
+  function onExecute() {
+    console.log('executing...');
+  }
+
+  return (
+    <EuiFlexGroup direction="row">
+      <EuiFlexItem>
+        <EuiFlexGroup direction="column" gutterSize="m">
+          <EuiFlexItem>
+            <EuiText>Query</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup direction="row">
+              <EuiFlexItem>
+                <EuiFieldText
+                  placeholder={'Enter some plaintext...'}
+                  compressed={false}
+                  value={userInput}
+                  onChange={(e) => {
+                    setUserInput(e.target.value);
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={onExecute} fill={false}>
+                  Run!
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCodeEditor
+              mode="json"
+              theme="textmate"
+              width="100%"
+              height="50vh"
+              value={getFormattedJSONString(queryObj)}
+              onChange={() => {}}
+              readOnly={true}
+              setOptions={{
+                fontSize: '14px',
+                //   enableBasicAutocompletion: true,
+                //   enableLiveAutocompletion: true,
+              }}
+              aria-label="Code Editor"
+              tabSize={2}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}></EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiText>Results</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem style={{ marginTop: '70px' }}>
+            <EuiCodeEditor
+              mode="json"
+              theme="textmate"
+              width="100%"
+              height="50vh"
+              value={getFormattedJSONString(resultsObj)}
+              onChange={() => {}}
+              readOnly={true}
+              setOptions={{
+                fontSize: '14px',
+              }}
+              aria-label="Code Editor"
+              tabSize={2}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}
+
+// utility fn to get the displayable JSON string
+function getFormattedJSONString(obj: {}): string {
+  return Object.values(obj).length > 0 ? JSON.stringify(obj, null, '\t') : '';
+}
+
+// getting the appropriate query generator function based on the use case
+function getQueryGeneratorFn(workflow: Workflow): QueryGeneratorFn {
+  let fn;
+  switch (workflow.use_case) {
+    case USE_CASE.SEMANTIC_SEARCH:
+    default: {
+      fn = () => generateSemanticSearchQuery;
+    }
+  }
+  return fn;
+}
+
+// getting the appropriate static values from the workflow based on the use case
+function getWorkflowValues(workflow: Workflow): WorkflowValues {
+  let values;
+  switch (workflow.use_case) {
+    case USE_CASE.SEMANTIC_SEARCH:
+    default: {
+      values = getSemanticSearchValues(workflow);
+    }
+  }
+  return values;
+}
+
+// utility fn to generate a semantic search query
+function generateSemanticSearchQuery(
+  queryText: string,
+  workflowValues: SemanticSearchValues
+): {} {
+  return {
+    _source: {
+      excludes: [`${workflowValues.vectorField}`],
+    },
+    query: {
+      neural: {
+        [workflowValues.vectorField]: {
+          query_text: queryText,
+          model_id: workflowValues.modelId,
+          k: 5,
+        },
+      },
+    },
+  };
+}

--- a/public/pages/workflow_detail/prototype/query_executor.tsx
+++ b/public/pages/workflow_detail/prototype/query_executor.tsx
@@ -70,7 +70,9 @@ export function QueryExecutor(props: QueryExecutorProps) {
     }
   }, [userInput, queryGeneratorFn, workflowValues]);
 
-  function onExecute() {}
+  function onExecute() {
+    console.log('executing...');
+  }
 
   return (
     <EuiFlexGroup direction="row">
@@ -120,11 +122,24 @@ export function QueryExecutor(props: QueryExecutorProps) {
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexItem grow={false}>
             <EuiText>Results</EuiText>
           </EuiFlexItem>
-          <EuiFlexItem style={{ marginTop: '70px' }}>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup direction="row">
+              <EuiFlexItem>
+                <EuiFieldText
+                  placeholder={indexName}
+                  prepend="Index:"
+                  compressed={false}
+                  disabled={false}
+                  readOnly={true}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem>
             <EuiCodeEditor
               mode="json"
               theme="textmate"

--- a/public/pages/workflow_detail/prototype/utils.ts
+++ b/public/pages/workflow_detail/prototype/utils.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared utility fns used in the prototyping page.
+ */
+
+export function getFormattedJSONString(obj: {}): string {
+  return Object.values(obj).length > 0 ? JSON.stringify(obj, null, '\t') : '';
+}

--- a/public/pages/workflow_detail/utils/data_extractor_utils.ts
+++ b/public/pages/workflow_detail/utils/data_extractor_utils.ts
@@ -20,14 +20,25 @@ import { getIngestNodesAndEdges } from './workflow_to_template_utils';
  * Collection of utility fns to extract
  * data fields from a Workflow
  */
+
+export function getIndexName(workflow: Workflow): string | undefined {
+  if (workflow?.ui_metadata?.workspace_flow) {
+    const indexerComponent = getIndexerComponent(workflow);
+    if (indexerComponent) {
+      const { indexName } = componentDataToFormik(indexerComponent.data) as {
+        indexName: string;
+      };
+      return indexName;
+    }
+  }
+}
+
 export function getSemanticSearchValues(
   workflow: Workflow
 ): { modelId: string; inputField: string; vectorField: string } {
-  const formValues = getFormValues(workflow) as WorkspaceFormValues;
-  const modelId = getModelId(workflow, formValues) as string;
+  const modelId = getModelId(workflow) as string;
   const transformerComponent = getTransformerComponent(
-    workflow,
-    formValues
+    workflow
   ) as ReactFlowComponent;
   const { inputField, vectorField } = componentDataToFormik(
     transformerComponent.data
@@ -45,12 +56,9 @@ function getFormValues(workflow: Workflow): WorkspaceFormValues | undefined {
   }
 }
 
-function getModelId(
-  workflow: Workflow,
-  formValues: WorkspaceFormValues
-): string | undefined {
+function getModelId(workflow: Workflow): string | undefined {
   if (workflow?.ui_metadata?.workspace_flow) {
-    const transformerComponent = getTransformerComponent(workflow, formValues);
+    const transformerComponent = getTransformerComponent(workflow);
     if (transformerComponent) {
       const { model } = componentDataToFormik(transformerComponent.data) as {
         model: ModelFormValue;
@@ -72,8 +80,7 @@ function getModelId(
 }
 
 function getTransformerComponent(
-  workflow: Workflow,
-  formValues: WorkspaceFormValues
+  workflow: Workflow
 ): ReactFlowComponent | undefined {
   if (workflow?.ui_metadata?.workspace_flow) {
     const { ingestNodes } = getIngestNodesAndEdges(
@@ -82,6 +89,20 @@ function getTransformerComponent(
     );
     return ingestNodes.find((ingestNode) =>
       ingestNode.data.baseClasses?.includes(COMPONENT_CLASS.ML_TRANSFORMER)
+    );
+  }
+}
+
+function getIndexerComponent(
+  workflow: Workflow
+): ReactFlowComponent | undefined {
+  if (workflow?.ui_metadata?.workspace_flow) {
+    const { ingestNodes } = getIngestNodesAndEdges(
+      workflow?.ui_metadata?.workspace_flow?.nodes,
+      workflow?.ui_metadata?.workspace_flow?.edges
+    );
+    return ingestNodes.find((ingestNode) =>
+      ingestNode.data.baseClasses?.includes(COMPONENT_CLASS.INDEXER)
     );
   }
 }

--- a/public/pages/workflow_detail/utils/data_extractor_utils.ts
+++ b/public/pages/workflow_detail/utils/data_extractor_utils.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ReactFlowComponent,
+  COMPONENT_CLASS,
+  componentDataToFormik,
+  ModelFormValue,
+  MODEL_CATEGORY,
+  WorkspaceFormValues,
+  Workflow,
+  WORKFLOW_RESOURCE_TYPE,
+  WorkflowResource,
+} from '../../../../common';
+import { getIngestNodesAndEdges } from './workflow_to_template_utils';
+
+/**
+ * Collection of utility fns to extract
+ * data fields from a Workflow
+ */
+export function getSemanticSearchValues(
+  workflow: Workflow
+): { modelId: string; inputField: string; vectorField: string } {
+  const formValues = getFormValues(workflow) as WorkspaceFormValues;
+  const modelId = getModelId(workflow, formValues) as string;
+  const transformerComponent = getTransformerComponent(
+    workflow,
+    formValues
+  ) as ReactFlowComponent;
+  const { inputField, vectorField } = componentDataToFormik(
+    transformerComponent.data
+  ) as { inputField: string; vectorField: string };
+  return { modelId, inputField, vectorField };
+}
+
+function getFormValues(workflow: Workflow): WorkspaceFormValues | undefined {
+  if (workflow?.ui_metadata?.workspace_flow) {
+    const formValues = {} as WorkspaceFormValues;
+    workflow.ui_metadata.workspace_flow.nodes.forEach((node) => {
+      formValues[node.id] = componentDataToFormik(node.data);
+    });
+    return formValues;
+  }
+}
+
+function getModelId(
+  workflow: Workflow,
+  formValues: WorkspaceFormValues
+): string | undefined {
+  if (workflow?.ui_metadata?.workspace_flow) {
+    const transformerComponent = getTransformerComponent(workflow, formValues);
+    if (transformerComponent) {
+      const { model } = componentDataToFormik(transformerComponent.data) as {
+        model: ModelFormValue;
+        inputField: string;
+        vectorField: string;
+      };
+
+      // if it's a pretrained model, we created a new model ID, parse from resources
+      if (model.category === MODEL_CATEGORY.PRETRAINED) {
+        const modelResource = workflow.resourcesCreated?.find(
+          (resource) => resource.type === WORKFLOW_RESOURCE_TYPE.MODEL_ID
+        ) as WorkflowResource;
+        return modelResource.id;
+      } else {
+        return model.id;
+      }
+    }
+  }
+}
+
+function getTransformerComponent(
+  workflow: Workflow,
+  formValues: WorkspaceFormValues
+): ReactFlowComponent | undefined {
+  if (workflow?.ui_metadata?.workspace_flow) {
+    const { ingestNodes } = getIngestNodesAndEdges(
+      workflow?.ui_metadata?.workspace_flow?.nodes,
+      workflow?.ui_metadata?.workspace_flow?.edges
+    );
+    return ingestNodes.find((ingestNode) =>
+      ingestNode.data.baseClasses?.includes(COMPONENT_CLASS.ML_TRANSFORMER)
+    );
+  }
+}

--- a/public/pages/workflow_detail/utils/index.ts
+++ b/public/pages/workflow_detail/utils/index.ts
@@ -5,3 +5,4 @@
 
 export * from './utils';
 export * from './workflow_to_template_utils';
+export * from './data_extractor_utils';

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -51,7 +51,7 @@ export function toTemplateFlows(
   };
 }
 
-function getIngestNodesAndEdges(
+export function getIngestNodesAndEdges(
   allNodes: ReactFlowComponent[],
   allEdges: ReactFlowEdge[]
 ): { ingestNodes: ReactFlowComponent[]; ingestEdges: ReactFlowEdge[] } {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -28,6 +28,7 @@ import { Resources } from './resources';
 
 // styling
 import './workflow-detail-styles.scss';
+import { Prototype } from './prototype';
 
 export interface WorkflowDetailRouterProps {
   workflowId: string;
@@ -42,6 +43,10 @@ enum WORKFLOW_DETAILS_TAB {
   // This gives clarity into what has been done on the cluster on behalf
   // of the frontend provisioning workflows.
   RESOURCES = 'resources',
+  // TODO: temporarily adding a prototype tab until UX is finalized.
+  // This allows simple UI for executing ingest and search against
+  // created workflow resources
+  PROTOTYPE = 'prototype',
 }
 
 const ACTIVE_TAB_PARAM = 'tab';
@@ -142,6 +147,15 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
         replaceActiveTab(WORKFLOW_DETAILS_TAB.RESOURCES, props);
       },
     },
+    {
+      id: WORKFLOW_DETAILS_TAB.PROTOTYPE,
+      label: 'Prototype',
+      isSelected: selectedTabId === WORKFLOW_DETAILS_TAB.PROTOTYPE,
+      onClick: () => {
+        setSelectedTabId(WORKFLOW_DETAILS_TAB.PROTOTYPE);
+        replaceActiveTab(WORKFLOW_DETAILS_TAB.PROTOTYPE, props);
+      },
+    },
   ];
 
   return (
@@ -163,6 +177,9 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
           )}
           {selectedTabId === WORKFLOW_DETAILS_TAB.RESOURCES && (
             <Resources workflow={workflow} />
+          )}
+          {selectedTabId === WORKFLOW_DETAILS_TAB.PROTOTYPE && (
+            <Prototype workflow={workflow} />
           )}
         </EuiPageBody>
       </EuiPage>

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -18,6 +18,7 @@ import {
   UPDATE_WORKFLOW_NODE_API_PATH,
   WorkflowTemplate,
   SEARCH_INDEX_NODE_API_PATH,
+  INGEST_NODE_API_PATH,
 } from '../common';
 
 /**
@@ -42,6 +43,7 @@ export interface RouteService {
   getWorkflowPresets: () => Promise<any | HttpFetchError>;
   catIndices: (pattern: string) => Promise<any | HttpFetchError>;
   searchIndex: (index: string, body: {}) => Promise<any | HttpFetchError>;
+  ingest: (index: string, doc: {}) => Promise<any | HttpFetchError>;
   searchModels: (body: {}) => Promise<any | HttpFetchError>;
 }
 
@@ -165,6 +167,19 @@ export function configureRoutes(core: CoreStart): RouteService {
           `${SEARCH_INDEX_NODE_API_PATH}/${index}`,
           {
             body: JSON.stringify(body),
+          }
+        );
+        return response;
+      } catch (e: any) {
+        return e as HttpFetchError;
+      }
+    },
+    ingest: async (index: string, doc: {}) => {
+      try {
+        const response = await core.http.put<{ respString: string }>(
+          `${INGEST_NODE_API_PATH}/${index}`,
+          {
+            body: JSON.stringify(doc),
           }
         );
         return response;

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -17,6 +17,7 @@ import {
   DEPROVISION_WORKFLOW_NODE_API_PATH,
   UPDATE_WORKFLOW_NODE_API_PATH,
   WorkflowTemplate,
+  SEARCH_INDEX_NODE_API_PATH,
 } from '../common';
 
 /**
@@ -40,6 +41,7 @@ export interface RouteService {
   deleteWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
   getWorkflowPresets: () => Promise<any | HttpFetchError>;
   catIndices: (pattern: string) => Promise<any | HttpFetchError>;
+  searchIndex: (index: string, body: {}) => Promise<any | HttpFetchError>;
   searchModels: (body: {}) => Promise<any | HttpFetchError>;
 }
 
@@ -151,6 +153,19 @@ export function configureRoutes(core: CoreStart): RouteService {
       try {
         const response = await core.http.get<{ respString: string }>(
           `${CAT_INDICES_NODE_API_PATH}/${pattern}`
+        );
+        return response;
+      } catch (e: any) {
+        return e as HttpFetchError;
+      }
+    },
+    searchIndex: async (index: string, body: {}) => {
+      try {
+        const response = await core.http.post<{ respString: string }>(
+          `${SEARCH_INDEX_NODE_API_PATH}/${index}`,
+          {
+            body: JSON.stringify(body),
+          }
         );
         return response;
       } catch (e: any) {

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -17,6 +17,7 @@ const initialState = {
 const OPENSEARCH_PREFIX = 'opensearch';
 const CAT_INDICES_ACTION = `${OPENSEARCH_PREFIX}/catIndices`;
 const SEARCH_INDEX_ACTION = `${OPENSEARCH_PREFIX}/search`;
+const INGEST_ACTION = `${OPENSEARCH_PREFIX}/ingest`;
 
 export const catIndices = createAsyncThunk(
   CAT_INDICES_ACTION,
@@ -46,6 +47,24 @@ export const searchIndex = createAsyncThunk(
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue('Error searching index: ' + response.body.message);
+    } else {
+      return response;
+    }
+  }
+);
+
+export const ingest = createAsyncThunk(
+  INGEST_ACTION,
+  async (ingestInfo: { index: string; doc: {} }, { rejectWithValue }) => {
+    const { index, doc } = ingestInfo;
+    const response: any | HttpFetchError = await getRouteService().ingest(
+      index,
+      doc
+    );
+    if (response instanceof HttpFetchError) {
+      return rejectWithValue(
+        'Error ingesting document: ' + response.body.message
+      );
     } else {
       return response;
     }

--- a/server/routes/opensearch_routes_service.ts
+++ b/server/routes/opensearch_routes_service.ts
@@ -4,7 +4,6 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { SearchRequest } from '@opensearch-project/opensearch/api/types';
 import {
   IRouter,
   IOpenSearchDashboardsResponse,
@@ -12,7 +11,11 @@ import {
   OpenSearchDashboardsRequest,
   OpenSearchDashboardsResponseFactory,
 } from '../../../../src/core/server';
-import { CAT_INDICES_NODE_API_PATH, Index } from '../../common';
+import {
+  CAT_INDICES_NODE_API_PATH,
+  Index,
+  SEARCH_INDEX_NODE_API_PATH,
+} from '../../common';
 import { generateCustomError } from './helpers';
 
 /**
@@ -33,6 +36,18 @@ export function registerOpenSearchRoutes(
       },
     },
     opensearchRoutesService.catIndices
+  );
+  router.post(
+    {
+      path: `${SEARCH_INDEX_NODE_API_PATH}/{index}`,
+      validate: {
+        params: schema.object({
+          index: schema.string(),
+        }),
+        body: schema.any(),
+      },
+    },
+    opensearchRoutesService.searchIndex
   );
 }
 
@@ -65,6 +80,27 @@ export class OpenSearchRoutesService {
       })) as Index[];
 
       return res.ok({ body: cleanedIndices });
+    } catch (err: any) {
+      return generateCustomError(res, err);
+    }
+  };
+
+  searchIndex = async (
+    context: RequestHandlerContext,
+    req: OpenSearchDashboardsRequest,
+    res: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    const { index } = req.params as { index: string };
+    const body = req.body;
+    try {
+      const response = await this.client
+        .asScoped(req)
+        .callAsCurrentUser('search', {
+          index,
+          body,
+        });
+
+      return res.ok({ body: response });
     } catch (err: any) {
       return generateCustomError(res, err);
     }


### PR DESCRIPTION
### Description

This PR adds a Prototype tab that can be used for testing a workflow end-to-end. _Note the placement of executing this in UX is TBD, so I've placed in its own sandboxed tab for now for ease of use_. It dynamically parses out the necessary fields to generate both 1/ a valid document schema to ingest to the configured index, and 2/ a valid query to run some variation of neural search against the configured index, all based on the workflow's use case. For example, a `SEMANTIC_SEARCH` use case will have the index mapping configured with a specific set of fields (input field, vector field, model ID), defining the document schema, and a particular way to execute a search with the neural query clause utilizing those fields. This will all be different than other neural search variations, that will have different schemas and a different construction of valid queries to execute.

In particular (current scope is only semantic search), we have UI guardrails to make everything readonly besides:
- the value of the plaintext field used when ingesting
- the value of the plaintext field used when querying
The rest of the construction is all generated based on the use case (for now only semantic search), and the values of the configured fields (input field, vector field, model ID, index name).

Note this is just a first start, we can easily expose more or less depending on how much flexibility is desired (e.g., freeform queries, opening up editing of `k` or other neural clause params, etc.) 

Implementation details:
- added `Ingestor` component to format, execute, and display response from running an indexing command against an index
- added `QueryExecutor` component to format, execute, and display a formatted list of results from running a query against an index
- added base `Prototype` component to handle global prototype state and tab state
- added `data_extractor_utils` to organize all utility fns used for parsing the workflow data to get different fields based on the workflow use case. this will be expanded upon and refactored as more use cases are added
- onboarded search index and index document APIs
- minor handling of empty state in prototype tab when the workflow has not been provisioned and/or no resources are available

Demo video:
- creating a semantic search workflow and defining all of the configured fields
- provisioning to set up the index and ingest pipeline
- using Ingest tab for ingesting some sample documents, only requiring plaintext input
- using Query tab for searching against those documents, only requiring plaintext input
- error handling on empty search
- basic validation of semantic search working as expected

[screen-capture (31).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/b280d704-f0fb-484e-bfa4-5f2f2c8eabcf)


### Issues Resolved

Makes progress on #68 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
