### PR TITLE
Add new workflow config interfaces

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -14,6 +14,43 @@ export type Index = {
 };
 
 /**
+ ********** WORKFLOW TYPES/INTERFACES **********
+TODO: over time these can become less generic as the form inputs & UX becomes finalized
+ */
+
+export type IndexConfig = {
+  isNew: boolean;
+  indexName: string;
+};
+
+export type IngestConfig = {
+  source: FormikValues;
+  enrich: FormikValues;
+  ingest: IndexConfig;
+};
+
+export type SearchConfig = {
+  request: FormikValues;
+  enrichRequest: FormikValues;
+  enrichResponse: FormikValues;
+};
+
+export type WorkflowConfig = {
+  ingest?: IngestConfig;
+  search?: SearchConfig;
+};
+
+export type WorkflowFormValues = {
+  ingest: FormikValues;
+  search: FormikValues;
+};
+
+export type WorkflowSchemaObj = {
+  [key: string]: ObjectSchema<any, any, any>;
+};
+export type WorkflowSchema = ObjectSchema<WorkflowSchemaObj>;
+
+/**
  ********** WORKSPACE TYPES/INTERFACES **********
  */
 
@@ -111,7 +148,8 @@ type ReactFlowViewport = {
 };
 
 export type UIState = {
-  workspace_flow: WorkspaceFlowState;
+  config: WorkflowConfig;
+  workspace_flow?: WorkspaceFlowState;
 };
 
 export type WorkspaceFlowState = {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -3,15 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+import React, { useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiRadioGroup,
+  EuiTitle,
+} from '@elastic/eui';
+import { Workflow } from '../../../../../common';
 
-interface IngestDataProps {}
+interface IngestDataProps {
+  workflow: Workflow;
+}
+
+enum OPTION {
+  NEW = 'new',
+  EXISTING = 'existing',
+}
+
+const options = [
+  {
+    id: OPTION.NEW,
+    label: 'Create a new index',
+  },
+  {
+    id: OPTION.EXISTING,
+    label: 'Choose existing index',
+  },
+];
 
 /**
  * Input component for configuring the data ingest (the OpenSearch index)
  */
 export function IngestData(props: IngestDataProps) {
+  const [selectedOption, setSelectedOption] = useState<OPTION>(OPTION.NEW);
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
@@ -20,7 +46,11 @@ export function IngestData(props: IngestDataProps) {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiText grow={false}>TODO</EuiText>
+        <EuiRadioGroup
+          options={options}
+          idSelected={selectedOption}
+          onChange={(optionId) => setSelectedOption(optionId as OPTION)}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -8,8 +8,11 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { SourceData } from './source_data';
 import { EnrichData } from './enrich_data';
 import { IngestData } from './ingest_data';
+import { Workflow } from '../../../../../common';
 
-interface IngestInputsProps {}
+interface IngestInputsProps {
+  workflow: Workflow;
+}
 
 /**
  * The base component containing all of the ingest-related inputs
@@ -30,7 +33,7 @@ export function IngestInputs(props: IngestInputsProps) {
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <IngestData />
+        <IngestData workflow={props.workflow} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -8,8 +8,11 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { ConfigureSearchRequest } from './configure_search_request';
 import { EnrichSearchRequest } from './enrich_search_request';
 import { EnrichSearchResponse } from './enrich_search_response';
+import { Workflow } from '../../../../../common';
 
-interface SearchInputsProps {}
+interface SearchInputsProps {
+  workflow: Workflow;
+}
 
 /**
  * The base component containing all of the search-related inputs

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -4,7 +4,13 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiTitle,
+} from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { Footer } from './footer';
 import { IngestInputs } from './ingest_inputs';
@@ -33,30 +39,34 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   return (
     <EuiPanel paddingSize="m">
-      <EuiFlexGroup
-        direction="column"
-        justifyContent="spaceBetween"
-        style={{ height: '100%', paddingBottom: '48px' }}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="s">
-            <h4>{selectedStep}</h4>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          {selectedStep === CREATE_STEP.INGEST ? (
-            <IngestInputs />
-          ) : (
-            <SearchInputs />
-          )}
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <Footer
-            selectedStep={selectedStep}
-            setSelectedStep={setSelectedStep}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      {props.workflow === undefined ? (
+        <EuiLoadingSpinner size="xl" />
+      ) : (
+        <EuiFlexGroup
+          direction="column"
+          justifyContent="spaceBetween"
+          style={{ height: '100%', paddingBottom: '48px' }}
+        >
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h4>{selectedStep}</h4>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {selectedStep === CREATE_STEP.INGEST ? (
+              <IngestInputs workflow={props.workflow} />
+            ) : (
+              <SearchInputs workflow={props.workflow} />
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <Footer
+              selectedStep={selectedStep}
+              setSelectedStep={setSelectedStep}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )}
     </EuiPanel>
   );
 }

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -3,56 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MarkerType } from 'reactflow';
 import {
-  WorkspaceFlowState,
-  ReactFlowComponent,
-  ReactFlowEdge,
-  COMPONENT_CATEGORY,
-  NODE_CATEGORY,
   USE_CASE,
   WorkflowTemplate,
-  COMPONENT_CLASS,
   START_FROM_SCRATCH_WORKFLOW_NAME,
   DEFAULT_NEW_WORKFLOW_NAME,
+  UIState,
 } from '../../../../common';
-import { initComponentData, generateId } from '../../../utils';
-import {
-  TextEmbeddingTransformer,
-  KnnIndexer,
-  Document,
-  SparseEncoderTransformer,
-  NeuralQuery,
-  MatchQuery,
-  NormalizationTransformer,
-} from '../../../component_types';
-
-// TODO: change from producing a flow state, to producing a form state w/ some preset values.
-// The form will generate the end flow state.
 
 // Fn to produce the complete preset template with all necessary UI metadata.
-// Some UI metadata we want to generate on-the-fly using our component classes we have on client-side.
-// Thus, we only persist a minimal subset of a full template on server-side. We generate
-// the rest dynamically based on the set of supported preset use cases.
 export function enrichPresetWorkflowWithUiMetadata(
   presetWorkflow: Partial<WorkflowTemplate>
 ): WorkflowTemplate {
-  let workspaceFlowState = {} as WorkspaceFlowState;
+  let uiMetadata = {} as UIState;
+  // TODO: for now we are defaulting to empty for all presets. As the form values become finalized,
+  // provide preset values for the different preset use cases.
   switch (presetWorkflow.use_case) {
     case USE_CASE.SEMANTIC_SEARCH: {
-      workspaceFlowState = fetchSemanticSearchWorkspaceFlow();
+      uiMetadata = fetchEmptyMetadata();
       break;
     }
     case USE_CASE.NEURAL_SPARSE_SEARCH: {
-      workspaceFlowState = fetchNeuralSparseSearchWorkspaceFlow();
+      uiMetadata = fetchEmptyMetadata();
       break;
     }
     case USE_CASE.HYBRID_SEARCH: {
-      workspaceFlowState = fetchHybridSearchWorkspaceFlow();
+      uiMetadata = fetchEmptyMetadata();
       break;
     }
     default: {
-      workspaceFlowState = fetchEmptyWorkspaceFlow();
+      uiMetadata = fetchEmptyMetadata();
       break;
     }
   }
@@ -61,658 +41,671 @@ export function enrichPresetWorkflowWithUiMetadata(
     ...presetWorkflow,
     ui_metadata: {
       ...presetWorkflow.ui_metadata,
-      workspace_flow: workspaceFlowState,
+      ...uiMetadata,
     },
   } as WorkflowTemplate;
 }
 
-function fetchEmptyWorkspaceFlow(): WorkspaceFlowState {
+function fetchEmptyMetadata(): UIState {
   return {
-    nodes: [],
-    edges: [],
+    config: {
+      ingest: {
+        source: {},
+        enrich: {},
+        ingest: {
+          isNew: true,
+          indexName: 'my-index',
+        },
+      },
+      search: {
+        request: {},
+        enrichRequest: {},
+        enrichResponse: {},
+      },
+    },
   };
 }
 
-function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
-  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
-  const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
-  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
-  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
-  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
-  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
-  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const edgeId0 = generateId('edge');
-  const edgeId1 = generateId('edge');
-  const edgeId2 = generateId('edge');
-  const edgeId3 = generateId('edge');
+// function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
+//   const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+//   const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+//   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+//   const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+//   const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+//   const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+//   const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const edgeId0 = generateId('edge');
+//   const edgeId1 = generateId('edge');
+//   const edgeId2 = generateId('edge');
+//   const edgeId3 = generateId('edge');
 
-  const ingestNodes = [
-    {
-      id: ingestGroupId,
-      position: { x: 400, y: 400 },
-      type: NODE_CATEGORY.INGEST_GROUP,
-      data: { label: COMPONENT_CATEGORY.INGEST },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__ingest',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new Document().toObj(), ingestId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toObj(),
-        ingestId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
-  const searchNodes = [
-    {
-      id: searchGroupId,
-      position: { x: 400, y: 1000 },
-      type: NODE_CATEGORY.SEARCH_GROUP,
-      data: { label: COMPONENT_CATEGORY.SEARCH },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__search',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new NeuralQuery().toObj(), searchId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toPlaceholderObj(),
-        searchId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const ingestNodes = [
+//     {
+//       id: ingestGroupId,
+//       position: { x: 400, y: 400 },
+//       type: NODE_CATEGORY.INGEST_GROUP,
+//       data: { label: COMPONENT_CATEGORY.INGEST },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__ingest',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new Document().toObj(), ingestId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toObj(),
+//         ingestId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
+//   const searchNodes = [
+//     {
+//       id: searchGroupId,
+//       position: { x: 400, y: 1000 },
+//       type: NODE_CATEGORY.SEARCH_GROUP,
+//       data: { label: COMPONENT_CATEGORY.SEARCH },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__search',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new NeuralQuery().toObj(), searchId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toPlaceholderObj(),
+//         searchId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  return {
-    nodes: [...ingestNodes, ...searchNodes],
-    edges: [
-      {
-        id: edgeId0,
-        key: edgeId0,
-        source: ingestId0,
-        target: ingestId1,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId1,
-        key: edgeId1,
-        source: ingestId1,
-        target: ingestId2,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
-          .baseClasses,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId2,
-        key: edgeId2,
-        source: searchId0,
-        target: searchId1,
-        sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
-          .baseClasses,
-        sourceHandle: COMPONENT_CLASS.QUERY,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId3,
-        key: edgeId3,
-        source: searchId1,
-        target: searchId2,
-        sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
-          .baseClasses,
-        sourceHandle: COMPONENT_CLASS.QUERY,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-    ] as ReactFlowEdge[],
-  };
-}
+//   return {
+//     nodes: [...ingestNodes, ...searchNodes],
+//     edges: [
+//       {
+//         id: edgeId0,
+//         key: edgeId0,
+//         source: ingestId0,
+//         target: ingestId1,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId1,
+//         key: edgeId1,
+//         source: ingestId1,
+//         target: ingestId2,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
+//           .baseClasses,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId2,
+//         key: edgeId2,
+//         source: searchId0,
+//         target: searchId1,
+//         sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+//           .baseClasses,
+//         sourceHandle: COMPONENT_CLASS.QUERY,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId3,
+//         key: edgeId3,
+//         source: searchId1,
+//         target: searchId2,
+//         sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
+//           .baseClasses,
+//         sourceHandle: COMPONENT_CLASS.QUERY,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//     ] as ReactFlowEdge[],
+//   };
+// }
 
-function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
-  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
-  const ingestId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
-  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
-  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
-  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
-  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
-  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const edgeId0 = generateId('edge');
-  const edgeId1 = generateId('edge');
-  const edgeId2 = generateId('edge');
-  const edgeId3 = generateId('edge');
+// function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
+//   const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+//   const ingestId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+//   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+//   const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+//   const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+//   const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+//   const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const edgeId0 = generateId('edge');
+//   const edgeId1 = generateId('edge');
+//   const edgeId2 = generateId('edge');
+//   const edgeId3 = generateId('edge');
 
-  const ingestNodes = [
-    {
-      id: ingestGroupId,
-      position: { x: 400, y: 400 },
-      type: NODE_CATEGORY.INGEST_GROUP,
-      data: { label: COMPONENT_CATEGORY.INGEST },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__ingest',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new Document().toObj(), ingestId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new SparseEncoderTransformer().toObj(),
-        ingestId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const ingestNodes = [
+//     {
+//       id: ingestGroupId,
+//       position: { x: 400, y: 400 },
+//       type: NODE_CATEGORY.INGEST_GROUP,
+//       data: { label: COMPONENT_CATEGORY.INGEST },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__ingest',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new Document().toObj(), ingestId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new SparseEncoderTransformer().toObj(),
+//         ingestId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  const searchNodes = [
-    {
-      id: searchGroupId,
-      position: { x: 400, y: 1000 },
-      type: NODE_CATEGORY.SEARCH_GROUP,
-      data: { label: COMPONENT_CATEGORY.SEARCH },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__search',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new NeuralQuery().toObj(), searchId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new SparseEncoderTransformer().toPlaceholderObj(),
-        searchId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const searchNodes = [
+//     {
+//       id: searchGroupId,
+//       position: { x: 400, y: 1000 },
+//       type: NODE_CATEGORY.SEARCH_GROUP,
+//       data: { label: COMPONENT_CATEGORY.SEARCH },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__search',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new NeuralQuery().toObj(), searchId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new SparseEncoderTransformer().toPlaceholderObj(),
+//         searchId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  return {
-    nodes: [...ingestNodes, ...searchNodes],
-    edges: [
-      {
-        id: edgeId0,
-        key: edgeId0,
-        source: ingestId0,
-        target: ingestId1,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId1,
-        key: edgeId1,
-        source: ingestId1,
-        target: ingestId2,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
-          .baseClasses,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId2,
-        key: edgeId2,
-        source: searchId0,
-        target: searchId1,
-        sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
-          .baseClasses,
-        sourceHandle: COMPONENT_CLASS.QUERY,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId3,
-        key: edgeId3,
-        source: searchId1,
-        target: searchId2,
-        sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
-          .baseClasses,
-        sourceHandle: COMPONENT_CLASS.QUERY,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-    ] as ReactFlowEdge[],
-  };
-}
+//   return {
+//     nodes: [...ingestNodes, ...searchNodes],
+//     edges: [
+//       {
+//         id: edgeId0,
+//         key: edgeId0,
+//         source: ingestId0,
+//         target: ingestId1,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId1,
+//         key: edgeId1,
+//         source: ingestId1,
+//         target: ingestId2,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
+//           .baseClasses,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId2,
+//         key: edgeId2,
+//         source: searchId0,
+//         target: searchId1,
+//         sourceClasses: ingestNodes.find((node) => node.id === searchId0)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+//           .baseClasses,
+//         sourceHandle: COMPONENT_CLASS.QUERY,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId3,
+//         key: edgeId3,
+//         source: searchId1,
+//         target: searchId2,
+//         sourceClasses: ingestNodes.find((node) => node.id === searchId1)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === searchId2)?.data
+//           .baseClasses,
+//         sourceHandle: COMPONENT_CLASS.QUERY,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//     ] as ReactFlowEdge[],
+//   };
+// }
 
-function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
-  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
-  const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
-  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
-  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
-  const searchId0 = generateId(COMPONENT_CLASS.MATCH_QUERY);
-  const searchId1 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
-  const searchId2 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
-  const searchId3 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const searchId4 = generateId(COMPONENT_CLASS.NORMALIZATION_TRANSFORMER);
-  const edgeId0 = generateId('edge');
-  const edgeId1 = generateId('edge');
-  const edgeId2 = generateId('edge');
-  const edgeId3 = generateId('edge');
-  const edgeId4 = generateId('edge');
-  const edgeId5 = generateId('edge');
+// function fetchHybridSearchWorkspaceFlow(): WorkspaceFlowState {
+//   const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+//   const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+//   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+//   const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+//   const searchId0 = generateId(COMPONENT_CLASS.MATCH_QUERY);
+//   const searchId1 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+//   const searchId2 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+//   const searchId3 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const searchId4 = generateId(COMPONENT_CLASS.NORMALIZATION_TRANSFORMER);
+//   const edgeId0 = generateId('edge');
+//   const edgeId1 = generateId('edge');
+//   const edgeId2 = generateId('edge');
+//   const edgeId3 = generateId('edge');
+//   const edgeId4 = generateId('edge');
+//   const edgeId5 = generateId('edge');
 
-  const ingestNodes = [
-    {
-      id: ingestGroupId,
-      position: { x: 400, y: 400 },
-      type: NODE_CATEGORY.INGEST_GROUP,
-      data: { label: COMPONENT_CATEGORY.INGEST },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__ingest',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new Document().toObj(), ingestId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toObj(),
-        ingestId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const ingestNodes = [
+//     {
+//       id: ingestGroupId,
+//       position: { x: 400, y: 400 },
+//       type: NODE_CATEGORY.INGEST_GROUP,
+//       data: { label: COMPONENT_CATEGORY.INGEST },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__ingest',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new Document().toObj(), ingestId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toObj(),
+//         ingestId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  const searchNodes = [
-    {
-      id: searchGroupId,
-      position: { x: 400, y: 1000 },
-      type: NODE_CATEGORY.SEARCH_GROUP,
-      data: { label: COMPONENT_CATEGORY.SEARCH },
-      style: {
-        width: 1700,
-        height: 600,
-      },
-      className: 'reactflow__group-node__search',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new NeuralQuery().toObj(), searchId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId1,
-      position: { x: 100, y: 370 },
-      data: initComponentData(new MatchQuery().toObj(), searchId1),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId2,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toPlaceholderObj(),
-        searchId2
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId3,
-      position: { x: 900, y: 200 },
-      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId3),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId4,
-      position: { x: 1300, y: 200 },
-      data: initComponentData(
-        new NormalizationTransformer().toObj(),
-        searchId4
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const searchNodes = [
+//     {
+//       id: searchGroupId,
+//       position: { x: 400, y: 1000 },
+//       type: NODE_CATEGORY.SEARCH_GROUP,
+//       data: { label: COMPONENT_CATEGORY.SEARCH },
+//       style: {
+//         width: 1700,
+//         height: 600,
+//       },
+//       className: 'reactflow__group-node__search',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new NeuralQuery().toObj(), searchId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId1,
+//       position: { x: 100, y: 370 },
+//       data: initComponentData(new MatchQuery().toObj(), searchId1),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId2,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toPlaceholderObj(),
+//         searchId2
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId3,
+//       position: { x: 900, y: 200 },
+//       data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId3),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId4,
+//       position: { x: 1300, y: 200 },
+//       data: initComponentData(
+//         new NormalizationTransformer().toObj(),
+//         searchId4
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  return {
-    nodes: [...ingestNodes, ...searchNodes],
-    edges: [
-      {
-        id: edgeId0,
-        key: edgeId0,
-        source: ingestId0,
-        target: ingestId1,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId1,
-        key: edgeId1,
-        source: ingestId1,
-        target: ingestId2,
-        sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
-          .baseClasses,
-        targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
-          .baseClasses,
-        targetHandle: COMPONENT_CLASS.DOCUMENT,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId2,
-        key: edgeId2,
-        source: searchId0,
-        target: searchId2,
-        sourceClasses: searchNodes.find((node) => node.id === searchId0)?.data
-          .baseClasses,
-        targetClasses: searchNodes.find((node) => node.id === searchId2)?.data
-          .baseClasses,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId3,
-        key: edgeId3,
-        source: searchId2,
-        target: searchId3,
-        sourceClasses: searchNodes.find((node) => node.id === searchId2)?.data
-          .baseClasses,
-        targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
-          .baseClasses,
-        sourceHandle: COMPONENT_CLASS.QUERY,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId4,
-        key: edgeId4,
-        source: searchId1,
-        target: searchId3,
-        sourceClasses: searchNodes.find((node) => node.id === searchId1)?.data
-          .baseClasses,
-        targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
-          .baseClasses,
-        targetHandle: COMPONENT_CLASS.QUERY,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId5,
-        key: edgeId5,
-        source: searchId3,
-        target: searchId4,
-        sourceClasses: searchNodes.find((node) => node.id === searchId3)?.data
-          .baseClasses,
-        targetClasses: searchNodes.find((node) => node.id === searchId4)?.data
-          .baseClasses,
-        targetHandle: COMPONENT_CLASS.RESULTS,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-    ] as ReactFlowEdge[],
-  };
-}
+//   return {
+//     nodes: [...ingestNodes, ...searchNodes],
+//     edges: [
+//       {
+//         id: edgeId0,
+//         key: edgeId0,
+//         source: ingestId0,
+//         target: ingestId1,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId0)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId1,
+//         key: edgeId1,
+//         source: ingestId1,
+//         target: ingestId2,
+//         sourceClasses: ingestNodes.find((node) => node.id === ingestId1)?.data
+//           .baseClasses,
+//         targetClasses: ingestNodes.find((node) => node.id === ingestId2)?.data
+//           .baseClasses,
+//         targetHandle: COMPONENT_CLASS.DOCUMENT,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId2,
+//         key: edgeId2,
+//         source: searchId0,
+//         target: searchId2,
+//         sourceClasses: searchNodes.find((node) => node.id === searchId0)?.data
+//           .baseClasses,
+//         targetClasses: searchNodes.find((node) => node.id === searchId2)?.data
+//           .baseClasses,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId3,
+//         key: edgeId3,
+//         source: searchId2,
+//         target: searchId3,
+//         sourceClasses: searchNodes.find((node) => node.id === searchId2)?.data
+//           .baseClasses,
+//         targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
+//           .baseClasses,
+//         sourceHandle: COMPONENT_CLASS.QUERY,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId4,
+//         key: edgeId4,
+//         source: searchId1,
+//         target: searchId3,
+//         sourceClasses: searchNodes.find((node) => node.id === searchId1)?.data
+//           .baseClasses,
+//         targetClasses: searchNodes.find((node) => node.id === searchId3)?.data
+//           .baseClasses,
+//         targetHandle: COMPONENT_CLASS.QUERY,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId5,
+//         key: edgeId5,
+//         source: searchId3,
+//         target: searchId4,
+//         sourceClasses: searchNodes.find((node) => node.id === searchId3)?.data
+//           .baseClasses,
+//         targetClasses: searchNodes.find((node) => node.id === searchId4)?.data
+//           .baseClasses,
+//         targetHandle: COMPONENT_CLASS.RESULTS,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//     ] as ReactFlowEdge[],
+//   };
+// }
 
 // Utility fn to process workflow names from their presentable/readable titles
 // on the UI, to a valid name format.

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -19,6 +19,9 @@ import {
   Workflow,
   WorkflowTemplate,
   ModelFormValue,
+  WorkflowConfig,
+  WorkflowFormValues,
+  WorkflowSchema,
 } from '../../common';
 
 // Append 16 random characters
@@ -45,6 +48,22 @@ export function initComponentData(
 /*
  **************** Formik (form) utils **********************
  */
+
+// TODO: implement this. Refer to formikToComponentData() below
+export function uiConfigToFormik(config: WorkflowConfig): WorkflowFormValues {
+  const formikValues = {} as WorkflowFormValues;
+  formikValues['ingest'] = {};
+  formikValues['search'] = {};
+  return formikValues;
+}
+
+// TODO: implement this. Refer to getComponentSchema() below
+export function uiConfigToSchema(config: WorkflowConfig): WorkflowSchema {
+  const schemaObj = {} as { [key: string]: ObjectSchema<any> };
+  schemaObj['ingest'] = {} as ObjectSchema<any>;
+  schemaObj['search'] = {} as ObjectSchema<any>;
+  return yup.object(schemaObj) as WorkflowSchema;
+}
 
 // TODO: below, we are hardcoding to only persisting and validating create fields.
 // If we support both, we will need to dynamically update.


### PR DESCRIPTION
### Description

This PR adds several base interfaces used in the new form/configuration component on the workflow editor page. These are kept generic for now until more details of the form inputs are finalized from UX. The base `WorkflowConfig` will live under the new `config` field added in the `ui_metadata` interface. The main idea is this base `config` will capture all of the input in the form, and will be used for generating the 1/ form values, 2/ `yup` validation schema, and 3/ the ReactFlow workspace's nodes/edges. The initial conversion fns have been added and stubbed.

Additionally, the form & schema values in `ResizableWorkspace` (`formValues`, `formSchema`) have changed from the workspace-flow-based form/schema, to the new interfaces, since these will be the source of truth, instead of the workspace nodes/edges being the source of truth. For now, we will leave those interfaces as they may prove useful later on, such as when full drag-and-drop functionality is supported.

This PR also removes the default workspace flow values (the sets of nodes/edges) for the various use cases; now we will only care about providing default values under `config`, since these will determine the final workspace flow. Defaults/presets are stubbed and left empty for now.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
