### PR TITLE
Initial refactoring of workflow editor page

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../../../common';
 
 interface WorkflowDetailHeaderProps {
-  tabs: any[];
   isNewWorkflow: boolean;
   workflow?: Workflow;
 }
@@ -61,7 +60,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
           Delete
         </EuiButton>,
       ]}
-      tabs={props.tabs}
       bottomBorder={true}
     />
   );

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -50,14 +50,9 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
         </EuiFlexGroup>
       }
       rightSideItems={[
-        // TODO: finalize if this is needed
-        <EuiButton
-          fill={false}
-          color="danger"
-          style={{ marginTop: '8px' }}
-          onClick={() => {}}
-        >
-          Delete
+        // TODO: implement export functionality
+        <EuiButton fill={false} style={{ marginTop: '8px' }} onClick={() => {}}>
+          Export
         </EuiButton>,
       ]}
       bottomBorder={true}

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -18,7 +18,7 @@ import {
   EuiPageHeader,
   EuiResizableContainer,
 } from '@elastic/eui';
-import { getCore } from '../../../services';
+import { getCore } from '../../services';
 
 import {
   Workflow,
@@ -29,15 +29,15 @@ import {
   WorkspaceFlowState,
   WORKFLOW_STATE,
   ReactFlowEdge,
-} from '../../../../common';
+} from '../../../common';
 import {
   componentDataToFormik,
   getComponentSchema,
   processNodes,
   reduceToTemplate,
   APP_PATH,
-} from '../../../utils';
-import { validateWorkspaceFlow, toTemplateFlows } from '../utils';
+} from '../../utils';
+import { validateWorkspaceFlow, toTemplateFlows } from './utils';
 import {
   AppState,
   createWorkflow,
@@ -48,20 +48,21 @@ import {
   setDirty,
   updateWorkflow,
   useAppDispatch,
-} from '../../../store';
-import { Workspace } from './workspace';
-import { ComponentDetails } from '../component_details';
+} from '../../store';
+import { Workspace } from './workspace/workspace';
+import { ComponentDetails } from './component_details';
 
 // styling
-import './workspace-styles.scss';
-import '../../../global-styles.scss';
+import './workspace/workspace-styles.scss';
+import '../../global-styles.scss';
+import { WorkflowInputs } from './workflow_inputs';
 
 interface ResizableWorkspaceProps {
   isNewWorkflow: boolean;
   workflow?: Workflow;
 }
 
