### PR TITLE
Onboard hybrid search use case; add readonly search flows for all use cases

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -56,16 +56,6 @@ export const BASE_MODEL_NODE_API_PATH = `${BASE_NODE_API_PATH}/model`;
 export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
 
 /**
- * BACKEND INTERFACES
- */
-export const CREATE_INGEST_PIPELINE_STEP_TYPE = 'create_ingest_pipeline';
-export const CREATE_INDEX_STEP_TYPE = 'create_index';
-export const REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE =
-  'register_local_pretrained_model';
-export const REGISTER_LOCAL_SPARSE_ENCODING_MODEL_STEP_TYPE =
-  'register_local_sparse_encoding_model';
-
-/**
  * ML PLUGIN PRETRAINED MODELS
  * (based off of https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models)
  */

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -157,6 +157,7 @@ export type Workflow = WorkflowTemplate & {
 export enum USE_CASE {
   SEMANTIC_SEARCH = 'SEMANTIC_SEARCH',
   NEURAL_SPARSE_SEARCH = 'NEURAL_SPARSE_SEARCH',
+  HYBRID_SEARCH = 'HYBRID_SEARCH',
 }
 
 /**

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -43,9 +43,11 @@ export type WorkspaceFlowState = {
  ********** USE CASE TEMPLATE TYPES/INTERFACES **********
  */
 
-export type IngestProcessor = {
-  description?: string;
-};
+export type IngestProcessor = {};
+export type SearchProcessor = {};
+export type SearchRequestProcessor = SearchProcessor & {};
+export type SearchResponseProcessor = SearchProcessor & {};
+export type SearchPhaseResultsProcessor = SearchProcessor & {};
 
 export type TextEmbeddingProcessor = IngestProcessor & {
   text_embedding: {
@@ -58,6 +60,18 @@ export type SparseEncodingProcessor = IngestProcessor & {
   sparse_encoding: {
     model_id: string;
     field_map: {};
+  };
+};
+
+export type NormalizationProcessor = SearchProcessor & {
+  normalization: {
+    technique: string;
+  };
+  combination: {
+    technique: string;
+    parameters: {
+      weights: number[];
+    };
   };
 };
 
@@ -86,6 +100,18 @@ export type CreateIngestPipelineNode = TemplateNode & {
     configurations: {
       description?: string;
       processors: IngestProcessor[];
+    };
+  };
+};
+
+export type CreateSearchPipelineNode = TemplateNode & {
+  user_inputs: {
+    pipeline_id: string;
+    configurations: {
+      description?: string;
+      request_processors?: SearchRequestProcessor[];
+      response_processors?: SearchResponseProcessor[];
+      phase_results_processors?: SearchPhaseResultsProcessor[];
     };
   };
 };
@@ -265,6 +291,7 @@ export enum WORKFLOW_STATE {
 
 export type WorkflowResource = {
   id: string;
+  stepType: WORKFLOW_STEP_TYPE;
   type: WORKFLOW_RESOURCE_TYPE;
 };
 
@@ -275,6 +302,25 @@ export enum WORKFLOW_RESOURCE_TYPE {
   MODEL_ID = 'Model',
   MODEL_GROUP_ID = 'Model group',
   CONNECTOR_ID = 'Connector',
+}
+
+export enum WORKFLOW_STEP_TYPE {
+  CREATE_INGEST_PIPELINE_STEP_TYPE = 'create_ingest_pipeline',
+  CREATE_SEARCH_PIPELINE_STEP_TYPE = 'create_search_pipeline',
+  CREATE_INDEX_STEP_TYPE = 'create_index',
+  REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE = 'register_local_pretrained_model',
+  REGISTER_LOCAL_SPARSE_ENCODING_MODEL_STEP_TYPE = 'register_local_sparse_encoding_model',
+}
+
+// We cannot disambiguate ingest vs. search pipelines based on workflow resource type. To work around
+// that, we maintain this map from workflow step type -> formatted type
+export enum WORKFLOW_STEP_TO_RESOURCE_TYPE_MAP {
+  'create_ingest_pipeline' = 'Ingest pipeline',
+  'create_search_pipeline' = 'Search pipeline',
+  'create_index' = 'Index',
+  'register_local_pretrained_model' = 'Model',
+  'register_local_sparse_encoding_model' = 'Model',
+  'deploy_model' = 'Model',
 }
 
 export type WorkflowDict = {

--- a/public/component_types/base_component.tsx
+++ b/public/component_types/base_component.tsx
@@ -34,4 +34,15 @@ export abstract class BaseComponent implements IComponent {
   toObj() {
     return Object.assign({}, this);
   }
+
+  // Helper fn to strip all fields for a component if we want to view it in the UI
+  // but not have it tied to any form/inputs. Example: showing an Index component in search,
+  // even if it is provisioned in ingest.
+  toPlaceholderObj() {
+    return {
+      ...Object.assign({}, this),
+      createFields: [],
+      fields: [],
+    };
+  }
 }

--- a/public/component_types/indexer/indexer.ts
+++ b/public/component_types/indexer/indexer.ts
@@ -25,6 +25,12 @@ export class Indexer extends BaseComponent {
         baseClass: COMPONENT_CLASS.DOCUMENT,
         acceptMultiple: false,
       },
+      {
+        id: 'query',
+        label: 'Query',
+        baseClass: COMPONENT_CLASS.QUERY,
+        acceptMultiple: true,
+      },
     ];
     this.fields = [
       {

--- a/public/component_types/indexer/indexer.ts
+++ b/public/component_types/indexer/indexer.ts
@@ -52,12 +52,11 @@ export class Indexer extends BaseComponent {
       //   placeholder: 'Enter an index mappings JSON blob...',
       // },
     ];
-    // this.outputs = [
-    //   {
-    //     label: this.label,
-    //     baseClasses: this.baseClasses,
-    //   },
-    // ];
-    this.outputs = [];
+    this.outputs = [
+      {
+        label: 'Results',
+        baseClasses: [COMPONENT_CLASS.RESULTS],
+      },
+    ];
   }
 }

--- a/public/component_types/other/index.ts
+++ b/public/component_types/other/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from './document';
+export * from './results';
 export * from './query';

--- a/public/component_types/other/query/index.ts
+++ b/public/component_types/other/query/index.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './document';
-export * from './query';
+export * from './match_query';
+export * from './neural_query';

--- a/public/component_types/other/query/match_query.tsx
+++ b/public/component_types/other/query/match_query.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CLASS } from '../../../utils';
+import { Query } from './query';
+
+/**
+ * A basic match query placeholder UI component.
+ * Does not have any functionality.
+ */
+export class MatchQuery extends Query {
+  constructor() {
+    super();
+    this.type = COMPONENT_CLASS.MATCH_QUERY;
+    this.label = 'Match Query';
+    this.description = 'An OpenSearch match query';
+    this.inputs = [];
+    this.baseClasses = [...this.baseClasses, this.type];
+    this.outputs = [
+      {
+        label: this.label,
+        baseClasses: this.baseClasses,
+      },
+    ];
+  }
+}

--- a/public/component_types/other/query/neural_query.tsx
+++ b/public/component_types/other/query/neural_query.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CLASS } from '../../../utils';
+import { Query } from './query';
+
+/**
+ * A basic neural query placeholder UI component.
+ * Does not have any functionality.
+ */
+export class NeuralQuery extends Query {
+  constructor() {
+    super();
+    this.type = COMPONENT_CLASS.NEURAL_QUERY;
+    this.label = 'Neural query';
+    this.description = 'An OpenSearch neural query';
+    this.inputs = [];
+    this.baseClasses = [...this.baseClasses, this.type];
+    this.outputs = [
+      {
+        label: this.label,
+        baseClasses: this.baseClasses,
+      },
+    ];
+  }
+}

--- a/public/component_types/other/query/query.tsx
+++ b/public/component_types/other/query/query.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../../../utils';
+import { BaseComponent } from '../../base_component';
+
+/**
+ * A basic Query placeholder UI component.
+ * Does not have any functionality.
+ */
+export abstract class Query extends BaseComponent {
+  constructor() {
+    super();
+    this.type = COMPONENT_CLASS.QUERY;
+    this.label = 'Query';
+    this.description = 'An OpenSearch query';
+    this.categories = [COMPONENT_CATEGORY.SEARCH];
+    this.allowsCreation = false;
+    this.baseClasses = [this.type];
+    this.inputs = [];
+    this.outputs = [];
+  }
+}

--- a/public/component_types/other/results.tsx
+++ b/public/component_types/other/results.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../../utils';
+import { BaseComponent } from '../base_component';
+
+/**
+ * A basic Results placeholder UI component.
+ * Does not have any functionality.
+ */
+export class Results extends BaseComponent {
+  constructor() {
+    super();
+    this.type = COMPONENT_CLASS.RESULTS;
+    this.label = 'Results';
+    this.description = 'OpenSearch results';
+    this.categories = [COMPONENT_CATEGORY.SEARCH];
+    this.allowsCreation = false;
+    this.baseClasses = [this.type];
+    this.inputs = [];
+    this.outputs = [
+      {
+        label: this.label,
+        baseClasses: this.baseClasses,
+      },
+    ];
+  }
+}

--- a/public/component_types/transformer/index.ts
+++ b/public/component_types/transformer/index.ts
@@ -6,3 +6,5 @@
 export * from './ml_transformer';
 export * from './text_embedding_transformer';
 export * from './sparse_encoder_transformer';
+export * from './results_transformer';
+export * from './normalization_transformer';

--- a/public/component_types/transformer/normalization_transformer.ts
+++ b/public/component_types/transformer/normalization_transformer.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CATEGORY, COMPONENT_CLASS } from '../../utils';
+import { ResultsTransformer } from './results_transformer';
+
+/**
+ * A normalization results transformer UI component
+ */
+export class NormalizationTransformer extends ResultsTransformer {
+  constructor() {
+    super();
+    (this.type = COMPONENT_CLASS.NORMALIZATION_TRANSFORMER),
+      (this.label = 'Normalization Transformer');
+    this.description = 'A transformer to normalize search results';
+    this.baseClasses = [...this.baseClasses, this.type];
+    this.categories = [COMPONENT_CATEGORY.SEARCH];
+  }
+}

