### PR TITLE
Complete conversions between config <-> form <-> template

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -120,6 +120,19 @@ export const NEURAL_SPARSE_TOKENIZER_TRANSFORMER = {
 } as PretrainedSparseEncodingModel;
 
 /**
+ * Various constants pertaining to Workflow configs
+ */
+
+export enum PROCESSOR_TYPE {
+  MODEL = 'model_processor',
+}
+
+export enum MODEL_TYPE {
+  TEXT_EMBEDDING = 'text_embedding',
+  SPARSE_ENCODER = 'sparse_encoder',
+}
+
+/**
  * Various constants pertaining to the drag-and-drop UI components
  */
 export enum COMPONENT_CATEGORY {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -63,8 +63,8 @@ export type SearchConfig = {
 };
 
 export type WorkflowConfig = {
-  ingest?: IngestConfig;
-  search?: SearchConfig;
+  ingest: IngestConfig;
+  search: SearchConfig;
 };
 
 export type WorkflowFormValues = {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -6,7 +6,12 @@
 import { Node, Edge } from 'reactflow';
 import { FormikValues } from 'formik';
 import { ObjectSchema } from 'yup';
-import { COMPONENT_CLASS, COMPONENT_CATEGORY } from './constants';
+import {
+  COMPONENT_CLASS,
+  COMPONENT_CATEGORY,
+  PROCESSOR_TYPE,
+  MODEL_TYPE,
+} from './constants';
 
 export type Index = {
   name: string;
@@ -42,8 +47,16 @@ export interface IConfig {
   metadata?: IConfigMetadata;
 }
 
+export interface IProcessorConfig extends IConfig {
+  type: PROCESSOR_TYPE;
+}
+
+export interface IModelProcessorConfig extends IProcessorConfig {
+  modelType: MODEL_TYPE;
+}
+
 export type EnrichConfig = {
-  processors: IConfig[];
+  processors: IProcessorConfig[];
 };
 
 export type IndexConfig = {

--- a/public/configs/ingest_processors/base_ingest_processor.ts
+++ b/public/configs/ingest_processors/base_ingest_processor.ts
@@ -10,10 +10,8 @@ import { BaseConfig } from '../base_config';
  */
 export abstract class BaseIngestProcessor extends BaseConfig {
   name: string;
-  type: string;
   constructor() {
     super();
     this.name = '';
-    this.type = '';
   }
 }

--- a/public/configs/ingest_processors/model_processor.ts
+++ b/public/configs/ingest_processors/model_processor.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MODEL_TYPE } from '../../../common';
+import { BaseIngestProcessor } from './base_ingest_processor';
+
+/**
+ * A base model processor config
+ */
+export abstract class ModelProcessor extends BaseIngestProcessor {
+  type: MODEL_TYPE;
+  constructor() {
+    super();
+  }
+}

--- a/public/configs/ingest_processors/text_embedding_processor.ts
+++ b/public/configs/ingest_processors/text_embedding_processor.ts
@@ -3,18 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MODEL_TYPE } from '../../../common';
 import { generateId } from '../../utils';
-import { BaseIngestProcessor } from './base_ingest_processor';
+import { ModelProcessor } from './model_processor';
 
 /**
  * A specialized text embedding processor config
  */
-export class TextEmbeddingProcessor extends BaseIngestProcessor {
+export class TextEmbeddingProcessor extends ModelProcessor {
   constructor() {
     super();
     this.id = generateId('text_embedding_processor');
     this.name = 'Text embedding processor';
-    this.type = 'text_embedding';
+    this.type = MODEL_TYPE.TEXT_EMBEDDING;
     this.fields = [
       {
         label: 'Text Embedding Model',

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -19,6 +19,7 @@ import {
   ReactFlowEdge,
   WorkflowFormValues,
   WorkflowSchema,
+  WorkflowConfig,
 } from '../../../common';
 import {
   APP_PATH,
@@ -222,7 +223,10 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
         setIsSaving(false);
       } else {
         setFormValidOnSubmit(true);
-        const updatedConfig = formikToUiConfig(formikProps.values);
+        const updatedConfig = formikToUiConfig(
+          formikProps.values,
+          workflow?.ui_metadata?.config as WorkflowConfig
+        );
         const updatedWorkflow = {
           ...workflow,
           ui_metadata: {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -61,7 +61,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           </EuiFlexItem>
           <EuiFlexItem
             grow={true}
-            style={{ overflowY: 'scroll', maxHeight: '55vh' }}
+            style={{
+              overflowY: 'scroll',
+              overflowX: 'hidden',
+              maxHeight: '55vh',
+            }}
           >
             {selectedStep === CREATE_STEP.INGEST ? (
               <IngestInputs

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -10,7 +10,8 @@ import {
   START_FROM_SCRATCH_WORKFLOW_NAME,
   DEFAULT_NEW_WORKFLOW_NAME,
   UIState,
-  IConfig,
+  PROCESSOR_TYPE,
+  IModelProcessorConfig,
 } from '../../../../common';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
@@ -93,13 +94,15 @@ function fetchSemanticSearchMetadata(): UIState {
   // @ts-ignore
   baseState.config.ingest.enrich.processors = [
     {
+      type: PROCESSOR_TYPE.MODEL,
+      modelType: processor.type,
       id: processor.id,
       fields: processor.fields,
       metadata: {
         label: processor.name,
       },
     },
-  ] as IConfig[];
+  ] as IModelProcessorConfig;
   return baseState;
 }
 

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -29,6 +29,7 @@ import {
   WorkflowSchemaObj,
   IConfigField,
   IndexConfig,
+  IProcessorConfig,
 } from '../../common';
 
 // Append 16 random characters
@@ -78,14 +79,19 @@ function enrichConfigToFormik(enrichConfig: EnrichConfig): FormikValues {
   let formValues = {} as FormikValues;
 
   enrichConfig.processors.forEach((processorConfig) => {
-    let fieldValues = {} as FormikValues;
-    processorConfig.fields.forEach((field) => {
-      fieldValues[field.id] = field.value || getInitialValue(field.type);
-    });
-    formValues[processorConfig.id] = fieldValues;
+    formValues[processorConfig.id] = processorConfigToFormik(processorConfig);
   });
-
   return formValues;
+}
+
+export function processorConfigToFormik(
+  processorConfig: IProcessorConfig
+): FormikValues {
+  const fieldValues = {} as FormikValues;
+  processorConfig.fields.forEach((field) => {
+    fieldValues[field.id] = field.value || getInitialValue(field.type);
+  });
+  return fieldValues;
 }
 
 function indexConfigToFormik(indexConfig: IndexConfig): FormikValues {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -7,6 +7,7 @@ import { FormikValues } from 'formik';
 import { EuiFilterSelectItem } from '@elastic/eui';
 import { Schema, ObjectSchema } from 'yup';
 import * as yup from 'yup';
+import { cloneDeep } from 'lodash';
 import {
   IComponent,
   IComponentData,
@@ -67,7 +68,6 @@ function ingestConfigToFormik(
 ): FormikValues {
   let ingestFormikValues = {} as FormikValues;
   if (ingestConfig) {
-    // TODO: implement for the other sub-categories
     ingestFormikValues['enrich'] = enrichConfigToFormik(ingestConfig.enrich);
     ingestFormikValues['index'] = indexConfigToFormik(ingestConfig.index);
   }
@@ -103,16 +103,60 @@ function searchConfigToFormik(
   return searchFormikValues;
 }
 
-// TODO: this may need more tuning. Currently this is force-converting the FormikValues obj
-// into a WorkflowConfig obj. It takes the assumption the form will include all possible
-// config values, including defaults.
+// Injecting all of the form values into the config
 export function formikToUiConfig(
-  formValues: WorkflowFormValues
+  formValues: WorkflowFormValues,
+  existingConfig: WorkflowConfig
 ): WorkflowConfig {
-  const workflowConfig = {} as WorkflowConfig;
-  workflowConfig['ingest'] = formValues.ingest as IngestConfig;
-  workflowConfig['search'] = formValues.search as SearchConfig;
-  return workflowConfig;
+  let updatedConfig = cloneDeep(existingConfig);
+  updatedConfig['ingest'] = formikToIngestUiConfig(
+    formValues.ingest,
+    updatedConfig.ingest
+  );
+  updatedConfig['search'] = {} as SearchConfig;
+
+  return {
+    ...updatedConfig,
+    ingest: formikToIngestUiConfig(formValues.ingest, updatedConfig.ingest),
+  };
+}
+
+function formikToIngestUiConfig(
+  ingestFormValues: FormikValues,
+  existingConfig: IngestConfig
+): IngestConfig {
+  return {
+    ...existingConfig,
+    enrich: formikToEnrichUiConfig(
+      ingestFormValues['enrich'],
+      existingConfig.enrich
+    ),
+    index: formikToIndexUiConfig(
+      ingestFormValues['index'],
+      existingConfig.index
+    ),
+  };
+}
+
+function formikToEnrichUiConfig(
+  enrichFormValues: FormikValues,
+  existingConfig: EnrichConfig
+): EnrichConfig {
+  existingConfig.processors.forEach((processorConfig) => {
+    const processorFormValues = enrichFormValues[processorConfig.id];
+    processorConfig.fields.forEach((processorField) => {
+      processorField.value = processorFormValues[processorField.id];
+    });
+  });
+  return existingConfig;
+}
+
+function formikToIndexUiConfig(
+  indexFormValues: FormikValues,
+  existingConfig: IndexConfig
+): IndexConfig {
+  existingConfig['name'].value = indexFormValues['name'];
+  return existingConfig;
 }
 
 /*


### PR DESCRIPTION
### Description

This PR completes the initial refactoring to support basic conversions of the config data to finally produce an end-to-end functional workflow. Specifically:
- implements logic to convert form values -> UI config by injecting the values
- implements logic to convert UI config -> final workflow template
- updates few existing interfaces to include sufficient information to create the workflow template. For example, the type of model (text embedding vs. sparse encoder vs. other) influences the template construction
- removes legacy logic for template conversion. The rest of what can/will be removed is tracked in #155 

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