-const COMPONENT_DETAILS_PANEL_ID = 'component_details_panel_id';
+const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
 
 /**
  * The overall workspace component that maintains state related to the 2 resizable
@@ -461,6 +462,26 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
               return (
                 <>
                   <EuiResizablePanel
+                    id={WORKFLOW_INPUTS_PANEL_ID}
+                    mode="collapsible"
+                    initialSize={40}
+                    minSize="25%"
+                    paddingSize="s"
+                    onToggleCollapsedInternal={() => onToggleChange()}
+                  >
+                    <EuiFlexGroup
+                      direction="column"
+                      gutterSize="s"
+                      className="workspace-panel"
+                    >
+                      <EuiFlexItem>
+                        <WorkflowInputs workflow={props.workflow} />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiResizablePanel>
+                  <EuiResizableButton />
+                  <EuiResizablePanel
+                    style={{ marginRight: '-16px' }}
                     mode="main"
                     initialSize={80}
                     minSize="50%"
@@ -478,31 +499,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                           readonly={false}
                           onNodesChange={onNodesChange}
                           onSelectionChange={onSelectionChange}
-                        />
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiResizablePanel>
-                  <EuiResizableButton />
-                  <EuiResizablePanel
-                    style={{ marginRight: '-16px' }}
-                    id={COMPONENT_DETAILS_PANEL_ID}
-                    mode="collapsible"
-                    initialSize={25}
-                    minSize="10%"
-                    paddingSize="s"
-                    onToggleCollapsedInternal={() => onToggleChange()}
-                  >
-                    <EuiFlexGroup
-                      direction="column"
-                      gutterSize="s"
-                      className="workspace-panel"
-                    >
-                      <EuiFlexItem>
-                        <ComponentDetails
-                          workflow={props.workflow}
-                          selectedComponent={selectedComponent}
-                          isDeprovisionable={isDeprovisionable}
-                          onFormChange={onFormChange}
                         />
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -464,7 +464,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                   <EuiResizablePanel
                     id={WORKFLOW_INPUTS_PANEL_ID}
                     mode="collapsible"
-                    initialSize={40}
+                    initialSize={50}
                     minSize="25%"
                     paddingSize="s"
                     onToggleCollapsedInternal={() => onToggleChange()}
@@ -483,8 +483,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                   <EuiResizablePanel
                     style={{ marginRight: '-16px' }}
                     mode="main"
-                    initialSize={80}
-                    minSize="50%"
+                    initialSize={60}
+                    minSize="25%"
                     paddingSize="s"
                   >
                     <EuiFlexGroup

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -11,11 +11,9 @@ import { Form, Formik, FormikProps } from 'formik';
 import * as yup from 'yup';
 import { cloneDeep } from 'lodash';
 import {
-  EuiButton,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPageHeader,
   EuiResizableContainer,
 } from '@elastic/eui';
 import { getCore } from '../../services';
@@ -34,23 +32,11 @@ import {
   componentDataToFormik,
   getComponentSchema,
   processNodes,
-  reduceToTemplate,
   APP_PATH,
 } from '../../utils';
 import { validateWorkspaceFlow, toTemplateFlows } from './utils';
-import {
-  AppState,
-  createWorkflow,
-  deprovisionWorkflow,
-  getWorkflowState,
-  provisionWorkflow,
-  removeDirty,
-  setDirty,
-  updateWorkflow,
-  useAppDispatch,
-} from '../../store';
+import { AppState, setDirty, useAppDispatch } from '../../store';
 import { Workspace } from './workspace/workspace';
-import { ComponentDetails } from './component_details';
 
 // styling
 import './workspace/workspace-styles.scss';
@@ -338,114 +324,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
               deprovisioned.
             </EuiCallOut>
           )}
-          <EuiPageHeader
-            style={{ marginBottom: '8px' }}
-            rightSideItems={[
-              <EuiButton
-                fill={false}
-                disabled={!isDeprovisionable || isLoadingGlobal}
-                isLoading={isDeprovisioning}
-                onClick={() => {
-                  if (workflow?.id) {
-                    setIsDeprovisioning(true);
-                    dispatch(deprovisionWorkflow(workflow.id))
-                      .unwrap()
-                      .then(async (result) => {
-                        await new Promise((f) => setTimeout(f, 3000));
-                        dispatch(getWorkflowState(workflow.id as string));
-                        setIsDeprovisioning(false);
-                      })
-                      .catch((error: any) => {
-                        setIsDeprovisioning(false);
-                      });
-                  } else {
-                    // This case should not happen
-                    console.debug(
-                      'Deprovisioning triggered on an invalid workflow. Ignoring.'
-                    );
-                  }
-                }}
-              >
-                Deprovision
-              </EuiButton>,
-              <EuiButton
-                fill={false}
-                disabled={!isProvisionable || isLoadingGlobal}
-                isLoading={isProvisioning}
-                onClick={() => {
-                  if (workflow?.id) {
-                    setIsProvisioning(true);
-                    dispatch(provisionWorkflow(workflow.id))
-                      .unwrap()
-                      .then(async (result) => {
-                        await new Promise((f) => setTimeout(f, 3000));
-                        dispatch(getWorkflowState(workflow.id as string));
-                        setIsProvisioning(false);
-                      })
-                      .catch((error: any) => {
-                        setIsProvisioning(false);
-                      });
-                  } else {
-                    // This case should not happen
-                    console.debug(
-                      'Provisioning triggered on an invalid workflow. Ignoring.'
-                    );
-                  }
-                }}
-              >
-                Provision
-              </EuiButton>,
-              <EuiButton
-                fill={false}
-                disabled={!isSaveable || isLoadingGlobal || isDeprovisionable}
-                isLoading={isSaving}
-                onClick={() => {
-                  setIsSaving(true);
-                  dispatch(removeDirty());
-                  if (isFirstSave) {
-                    setIsFirstSave(false);
-                  }
-                  validateFormAndFlow(
-                    formikProps,
-                    // The callback fn to run if everything is valid.
-                    (updatedWorkflow) => {
-                      if (updatedWorkflow.id) {
-                        dispatch(
-                          updateWorkflow({
-                            workflowId: updatedWorkflow.id,
-                            workflowTemplate: reduceToTemplate(updatedWorkflow),
-                          })
-                        )
-                          .unwrap()
-                          .then((result) => {
-                            setIsSaving(false);
-                          })
-                          .catch((error: any) => {
-                            setIsSaving(false);
-                          });
-                      } else {
-                        dispatch(createWorkflow(updatedWorkflow))
-                          .unwrap()
-                          .then((result) => {
-                            const { workflow } = result;
-                            history.replace(
-                              `${APP_PATH.WORKFLOWS}/${workflow.id}`
-                            );
-                            history.go(0);
-                          })
-                          .catch((error: any) => {
-                            setIsSaving(false);
-                          });
-                      }
-                    }
-                  );
-                }}
-              >
-                {props.isNewWorkflow || isCreating ? 'Create' : 'Save'}
-              </EuiButton>,
-            ]}
-            bottomBorder={false}
-          />
           <EuiResizableContainer
             direction="horizontal"
             className="stretch-absolute"

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { ReactFlowProvider } from 'reactflow';
-import queryString from 'query-string';
 import { EuiPage, EuiPageBody } from '@elastic/eui';
 import { BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
@@ -24,8 +23,6 @@ import {
   FETCH_ALL_QUERY_BODY,
   NEW_WORKFLOW_ID_URL,
 } from '../../../common';
-import { Resources } from './resources';
-import { Prototype } from './prototype';
 
 // styling
 import './workflow-detail-styles.scss';
@@ -37,29 +34,6 @@ export interface WorkflowDetailRouterProps {
 
 interface WorkflowDetailProps
   extends RouteComponentProps<WorkflowDetailRouterProps> {}
-
-enum WORKFLOW_DETAILS_TAB {
-  EDITOR = 'editor',
-  // TODO: temporarily adding a resources tab until UX is finalized.
-  // This gives clarity into what has been done on the cluster on behalf
-  // of the frontend provisioning workflows.
-  RESOURCES = 'resources',
-  // TODO: temporarily adding a prototype tab until UX is finalized.
-  // This allows simple UI for executing ingest and search against
-  // created workflow resources
-  PROTOTYPE = 'prototype',
-}
-
-const ACTIVE_TAB_PARAM = 'tab';
-
-function replaceActiveTab(activeTab: string, props: WorkflowDetailProps) {
-  props.history.replace({
-    ...history,
-    search: queryString.stringify({
-      [ACTIVE_TAB_PARAM]: activeTab,
-    }),
-  });
-}
 
 /**
  * The workflow details page. This is where users will configure, create, and
@@ -83,25 +57,6 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     : isNewWorkflow && !workflow
     ? DEFAULT_NEW_WORKFLOW_NAME
     : '';
-
-  // tab state
-  const tabFromUrl = queryString.parse(useLocation().search)[
-    ACTIVE_TAB_PARAM
-  ] as WORKFLOW_DETAILS_TAB;
-  const [selectedTabId, setSelectedTabId] = useState<WORKFLOW_DETAILS_TAB>(
-    tabFromUrl
-  );
-
-  // Default to editor tab if there is none or invalid tab ID specified via url.
-  useEffect(() => {
-    if (
-      !selectedTabId ||
-      !Object.values(WORKFLOW_DETAILS_TAB).includes(selectedTabId)
-    ) {
-      setSelectedTabId(WORKFLOW_DETAILS_TAB.EDITOR);
-      replaceActiveTab(WORKFLOW_DETAILS_TAB.EDITOR, props);
-    }
-  }, []);
 
   useEffect(() => {
     getCore().chrome.setBreadcrumbs([
@@ -129,36 +84,6 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     }
   }, [errorMessage]);
 
-  const tabs = [
-    {
-      id: WORKFLOW_DETAILS_TAB.EDITOR,
-      label: 'Editor',
-      isSelected: selectedTabId === WORKFLOW_DETAILS_TAB.EDITOR,
-      onClick: () => {
-        setSelectedTabId(WORKFLOW_DETAILS_TAB.EDITOR);
-        replaceActiveTab(WORKFLOW_DETAILS_TAB.EDITOR, props);
-      },
-    },
-    {
-      id: WORKFLOW_DETAILS_TAB.RESOURCES,
-      label: 'Resources',
-      isSelected: selectedTabId === WORKFLOW_DETAILS_TAB.RESOURCES,
-      onClick: () => {
-        setSelectedTabId(WORKFLOW_DETAILS_TAB.RESOURCES);
-        replaceActiveTab(WORKFLOW_DETAILS_TAB.RESOURCES, props);
-      },
-    },
-    {
-      id: WORKFLOW_DETAILS_TAB.PROTOTYPE,
-      label: 'Prototype',
-      isSelected: selectedTabId === WORKFLOW_DETAILS_TAB.PROTOTYPE,
-      onClick: () => {
-        setSelectedTabId(WORKFLOW_DETAILS_TAB.PROTOTYPE);
-        replaceActiveTab(WORKFLOW_DETAILS_TAB.PROTOTYPE, props);
-      },
-    },
-  ];
-
   return (
     <ReactFlowProvider>
       <EuiPage>
@@ -166,22 +91,13 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
           <WorkflowDetailHeader
             workflow={workflow}
             isNewWorkflow={isNewWorkflow}
-            tabs={tabs}
           />
-          {selectedTabId === WORKFLOW_DETAILS_TAB.EDITOR && (
-            <ReactFlowProvider>
-              <ResizableWorkspace
-                isNewWorkflow={isNewWorkflow}
-                workflow={workflow}
-              />
-            </ReactFlowProvider>
-          )}
-          {selectedTabId === WORKFLOW_DETAILS_TAB.RESOURCES && (
-            <Resources workflow={workflow} />
-          )}
-          {selectedTabId === WORKFLOW_DETAILS_TAB.PROTOTYPE && (
-            <Prototype workflow={workflow} />
-          )}
+          <ReactFlowProvider>
+            <ResizableWorkspace
+              isNewWorkflow={isNewWorkflow}
+              workflow={workflow}
+            />
+          </ReactFlowProvider>
         </EuiPageBody>
       </EuiPage>
     </ReactFlowProvider>

--- a/public/pages/workflow_detail/workflow_inputs/footer.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/footer.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+} from '@elastic/eui';
+import { CREATE_STEP } from './workflow_inputs';
+
+interface FooterProps {
+  selectedStep: CREATE_STEP;
+  setSelectedStep: (step: CREATE_STEP) => void;
+}
+
+/**
+ * The footer component containing the navigation buttons.
+ */
+export function Footer(props: FooterProps) {
+  return (
+    <EuiFlexGroup direction="column" gutterSize="none">
+      <EuiFlexItem>
+        <EuiHorizontalRule margin="m" />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup direction="row" justifyContent="flexEnd">
+          {props.selectedStep === CREATE_STEP.INGEST ? (
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                onClick={() => props.setSelectedStep(CREATE_STEP.SEARCH)}
+              >
+                Next
+              </EuiButton>
+            </EuiFlexItem>
+          ) : (
+            <>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  onClick={() => props.setSelectedStep(CREATE_STEP.INGEST)}
+                >
+                  Back
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  disabled={true}
+                  onClick={() =>
+                    // TODO: implement creation
+                    console.log('Placeholder for workflow creation...')
+                  }
+                >
+                  Create
+                </EuiButton>
+              </EuiFlexItem>
+            </>
+          )}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { ResizableWorkspace } from '../resizable_workspace';
+export * from './workflow_inputs';

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface EnrichDataProps {}
+
+/**
+ * Input component for configuring any data enrichment for ingest (ingest pipeline processors etc.)
+ */
+export function EnrichData(props: EnrichDataProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Enrich data</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './ingest_inputs';

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface IngestDataProps {}
+
+/**
+ * Input component for configuring the data ingest (the OpenSearch index)
+ */
+export function IngestData(props: IngestDataProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Ingest data</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
+import { SourceData } from './source_data';
+import { EnrichData } from './enrich_data';
+import { IngestData } from './ingest_data';
+
+interface IngestInputsProps {}
+
+/**
+ * The base component containing all of the ingest-related inputs
+ */
+export function IngestInputs(props: IngestInputsProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <SourceData />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiHorizontalRule margin="none" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EnrichData />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiHorizontalRule margin="none" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <IngestData />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface SourceDataProps {}
+
+/**
+ * Input component for configuring the source data for ingest.
+ */
+export function SourceData(props: SourceDataProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Source data</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface ConfigureSearchRequestProps {}
+
+/**
+ * Input component for configuring a search request
+ */
+export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Configure search request</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface EnrichSearchRequestProps {}
+
+/**
+ * Input component for enriching a search request (configuring search request processors, etc.)
+ */
+export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Enrich search request</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+
+interface EnrichSearchResponseProps {}
+
+/**
+ * Input component for enriching a search response (configuring search response processors, etc.)
+ */
+export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>Enrich search response</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText grow={false}>TODO</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './search_inputs';

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
+import { ConfigureSearchRequest } from './configure_search_request';
+import { EnrichSearchRequest } from './enrich_search_request';
+import { EnrichSearchResponse } from './enrich_search_response';
+
+interface SearchInputsProps {}
+
+/**
+ * The base component containing all of the search-related inputs
+ */
+export function SearchInputs(props: SearchInputsProps) {
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <ConfigureSearchRequest />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiHorizontalRule margin="none" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EnrichSearchRequest />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiHorizontalRule margin="none" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EnrichSearchResponse />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { Workflow } from '../../../../common';
+
+interface WorkflowInputsProps {
+  workflow: Workflow | undefined;
+}
+
+/**
+ * The workflow inputs component containing the multi-step flow to create ingest
+ * and search flows for a particular workflow.
+ */
+
+export function WorkflowInputs(props: WorkflowInputsProps) {
+  return (
+    <EuiPanel paddingSize="m">
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiText>Hello world</EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -36,7 +36,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
       <EuiFlexGroup
         direction="column"
         justifyContent="spaceBetween"
-        style={{ height: '100%', paddingBottom: '96px' }}
+        style={{ height: '100%', paddingBottom: '48px' }}
       >
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -3,12 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
 import { Workflow } from '../../../../common';
+import { Footer } from './footer';
+import { IngestInputs } from './ingest_inputs';
+import { SearchInputs } from './search_inputs';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;
+}
+
+export enum CREATE_STEP {
+  INGEST = 'Step 1: Define ingestion pipeline',
+  SEARCH = 'Step 2: Define search pipeline',
 }
 
 /**
@@ -17,11 +25,36 @@ interface WorkflowInputsProps {
  */
 
 export function WorkflowInputs(props: WorkflowInputsProps) {
+  const [selectedStep, setSelectedStep] = useState<CREATE_STEP>(
+    CREATE_STEP.INGEST
+  );
+
+  useEffect(() => {}, [selectedStep]);
+
   return (
     <EuiPanel paddingSize="m">
-      <EuiFlexGroup>
+      <EuiFlexGroup
+        direction="column"
+        justifyContent="spaceBetween"
+        style={{ height: '100%', paddingBottom: '96px' }}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h4>{selectedStep}</h4>
+          </EuiTitle>
+        </EuiFlexItem>
         <EuiFlexItem>
-          <EuiText>Hello world</EuiText>
+          {selectedStep === CREATE_STEP.INGEST ? (
+            <IngestInputs />
+          ) : (
+            <SearchInputs />
+          )}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <Footer
+            selectedStep={selectedStep}
+            setSelectedStep={setSelectedStep}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -27,6 +27,9 @@ import {
   NormalizationTransformer,
 } from '../../../component_types';
 
+// TODO: change from producing a flow state, to producing a form state w/ some preset values.
+// The form will generate the end flow state.
+
 // Fn to produce the complete preset template with all necessary UI metadata.
 // Some UI metadata we want to generate on-the-fly using our component classes we have on client-side.
 // Thus, we only persist a minimal subset of a full template on server-side. We generate


### PR DESCRIPTION
### Description

There has been recent changes to the proposed UX. The previous proposal was filling out inputs individually within a selected ReactFlow component. The new proposal is a more guided/structured way of filling out inputs. Now, it is form based via a single, stepped form with all of the required inputs end-to-end in one view. As users fill it out, the workspace components automatically populate based on the inputs. The workspace itself remains readonly. And for further testing, there will be a new tools view for executing ingest and search, all within the single page (no tabs / other dedicated views).

This PR handles the initial refactoring and setup of the stubbed form input components to be implemented incrementally. More specifically:
- new `WorkflowInputs` component & several child components for breaking up the required inputs for both ingest and search flows. The child components are stubbed for now.
- changes `ResizableWorkspace` to include the new `WorkflowInputs` component and removes the `ComponentInputs` component previously used for dynamically showing the form for an individual component in the dnd workspace
- removes the create/update/provision/deprovision/delete buttons as these will later be reintroduced within `WorkflowInputs` and a later `Tools` component
- removes tabs in the details page

Demo video below shows the new `WorkflowInputs` component and it's stepped flow. All form inputs are stubbed for now.

[screen-capture (30).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/04fd6b7e-f364-4477-be05-7073a2477c2d)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