--- a/public/component_types/transformer/results_transformer.ts
+++ b/public/component_types/transformer/results_transformer.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENT_CLASS } from '../../utils';
+import { BaseTransformer } from './base_transformer';
+
+/**
+ * A generic results transformer UI component
+ */
+export class ResultsTransformer extends BaseTransformer {
+  constructor() {
+    super();
+    (this.type = COMPONENT_CLASS.RESULTS_TRANSFORMER),
+      (this.label = 'Results Transformer');
+    this.description = 'A general results transformer';
+    this.baseClasses = [...this.baseClasses, this.type];
+    this.inputs = [
+      {
+        id: 'results',
+        label: 'Results',
+        baseClass: COMPONENT_CLASS.RESULTS,
+        acceptMultiple: false,
+      },
+    ];
+    this.outputs = [
+      {
+        label: 'Transformed Results',
+        baseClasses: [COMPONENT_CLASS.RESULTS],
+      },
+    ];
+  }
+}

--- a/public/component_types/transformer/sparse_encoder_transformer.ts
+++ b/public/component_types/transformer/sparse_encoder_transformer.ts
@@ -25,6 +25,12 @@ export class SparseEncoderTransformer extends MLTransformer {
         baseClass: COMPONENT_CLASS.DOCUMENT,
         acceptMultiple: false,
       },
+      {
+        id: 'query',
+        label: 'Query',
+        baseClass: COMPONENT_CLASS.QUERY,
+        acceptMultiple: false,
+      },
     ];
     this.createFields = [
       {
@@ -58,6 +64,10 @@ export class SparseEncoderTransformer extends MLTransformer {
       {
         label: 'Transformed Document',
         baseClasses: [COMPONENT_CLASS.DOCUMENT],
+      },
+      {
+        label: 'Transformed Query',
+        baseClasses: [COMPONENT_CLASS.QUERY],
       },
     ];
   }

--- a/public/component_types/transformer/text_embedding_transformer.ts
+++ b/public/component_types/transformer/text_embedding_transformer.ts
@@ -24,6 +24,12 @@ export class TextEmbeddingTransformer extends MLTransformer {
         baseClass: COMPONENT_CLASS.DOCUMENT,
         acceptMultiple: false,
       },
+      {
+        id: 'query',
+        label: 'Query',
+        baseClass: COMPONENT_CLASS.QUERY,
+        acceptMultiple: false,
+      },
     ];
     this.createFields = [
       {
@@ -56,6 +62,10 @@ export class TextEmbeddingTransformer extends MLTransformer {
       {
         label: 'Transformed Document',
         baseClasses: [COMPONENT_CLASS.DOCUMENT],
+      },
+      {
+        label: 'Transformed Query',
+        baseClasses: [COMPONENT_CLASS.QUERY],
       },
     ];
   }

--- a/public/pages/workflow_detail/prototype/ingestor.tsx
+++ b/public/pages/workflow_detail/prototype/ingestor.tsx
@@ -185,6 +185,7 @@ function getDocGeneratorFn(workflow: Workflow): DocGeneratorFn {
   switch (workflow.use_case) {
     case USE_CASE.SEMANTIC_SEARCH:
     case USE_CASE.NEURAL_SPARSE_SEARCH:
+    case USE_CASE.HYBRID_SEARCH:
     default: {
       fn = () => generateNeuralSearchDoc;
     }
@@ -198,6 +199,7 @@ function getWorkflowValues(workflow: Workflow): WorkflowValues {
   switch (workflow.use_case) {
     case USE_CASE.SEMANTIC_SEARCH:
     case USE_CASE.NEURAL_SPARSE_SEARCH:
+    case USE_CASE.HYBRID_SEARCH:
     default: {
       values = getNeuralSearchValues(workflow);
     }

--- a/public/pages/workflow_detail/prototype/utils.ts
+++ b/public/pages/workflow_detail/prototype/utils.ts
@@ -21,5 +21,7 @@ export type SemanticSearchValues = WorkflowValues & {
   inputField: string;
   vectorField: string;
 };
-
 export type NeuralSparseValues = SemanticSearchValues;
+export type HybridSearchValues = SemanticSearchValues & {
+  searchPipelineId: string;
+};

--- a/public/pages/workflow_detail/resources/columns.tsx
+++ b/public/pages/workflow_detail/resources/columns.tsx
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {
+  WORKFLOW_STEP_TO_RESOURCE_TYPE_MAP,
+  WORKFLOW_STEP_TYPE,
+} from '../../../../common';
+
 export const columns = [
   {
     field: 'id',
@@ -10,8 +15,11 @@ export const columns = [
     sortable: true,
   },
   {
-    field: 'type',
+    field: 'stepType',
     name: 'Type',
     sortable: true,
+    render: (stepType: WORKFLOW_STEP_TYPE) => {
+      return WORKFLOW_STEP_TO_RESOURCE_TYPE_MAP[stepType];
+    },
   },
 ];

--- a/public/pages/workflow_detail/utils/data_extractor_utils.ts
+++ b/public/pages/workflow_detail/utils/data_extractor_utils.ts
@@ -14,6 +14,7 @@ import {
   WORKFLOW_RESOURCE_TYPE,
   WorkflowResource,
   NODE_CATEGORY,
+  WORKFLOW_STEP_TYPE,
 } from '../../../../common';
 import { getNodesAndEdgesUnderParent } from './workflow_to_template_utils';
 
@@ -38,7 +39,12 @@ export function getIndexName(workflow: Workflow): string | undefined {
 // persist the same values to use during ingest and search, so we keep the naming general
 export function getNeuralSearchValues(
   workflow: Workflow
-): { modelId: string; inputField: string; vectorField: string } {
+): {
+  modelId: string;
+  inputField: string;
+  vectorField: string;
+  searchPipelineId?: string;
+} {
   const modelId = getModelId(workflow) as string;
   const transformerComponent = getTransformerComponent(
     workflow
@@ -46,7 +52,13 @@ export function getNeuralSearchValues(
   const { inputField, vectorField } = componentDataToFormik(
     transformerComponent.data
   ) as { inputField: string; vectorField: string };
-  return { modelId, inputField, vectorField };
+
+  const searchPipelineId = workflow.resourcesCreated?.find(
+    (resource) =>
+      resource.stepType === WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
+  )?.id;
+
+  return { modelId, inputField, vectorField, searchPipelineId };
 }
 
 function getFormValues(workflow: Workflow): WorkspaceFormValues | undefined {

--- a/public/pages/workflow_detail/utils/data_extractor_utils.ts
+++ b/public/pages/workflow_detail/utils/data_extractor_utils.ts
@@ -13,8 +13,9 @@ import {
   Workflow,
   WORKFLOW_RESOURCE_TYPE,
   WorkflowResource,
+  NODE_CATEGORY,
 } from '../../../../common';
-import { getIngestNodesAndEdges } from './workflow_to_template_utils';
+import { getNodesAndEdgesUnderParent } from './workflow_to_template_utils';
 
 /**
  * Collection of utility fns to extract
@@ -85,7 +86,8 @@ function getTransformerComponent(
   workflow: Workflow
 ): ReactFlowComponent | undefined {
   if (workflow?.ui_metadata?.workspace_flow) {
-    const { ingestNodes } = getIngestNodesAndEdges(
+    const { nodes: ingestNodes } = getNodesAndEdgesUnderParent(
+      NODE_CATEGORY.INGEST_GROUP,
       workflow?.ui_metadata?.workspace_flow?.nodes,
       workflow?.ui_metadata?.workspace_flow?.edges
     );
@@ -99,7 +101,8 @@ function getIndexerComponent(
   workflow: Workflow
 ): ReactFlowComponent | undefined {
   if (workflow?.ui_metadata?.workspace_flow) {
-    const { ingestNodes } = getIngestNodesAndEdges(
+    const { nodes: ingestNodes } = getNodesAndEdgesUnderParent(
+      NODE_CATEGORY.INGEST_GROUP,
       workflow?.ui_metadata?.workspace_flow?.nodes,
       workflow?.ui_metadata?.workspace_flow?.edges
     );

--- a/public/pages/workflow_detail/utils/data_extractor_utils.ts
+++ b/public/pages/workflow_detail/utils/data_extractor_utils.ts
@@ -85,8 +85,8 @@ function getModelId(workflow: Workflow): string | undefined {
       if (model.category === MODEL_CATEGORY.PRETRAINED) {
         const modelResource = workflow.resourcesCreated?.find(
           (resource) => resource.type === WORKFLOW_RESOURCE_TYPE.MODEL_ID
-        ) as WorkflowResource;
-        return modelResource.id;
+        );
+        return modelResource?.id;
       } else {
         return model.id;
       }

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -11,8 +11,6 @@ import {
   NODE_CATEGORY,
   TemplateNode,
   COMPONENT_CLASS,
-  CREATE_INGEST_PIPELINE_STEP_TYPE,
-  CREATE_INDEX_STEP_TYPE,
   CreateIngestPipelineNode,
   TextEmbeddingProcessor,
   componentDataToFormik,
@@ -27,14 +25,14 @@ import {
   ROBERTA_SENTENCE_TRANSFORMER,
   MPNET_SENTENCE_TRANSFORMER,
   BERT_SENTENCE_TRANSFORMER,
-  REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE,
   generateId,
   NEURAL_SPARSE_TRANSFORMER,
   NEURAL_SPARSE_DOC_TRANSFORMER,
   NEURAL_SPARSE_TOKENIZER_TRANSFORMER,
-  REGISTER_LOCAL_SPARSE_ENCODING_MODEL_STEP_TYPE,
   SparseEncodingProcessor,
   IndexMappings,
+  CreateSearchPipelineNode,
+  WORKFLOW_STEP_TYPE,
 } from '../../../../common';
 
 /**
@@ -45,12 +43,7 @@ import {
 export function toTemplateFlows(
   workspaceFlow: WorkspaceFlowState
 ): TemplateFlows {
-  const { ingestNodes, ingestEdges } = getIngestNodesAndEdges(
-    workspaceFlow.nodes,
-    workspaceFlow.edges
-  );
-  // TODO: support beyond ingest
-  const provisionFlow = toProvisionTemplateFlow(ingestNodes, ingestEdges);
+  const provisionFlow = toProvisionTemplateFlow(workspaceFlow);
 
   // TODO: support beyond provision
   return {
@@ -58,36 +51,57 @@ export function toTemplateFlows(
   };
 }
 
-export function getIngestNodesAndEdges(
+export function getNodesAndEdgesUnderParent(
+  parentGroup: NODE_CATEGORY,
   allNodes: ReactFlowComponent[],
   allEdges: ReactFlowEdge[]
-): { ingestNodes: ReactFlowComponent[]; ingestEdges: ReactFlowEdge[] } {
-  const ingestParentId = allNodes.find(
-    (node) => node.type === NODE_CATEGORY.INGEST_GROUP
-  )?.id as string;
-  const ingestNodes = allNodes.filter(
-    (node) => node.parentNode === ingestParentId
+): { nodes: ReactFlowComponent[]; edges: ReactFlowEdge[] } {
+  const parentId = allNodes.find((node) => node.type === parentGroup)
+    ?.id as string;
+  const nodes = allNodes.filter(
+    (node) =>
+      node.parentNode === parentId &&
+      // TODO: hardcoding that only create fields will be eligible for parsing. Make more generic in the future
+      node.data.createFields !== undefined &&
+      node.data.createFields.length > 0
   );
-  const ingestIds = ingestNodes.map((node) => node.id);
-  const ingestEdges = allEdges.filter(
-    (edge) => ingestIds.includes(edge.source) || ingestIds.includes(edge.target)
+  const nodeIds = nodes.map((node) => node.id);
+  const edges = allEdges.filter(
+    (edge) => nodeIds.includes(edge.source) || nodeIds.includes(edge.target)
   );
   return {
-    ingestNodes,
-    ingestEdges,
+    nodes,
+    edges,
   };
 }
 
 // Generates the end-to-end provision subflow, if applicable
 function toProvisionTemplateFlow(
-  nodes: ReactFlowComponent[],
-  edges: ReactFlowEdge[]
+  workspaceFlow: WorkspaceFlowState
 ): TemplateFlow {
+  const {
+    nodes: ingestNodes,
+    edges: ingestEdges,
+  } = getNodesAndEdgesUnderParent(
+    NODE_CATEGORY.INGEST_GROUP,
+    workspaceFlow.nodes,
+    workspaceFlow.edges
+  );
+  const {
+    nodes: searchNodes,
+    edges: searchEdges,
+  } = getNodesAndEdgesUnderParent(
+    NODE_CATEGORY.SEARCH_GROUP,
+    workspaceFlow.nodes,
+    workspaceFlow.edges
+  );
+
+  // INGEST: iterate through nodes/edges and generate the valid template nodes
   const prevNodes = [] as ReactFlowComponent[];
   const finalTemplateNodes = [] as TemplateNode[];
   const templateEdges = [] as TemplateEdge[];
-  nodes.forEach((node) => {
-    const templateNodes = toTemplateNodes(node, prevNodes, edges);
+  ingestNodes.forEach((node) => {
+    const templateNodes = toTemplateNodes(node, prevNodes, ingestEdges);
     // it may be undefined if the node is not convertible for some reason
     if (templateNodes) {
       finalTemplateNodes.push(...templateNodes);
@@ -95,12 +109,22 @@ function toProvisionTemplateFlow(
     }
   });
 
-  edges.forEach((edge) => {
+  ingestEdges.forEach((edge) => {
     // it may be undefined if the edge is not convertible
     // (e.g., connecting to some meta/other UI component, like "document" or "query")
     const templateEdge = toTemplateEdge(edge);
     if (templateEdge) {
       templateEdges.push(templateEdge);
+    }
+  });
+
+  // SEARCH: iterate through nodes/edges and generate the valid template nodes
+  // TODO: currently the scope is limited to only expecting a single search processor
+  // node, and hence logic is hardcoded to return a single CreateSearchPipelineNode
+  searchNodes.forEach((node) => {
+    if (node.data.baseClasses?.includes(COMPONENT_CLASS.RESULTS_TRANSFORMER)) {
+      const templateNode = resultsTransformerToTemplateNode(node);
+      finalTemplateNodes.push(templateNode);
     }
   });
 
@@ -158,8 +182,8 @@ function transformerToTemplateNodes(
       // register model workflow step type is different per use case
       const registerModelStepType =
         flowNode.data.type === COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER
-          ? REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE
-          : REGISTER_LOCAL_SPARSE_ENCODING_MODEL_STEP_TYPE;
+          ? WORKFLOW_STEP_TYPE.REGISTER_LOCAL_PRETRAINED_MODEL_STEP_TYPE
+          : WORKFLOW_STEP_TYPE.REGISTER_LOCAL_SPARSE_ENCODING_MODEL_STEP_TYPE;
 
       let registerModelStep = undefined as
         | RegisterPretrainedModelNode
@@ -225,7 +249,7 @@ function transformerToTemplateNodes(
 
       const createIngestPipelineStep = {
         id: flowNode.data.id,
-        type: CREATE_INGEST_PIPELINE_STEP_TYPE,
+        type: WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE,
         user_inputs: {
           pipeline_id: ingestPipelineName,
           model_id: finalModelId,
@@ -308,7 +332,7 @@ function indexerToTemplateNode(
 
       return {
         id: flowNode.data.id,
-        type: CREATE_INDEX_STEP_TYPE,
+        type: WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE,
         previous_node_inputs: {
           [directlyConnectedNode.id]: 'pipeline_id',
         },
@@ -324,6 +348,38 @@ function indexerToTemplateNode(
       };
     }
   }
+}
+
+// General fn to process all result transformer nodes.
+// TODO: currently hardcoding to return a static configuration of a normalization
+// phase results processor. Should make dynamic & generic
+function resultsTransformerToTemplateNode(
+  flowNode: ReactFlowComponent
+): CreateSearchPipelineNode {
+  return {
+    id: flowNode.data.id,
+    type: WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE,
+    user_inputs: {
+      pipeline_id: generateId('search_pipeline'),
+      configurations: {
+        phase_results_processors: [
+          {
+            ['normalization-processor']: {
+              normalization: {
+                technique: 'min_max',
+              },
+              combination: {
+                technique: 'arithmetic_mean',
+                parameters: {
+                  weights: `[0.3, 0.7]`,
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  } as CreateSearchPipelineNode;
 }
 
 // Fetch all directly connected predecessor nodes

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -58,13 +58,7 @@ export function getNodesAndEdgesUnderParent(
 ): { nodes: ReactFlowComponent[]; edges: ReactFlowEdge[] } {
   const parentId = allNodes.find((node) => node.type === parentGroup)
     ?.id as string;
-  const nodes = allNodes.filter(
-    (node) =>
-      node.parentNode === parentId &&
-      // TODO: hardcoding that only create fields will be eligible for parsing. Make more generic in the future
-      node.data.createFields !== undefined &&
-      node.data.createFields.length > 0
-  );
+  const nodes = allNodes.filter((node) => node.parentNode === parentId);
   const nodeIds = nodes.map((node) => node.id);
   const edges = allEdges.filter(
     (edge) => nodeIds.includes(edge.source) || nodeIds.includes(edge.target)

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -49,6 +49,7 @@ export function toTemplateFlows(
     workspaceFlow.nodes,
     workspaceFlow.edges
   );
+  // TODO: support beyond ingest
   const provisionFlow = toProvisionTemplateFlow(ingestNodes, ingestEdges);
 
   // TODO: support beyond provision

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -19,7 +19,7 @@ $handle-color-invalid: $euiColorDanger;
 
 .reactflow-workspace .react-flow__node {
   width: 300px;
-  height: 250px;
+  min-height: 100px;
 }
 
 .reactflow__group-node {
@@ -38,6 +38,8 @@ $handle-color-invalid: $euiColorDanger;
 // Overriding the styling for the reactflow node when it is selected.
 // We need to use important tag to override ReactFlow's wrapNode that sets the box-shadow.
 // Ref: https://github.com/wbkd/react-flow/blob/main/packages/core/src/components/Nodes/wrapNode.tsx#L187
+// TODO: when the node sizing is dynamic (e.g., 'min-height', the shadow only covers the min height
+// instead of the node's final rendered height.
 .reactflow-workspace .react-flow__node-custom.selected {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.5);
   border-radius: 5px;

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -38,8 +38,10 @@ $handle-color-invalid: $euiColorDanger;
 // Overriding the styling for the reactflow node when it is selected.
 // We need to use important tag to override ReactFlow's wrapNode that sets the box-shadow.
 // Ref: https://github.com/wbkd/react-flow/blob/main/packages/core/src/components/Nodes/wrapNode.tsx#L187
-// TODO: when the node sizing is dynamic (e.g., 'min-height', the shadow only covers the min height
-// instead of the node's final rendered height.
+// TODO: when the node sizing is dynamic (e.g., 'min-height', it causes several issues:
+// 1. the shadow only covers the min height instead of the node's final rendered height
+// 2. the bounding edges of the parent node only fit with the 'min-height' amount, causing
+//    the node to look like it can be drug slightly out of the parent node
 .reactflow-workspace .react-flow__node-custom.selected {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.5);
   border-radius: 5px;

--- a/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
@@ -10,6 +10,7 @@ import {
   EuiCard,
   EuiText,
   EuiTitle,
+  EuiSpacer,
 } from '@elastic/eui';
 import { setDirty, useAppDispatch } from '../../../../store';
 import { IComponentData } from '../../../../component_types';
@@ -76,11 +77,12 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
         </EuiFlexGroup>
       }
     >
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize="none">
         <EuiFlexItem>
           <EuiText size="s" color="subdued">
             {component.description}
           </EuiText>
+          <EuiSpacer size="s" />
         </EuiFlexItem>
         {component.inputs?.map((input, index) => {
           return (

--- a/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
@@ -33,6 +33,9 @@ interface WorkspaceComponentProps {
 export function WorkspaceComponent(props: WorkspaceComponentProps) {
   const dispatch = useAppDispatch();
   const component = props.data;
+  // TODO: remove hardcoded logic that only create fields are allowed
+  const containsFormFields =
+    props.data.createFields !== undefined && props.data.createFields.length > 0;
   const reactFlowInstance = useReactFlow();
 
   // TODO: re-enable deletion
@@ -51,9 +54,12 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
     dispatch(setDirty());
   };
 
+  const backgroundColor = containsFormFields ? '#172430' : '#0A121A';
+
   return (
     <EuiCard
       className="react-flow__node"
+      style={{ backgroundColor }}
       textAlign="left"
       title={
         <EuiFlexGroup direction="row" justifyContent="spaceBetween">
@@ -77,7 +83,7 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
         </EuiFlexGroup>
       }
     >
-      <EuiFlexGroup direction="column" gutterSize="none">
+      <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>
           <EuiText size="s" color="subdued">
             {component.description}

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -23,6 +23,7 @@ import {
   SparseEncoderTransformer,
   NeuralQuery,
   MatchQuery,
+  NormalizationTransformer,
 } from '../../../../common';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
@@ -276,11 +277,13 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
   const searchId1 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
   const searchId2 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
   const searchId3 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  const searchId4 = generateId(COMPONENT_CLASS.NORMALIZATION_TRANSFORMER);
   const edgeId0 = generateId('edge');
   const edgeId1 = generateId('edge');
   const edgeId2 = generateId('edge');
   const edgeId3 = generateId('edge');
   const edgeId4 = generateId('edge');
+  const edgeId5 = generateId('edge');
 
   const ingestNodes = [
     {
@@ -339,7 +342,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.SEARCH_GROUP,
       data: { label: COMPONENT_CATEGORY.SEARCH },
       style: {
-        width: 1300,
+        width: 1700,
         height: 600,
       },
       className: 'reactflow__group-node__search',
@@ -384,6 +387,19 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       id: searchId3,
       position: { x: 900, y: 200 },
       data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId3),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId4,
+      position: { x: 1300, y: 200 },
+      data: initComponentData(
+        new NormalizationTransformer().toObj(),
+        searchId4
+      ),
       type: NODE_CATEGORY.CUSTOM,
       parentNode: searchGroupId,
       extent: 'parent',
@@ -477,6 +493,24 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
         targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
           .baseClasses,
         targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId5,
+        key: edgeId5,
+        source: searchId3,
+        target: searchId4,
+        sourceClasses: searchNodes.find((node) => node.id === searchId3)?.data
+          .baseClasses,
+        targetClasses: searchNodes.find((node) => node.id === searchId4)?.data
+          .baseClasses,
+        targetHandle: COMPONENT_CLASS.RESULTS,
         markerEnd: {
           type: MarkerType.ArrowClosed,
           width: 20,

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -74,8 +74,14 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
   const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
   const edgeId0 = generateId('edge');
   const edgeId1 = generateId('edge');
+  const edgeId2 = generateId('edge');
+  const edgeId3 = generateId('edge');
 
   const ingestNodes = [
     {
@@ -126,9 +132,58 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
       deletable: false,
     },
   ] as ReactFlowComponent[];
+  const searchNodes = [
+    {
+      id: searchGroupId,
+      position: { x: 400, y: 1000 },
+      type: NODE_CATEGORY.SEARCH_GROUP,
+      data: { label: COMPONENT_CATEGORY.SEARCH },
+      style: {
+        width: 1300,
+        height: 400,
+      },
+      className: 'reactflow__group-node__search',
+      selectable: true,
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new NeuralQuery().toObj(), searchId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId1,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new TextEmbeddingTransformer().toPlaceholderObj(),
+        searchId1
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId2,
+      position: { x: 900, y: 70 },
+      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
 
   return {
-    nodes: ingestNodes,
+    nodes: [...ingestNodes, ...searchNodes],
     edges: [
       {
         id: edgeId0,
@@ -164,6 +219,44 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
         zIndex: 2,
         deletable: false,
       },
+      {
+        id: edgeId2,
+        key: edgeId2,
+        source: searchId0,
+        target: searchId1,
+        sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+          .baseClasses,
+        sourceHandle: COMPONENT_CLASS.QUERY,
+        targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId3,
+        key: edgeId3,
+        source: searchId1,
+        target: searchId2,
+        sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
+          .baseClasses,
+        sourceHandle: COMPONENT_CLASS.QUERY,
+        targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
     ] as ReactFlowEdge[],
   };
 }
@@ -173,8 +266,14 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
   const ingestId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
   const edgeId0 = generateId('edge');
   const edgeId1 = generateId('edge');
+  const edgeId2 = generateId('edge');
+  const edgeId3 = generateId('edge');
 
   const ingestNodes = [
     {
@@ -226,8 +325,58 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
     },
   ] as ReactFlowComponent[];
 
+  const searchNodes = [
+    {
+      id: searchGroupId,
+      position: { x: 400, y: 1000 },
+      type: NODE_CATEGORY.SEARCH_GROUP,
+      data: { label: COMPONENT_CATEGORY.SEARCH },
+      style: {
+        width: 1300,
+        height: 400,
+      },
+      className: 'reactflow__group-node__search',
+      selectable: true,
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new NeuralQuery().toObj(), searchId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId1,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new SparseEncoderTransformer().toPlaceholderObj(),
+        searchId1
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId2,
+      position: { x: 900, y: 70 },
+      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
+
   return {
-    nodes: ingestNodes,
+    nodes: [...ingestNodes, ...searchNodes],
     edges: [
       {
         id: edgeId0,
@@ -255,6 +404,44 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
           .baseClasses,
         targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
           .baseClasses,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId2,
+        key: edgeId2,
+        source: searchId0,
+        target: searchId1,
+        sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+          .baseClasses,
+        sourceHandle: COMPONENT_CLASS.QUERY,
+        targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId3,
+        key: edgeId3,
+        source: searchId1,
+        target: searchId2,
+        sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
+          .baseClasses,
+        sourceHandle: COMPONENT_CLASS.QUERY,
+        targetHandle: COMPONENT_CLASS.QUERY,
         markerEnd: {
           type: MarkerType.ArrowClosed,
           width: 20,

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -88,7 +88,7 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
       },
       className: 'reactflow__group-node__ingest',
       selectable: true,
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -98,7 +98,7 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -111,7 +111,7 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -121,7 +121,7 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
   ] as ReactFlowComponent[];
@@ -187,7 +187,7 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
       },
       className: 'reactflow__group-node__ingest',
       selectable: true,
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -197,7 +197,7 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -210,7 +210,7 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -220,7 +220,7 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
   ] as ReactFlowComponent[];
@@ -294,7 +294,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       },
       className: 'reactflow__group-node__ingest',
       selectable: true,
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -304,7 +304,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -317,7 +317,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -327,7 +327,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: ingestGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
   ] as ReactFlowComponent[];
@@ -340,11 +340,11 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       data: { label: COMPONENT_CATEGORY.SEARCH },
       style: {
         width: 1300,
-        height: 700,
+        height: 600,
       },
       className: 'reactflow__group-node__search',
       selectable: true,
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -354,7 +354,7 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: searchGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
@@ -364,30 +364,30 @@ function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
       type: NODE_CATEGORY.CUSTOM,
       parentNode: searchGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
       id: searchId2,
       position: { x: 500, y: 70 },
       data: initComponentData(
-        new TextEmbeddingTransformer().toObj(),
+        new TextEmbeddingTransformer().toPlaceholderObj(),
         searchId2
       ),
       type: NODE_CATEGORY.CUSTOM,
       parentNode: searchGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
     {
       id: searchId3,
       position: { x: 900, y: 200 },
-      data: initComponentData(new KnnIndexer().toObj(), searchId3),
+      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId3),
       type: NODE_CATEGORY.CUSTOM,
       parentNode: searchGroupId,
       extent: 'parent',
-      draggable: false,
+      draggable: true,
       deletable: false,
     },
   ] as ReactFlowComponent[];

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -21,6 +21,8 @@ import {
   DEFAULT_NEW_WORKFLOW_NAME,
   Document,
   SparseEncoderTransformer,
+  NeuralQuery,
+  MatchQuery,
 } from '../../../../common';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
@@ -38,6 +40,10 @@ export function enrichPresetWorkflowWithUiMetadata(
     }
     case USE_CASE.NEURAL_SPARSE_SEARCH: {
       workspaceFlowState = fetchNeuralSparseSearchWorkspaceFlow();
+      break;
+    }
+    case USE_CASE.HYBRID_SEARCH: {
+      workspaceFlowState = fetchHybridSearchWorkspaceFlow();
       break;
     }
     default: {
@@ -67,7 +73,6 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
   const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
-  // const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
   const edgeId0 = generateId('edge');
   const edgeId1 = generateId('edge');
 
@@ -121,26 +126,8 @@ function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
     },
   ] as ReactFlowComponent[];
 
-  // const searchNodes = [
-  //   {
-  //     id: searchGroupId,
-  //     position: { x: 400, y: 1000 },
-  //     type: NODE_CATEGORY.SEARCH_GROUP,
-  //     data: { label: COMPONENT_CATEGORY.SEARCH },
-  //     style: {
-  //       width: 900,
-  //       height: 400,
-  //     },
-  //     className: 'reactflow__group-node__search',
-  //     selectable: true,
-  //     draggable: false,
-  //     deletable: false,
-  //   },
-  // ] as ReactFlowComponent[];
-  const searchNodes = [] as ReactFlowComponent[];
-
   return {
-    nodes: [...ingestNodes, ...searchNodes],
+    nodes: ingestNodes,
     edges: [
       {
         id: edgeId0,
@@ -238,7 +225,172 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
     },
   ] as ReactFlowComponent[];
 
-  const searchNodes = [] as ReactFlowComponent[];
+  return {
+    nodes: ingestNodes,
+    edges: [
+      {
+        id: edgeId0,
+        key: edgeId0,
+        source: ingestId0,
+        target: ingestId1,
+        sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+          .baseClasses,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId1,
+        key: edgeId1,
+        source: ingestId1,
+        target: ingestId2,
+        sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+          .baseClasses,
+        targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
+          .baseClasses,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+    ] as ReactFlowEdge[],
+  };
+}
+
+function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
+  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+  const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+  const searchId0 = generateId(COMPONENT_CLASS.MATCH_QUERY);
+  const searchId1 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+  const searchId2 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+  const searchId3 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  const edgeId0 = generateId('edge');
+  const edgeId1 = generateId('edge');
+  const edgeId2 = generateId('edge');
+  const edgeId3 = generateId('edge');
+  const edgeId4 = generateId('edge');
+
+  const ingestNodes = [
+    {
+      id: ingestGroupId,
+      position: { x: 400, y: 400 },
+      type: NODE_CATEGORY.INGEST_GROUP,
+      data: { label: COMPONENT_CATEGORY.INGEST },
+      style: {
+        width: 1300,
+        height: 400,
+      },
+      className: 'reactflow__group-node__ingest',
+      selectable: true,
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: ingestId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new Document().toObj(), ingestId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: ingestId1,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new TextEmbeddingTransformer().toObj(),
+        ingestId1
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: ingestId2,
+      position: { x: 900, y: 70 },
+      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
+
+  const searchNodes = [
+    {
+      id: searchGroupId,
+      position: { x: 400, y: 1000 },
+      type: NODE_CATEGORY.SEARCH_GROUP,
+      data: { label: COMPONENT_CATEGORY.SEARCH },
+      style: {
+        width: 1300,
+        height: 700,
+      },
+      className: 'reactflow__group-node__search',
+      selectable: true,
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: searchId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new NeuralQuery().toObj(), searchId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: searchId1,
+      position: { x: 100, y: 370 },
+      data: initComponentData(new MatchQuery().toObj(), searchId1),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: searchId2,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new TextEmbeddingTransformer().toObj(),
+        searchId2
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+    {
+      id: searchId3,
+      position: { x: 900, y: 200 },
+      data: initComponentData(new KnnIndexer().toObj(), searchId3),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: false,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
 
   return {
     nodes: [...ingestNodes, ...searchNodes],
@@ -269,6 +421,62 @@ function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
           .baseClasses,
         targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
           .baseClasses,
+        targetHandle: COMPONENT_CLASS.DOCUMENT,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId2,
+        key: edgeId2,
+        source: searchId0,
+        target: searchId2,
+        sourceClasses: searchNodes.find((node) => node.id === searchId0)?.data
+          .baseClasses,
+        targetClasses: searchNodes.find((node) => node.id === searchId2)?.data
+          .baseClasses,
+        targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId3,
+        key: edgeId3,
+        source: searchId2,
+        target: searchId3,
+        sourceClasses: searchNodes.find((node) => node.id === searchId2)?.data
+          .baseClasses,
+        targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
+          .baseClasses,
+        sourceHandle: COMPONENT_CLASS.QUERY,
+        targetHandle: COMPONENT_CLASS.QUERY,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId4,
+        key: edgeId4,
+        source: searchId1,
+        target: searchId3,
+        sourceClasses: searchNodes.find((node) => node.id === searchId1)?.data
+          .baseClasses,
+        targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
+          .baseClasses,
+        targetHandle: COMPONENT_CLASS.QUERY,
         markerEnd: {
           type: MarkerType.ArrowClosed,
           width: 20,

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -42,7 +42,11 @@ export interface RouteService {
   deleteWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
   getWorkflowPresets: () => Promise<any | HttpFetchError>;
   catIndices: (pattern: string) => Promise<any | HttpFetchError>;
-  searchIndex: (index: string, body: {}) => Promise<any | HttpFetchError>;
+  searchIndex: (
+    index: string,
+    body: {},
+    searchPipeline?: string
+  ) => Promise<any | HttpFetchError>;
   ingest: (index: string, doc: {}) => Promise<any | HttpFetchError>;
   searchModels: (body: {}) => Promise<any | HttpFetchError>;
 }
@@ -161,14 +165,15 @@ export function configureRoutes(core: CoreStart): RouteService {
         return e as HttpFetchError;
       }
     },
-    searchIndex: async (index: string, body: {}) => {
+    searchIndex: async (index: string, body: {}, searchPipeline?: string) => {
       try {
-        const response = await core.http.post<{ respString: string }>(
-          `${SEARCH_INDEX_NODE_API_PATH}/${index}`,
-          {
-            body: JSON.stringify(body),
-          }
-        );
+        const basePath = `${SEARCH_INDEX_NODE_API_PATH}/${index}`;
+        const path = searchPipeline
+          ? `${basePath}/${searchPipeline}`
+          : basePath;
+        const response = await core.http.post<{ respString: string }>(path, {
+          body: JSON.stringify(body),
+        });
         return response;
       } catch (e: any) {
         return e as HttpFetchError;

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -39,11 +39,15 @@ export const catIndices = createAsyncThunk(
 
 export const searchIndex = createAsyncThunk(
   SEARCH_INDEX_ACTION,
-  async (searchIndexInfo: { index: string; body: {} }, { rejectWithValue }) => {
-    const { index, body } = searchIndexInfo;
+  async (
+    searchIndexInfo: { index: string; body: {}; searchPipeline?: string },
+    { rejectWithValue }
+  ) => {
+    const { index, body, searchPipeline } = searchIndexInfo;
     const response: any | HttpFetchError = await getRouteService().searchIndex(
       index,
-      body
+      body,
+      searchPipeline
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue('Error searching index: ' + response.body.message);

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -52,6 +52,8 @@ export enum COMPONENT_CLASS {
   SPARSE_ENCODER_TRANSFORMER = 'sparse_encoder_transformer',
   // Query-related classes
   QUERY = 'query',
+  MATCH_QUERY = 'match_query',
+  NEURAL_QUERY = 'neural_query',
   // Document-related classes
   DOCUMENT = 'document',
 }

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -50,10 +50,14 @@ export enum COMPONENT_CLASS {
   ML_TRANSFORMER = 'ml_transformer',
   TEXT_EMBEDDING_TRANSFORMER = 'text_embedding_transformer',
   SPARSE_ENCODER_TRANSFORMER = 'sparse_encoder_transformer',
+  RESULTS_TRANSFORMER = 'results_transformer',
+  NORMALIZATION_TRANSFORMER = 'normalization_transformer',
   // Query-related classes
   QUERY = 'query',
   MATCH_QUERY = 'match_query',
   NEURAL_QUERY = 'neural_query',
   // Document-related classes
   DOCUMENT = 'document',
+  // Results-related classes
+  RESULTS = 'results',
 }

--- a/server/resources/templates/hybrid_search.json
+++ b/server/resources/templates/hybrid_search.json
@@ -1,0 +1,12 @@
+{
+    "name": "Hybrid Search",
+    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing hybrid search",
+    "use_case": "HYBRID_SEARCH",
+    "version": {
+        "template": "1.0.0",
+        "compatibility": [
+            "2.13.0",
+            "3.0.0"
+        ]
+    }
+}

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -128,6 +128,7 @@ export function getResourcesCreatedFromResponse(
     resourcesCreated.forEach((backendResource) => {
       finalResources.push({
         id: backendResource.resource_id,
+        stepType: backendResource.workflow_step_name,
         type:
           // @ts-ignore
           WORKFLOW_RESOURCE_TYPE[

--- a/server/routes/opensearch_routes_service.ts
+++ b/server/routes/opensearch_routes_service.ts
@@ -50,6 +50,19 @@ export function registerOpenSearchRoutes(
     },
     opensearchRoutesService.searchIndex
   );
+  router.post(
+    {
+      path: `${SEARCH_INDEX_NODE_API_PATH}/{index}/{search_pipeline}`,
+      validate: {
+        params: schema.object({
+          index: schema.string(),
+          search_pipeline: schema.string(),
+        }),
+        body: schema.any(),
+      },
+    },
+    opensearchRoutesService.searchIndex
+  );
   router.put(
     {
       path: `${INGEST_NODE_API_PATH}/{index}`,
@@ -103,7 +116,10 @@ export class OpenSearchRoutesService {
     req: OpenSearchDashboardsRequest,
     res: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
-    const { index } = req.params as { index: string };
+    const { index, search_pipeline } = req.params as {
+      index: string;
+      search_pipeline: string | undefined;
+    };
     const body = req.body;
     try {
       const response = await this.client
@@ -111,6 +127,7 @@ export class OpenSearchRoutesService {
         .callAsCurrentUser('search', {
           index,
           body,
+          search_pipeline,
         });
 
       return res.ok({ body: response });


### PR DESCRIPTION
### Context

This PR adds many changes to the I/O and appearance on the drag-and-drop workspace. Note the final inputs/outputs/component types etc. are still not finalized. The purpose for adding placeholder components and updating inputs/outputs now is to iteratively improve on and make the current state of the plugin more functional and user-friendly, and to help start gathering initial feedback. Adding the existing use cases helps provide some immediate utility and testing of the corresponding backend Flow Framework plugin.

### Description

This PR has 2 main changes: 1/ Onboarding a basic [hybrid search](https://opensearch.org/docs/latest/search-plugins/hybrid-search/) use case, and 2/ providing visible, readonly flows on the DnD workspace for better overall e2e understanding from user perspective. More details:
- adds several UI drag-and-drop components for both hybrid search use case (results transformer), and for search flow visibility (several query-related blocks)
- modifies several existing components to handle inputs for both ingest and search (e.g., all transformers can now accept a document to be used on ingest, or a query to be used on search)
- adds interfaces and functionality to create search pipelines
- integrates the new use case into the prototyping components- `Ingestor` and `QueryExecutor`
- makes resource descriptions on resource list tab more robust by determining type based on step type vs. resource type - this is due to a backend limitation of both ingest and search pipelines falling under the same `pipeline_id` resource type
- minor refactoring of helper fns to handle more use cases
- enhances `searchIndex()` end-to-end flow to process an optional `search_pipeline` param to propagate to the cluster. this is used behind-the-scenes in the `QueryExecutor` when executing the searches, if the use case is of type `HYBRID_SEARCH`.

And some minor tweaks to the reactflow workspace:
- makes components draggable again, but still readonly
- dynamically rendering color based on if the component needs input or is just a placeholder

Demo video:
- selecting new hybrid search option
- view of the end-to-end flows for both ingest and search (note all search components are readonly currently as we hardcode the results transformer/search pipeline)
- creating and provisioning all of the resources needed for hybrid search, including a search pipeline
- executing ingest
- executing search with a hybrid query template, and using the created search pipeline behind the scenes

[screen-capture (28).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/4844005d-fb0e-45cd-90de-45e38431d476)


Screenshots of search flows added for other use cases:
Semantic search:

![semantic](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/ce144f44-e363-4ac0-b461-58aee1030d1d)

Neural sparse search:

![neural-sparse](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/4dfc14b6-d7df-4c29-b8b8-766b70476e2c)

### Issues Resolved

Makes progress on #23, #68

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
