### PR TITLE
Add initial logic to generate ReactFlow workspace

### DIFF
--- a/public/component_types/other/results.tsx
+++ b/public/component_types/other/results.tsx
@@ -16,5 +16,6 @@ export class Results extends BaseComponent {
     this.type = COMPONENT_CLASS.RESULTS;
     this.label = 'Results';
     this.description = 'OpenSearch results';
+    this.inputs = [{ id: 'input', label: 'Input', acceptMultiple: false }];
   }
 }

--- a/public/component_types/transformer/index.ts
+++ b/public/component_types/transformer/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from './ml_transformer';
 export * from './text_embedding_transformer';
 export * from './sparse_encoder_transformer';
 export * from './results_transformer';

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -23,6 +23,7 @@ import {
   ReactFlowComponent,
   ReactFlowEdge,
   Workflow,
+  WorkflowConfig,
 } from '../../../../common';
 import {
   IngestGroupComponent,
@@ -30,6 +31,7 @@ import {
   WorkspaceComponent,
 } from './workspace_components';
 import { DeletableEdge } from './workspace_edge';
+import { uiConfigToWorkspaceFlow } from '../../../utils';
 
 // styling
 import 'reactflow/dist/style.css';
@@ -107,12 +109,15 @@ export function Workspace(props: WorkspaceProps) {
     [setEdges]
   );
 
-  // Initialization. Set the nodes and edges to an existing workflow state,
+  // Initialization. Generate the nodes and edges based on the workflow config.
   useEffect(() => {
     const workflow = { ...props.workflow };
-    if (workflow?.ui_metadata?.workspace_flow) {
-      setNodes(workflow.ui_metadata.workspace_flow.nodes);
-      setEdges(workflow.ui_metadata.workspace_flow.edges);
+    if (workflow?.ui_metadata?.config) {
+      const proposedWorkspaceFlow = uiConfigToWorkspaceFlow(
+        workflow.ui_metadata?.config as WorkflowConfig
+      );
+      setNodes(proposedWorkspaceFlow.nodes);
+      setEdges(proposedWorkspaceFlow.edges);
     }
   }, [props.workflow]);
 
@@ -141,6 +146,7 @@ export function Workspace(props: WorkspaceProps) {
               onConnect={onConnect}
               className="reactflow-workspace"
               fitView
+              minZoom={0.2}
               edgesUpdatable={!props.readonly}
               edgesFocusable={!props.readonly}
               nodesDraggable={!props.readonly}

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -121,181 +121,180 @@ function fetchSemanticSearchMetadata(): UIState {
       },
     },
   ] as IModelProcessorConfig;
-  baseState.workspace_flow = fetchSemanticSearchWorkspaceFlow();
   return baseState;
 }
 
-function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
-  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
-  const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
-  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
-  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
-  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
-  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
-  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
-  const edgeId0 = generateId('edge');
-  const edgeId1 = generateId('edge');
-  const edgeId2 = generateId('edge');
-  const edgeId3 = generateId('edge');
+// function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
+//   const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+//   const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+//   const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+//   const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+//   const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+//   const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+//   const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+//   const edgeId0 = generateId('edge');
+//   const edgeId1 = generateId('edge');
+//   const edgeId2 = generateId('edge');
+//   const edgeId3 = generateId('edge');
 
-  const ingestNodes = [
-    {
-      id: ingestGroupId,
-      position: { x: 400, y: 400 },
-      type: NODE_CATEGORY.INGEST_GROUP,
-      data: { label: COMPONENT_CATEGORY.INGEST },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__ingest',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new Document().toObj(), ingestId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toObj(),
-        ingestId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: ingestId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: ingestGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
-  const searchNodes = [
-    {
-      id: searchGroupId,
-      position: { x: 400, y: 1000 },
-      type: NODE_CATEGORY.SEARCH_GROUP,
-      data: { label: COMPONENT_CATEGORY.SEARCH },
-      style: {
-        width: 1300,
-        height: 400,
-      },
-      className: 'reactflow__group-node__search',
-      selectable: true,
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId0,
-      position: { x: 100, y: 70 },
-      data: initComponentData(new NeuralQuery().toObj(), searchId0),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId1,
-      position: { x: 500, y: 70 },
-      data: initComponentData(
-        new TextEmbeddingTransformer().toPlaceholderObj(),
-        searchId1
-      ),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-    {
-      id: searchId2,
-      position: { x: 900, y: 70 },
-      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
-      type: NODE_CATEGORY.CUSTOM,
-      parentNode: searchGroupId,
-      extent: 'parent',
-      draggable: true,
-      deletable: false,
-    },
-  ] as ReactFlowComponent[];
+//   const ingestNodes = [
+//     {
+//       id: ingestGroupId,
+//       position: { x: 400, y: 400 },
+//       type: NODE_CATEGORY.INGEST_GROUP,
+//       data: { label: COMPONENT_CATEGORY.INGEST },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__ingest',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new Document().toObj(), ingestId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toObj(),
+//         ingestId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: ingestId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: ingestGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
+//   const searchNodes = [
+//     {
+//       id: searchGroupId,
+//       position: { x: 400, y: 1000 },
+//       type: NODE_CATEGORY.SEARCH_GROUP,
+//       data: { label: COMPONENT_CATEGORY.SEARCH },
+//       style: {
+//         width: 1300,
+//         height: 400,
+//       },
+//       className: 'reactflow__group-node__search',
+//       selectable: true,
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId0,
+//       position: { x: 100, y: 70 },
+//       data: initComponentData(new NeuralQuery().toObj(), searchId0),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId1,
+//       position: { x: 500, y: 70 },
+//       data: initComponentData(
+//         new TextEmbeddingTransformer().toPlaceholderObj(),
+//         searchId1
+//       ),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//     {
+//       id: searchId2,
+//       position: { x: 900, y: 70 },
+//       data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+//       type: NODE_CATEGORY.CUSTOM,
+//       parentNode: searchGroupId,
+//       extent: 'parent',
+//       draggable: true,
+//       deletable: false,
+//     },
+//   ] as ReactFlowComponent[];
 
-  return {
-    nodes: [...ingestNodes, ...searchNodes],
-    edges: [
-      {
-        id: edgeId0,
-        key: edgeId0,
-        source: ingestId0,
-        target: ingestId1,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId1,
-        key: edgeId1,
-        source: ingestId1,
-        target: ingestId2,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId2,
-        key: edgeId2,
-        source: searchId0,
-        target: searchId1,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-      {
-        id: edgeId3,
-        key: edgeId3,
-        source: searchId1,
-        target: searchId2,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          width: 20,
-          height: 20,
-        },
-        zIndex: 2,
-        deletable: false,
-      },
-    ] as ReactFlowEdge[],
-  };
-}
+//   return {
+//     nodes: [...ingestNodes, ...searchNodes],
+//     edges: [
+//       {
+//         id: edgeId0,
+//         key: edgeId0,
+//         source: ingestId0,
+//         target: ingestId1,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId1,
+//         key: edgeId1,
+//         source: ingestId1,
+//         target: ingestId2,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId2,
+//         key: edgeId2,
+//         source: searchId0,
+//         target: searchId1,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//       {
+//         id: edgeId3,
+//         key: edgeId3,
+//         source: searchId1,
+//         target: searchId2,
+//         markerEnd: {
+//           type: MarkerType.ArrowClosed,
+//           width: 20,
+//           height: 20,
+//         },
+//         zIndex: 2,
+//         deletable: false,
+//       },
+//     ] as ReactFlowEdge[],
+//   };
+// }
 
 // function fetchNeuralSparseSearchWorkspaceFlow(): WorkspaceFlowState {
 //   const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -27,7 +27,26 @@ import {
   IConfigField,
   IndexConfig,
   IProcessorConfig,
+  WorkspaceFlowState,
+  ReactFlowEdge,
+  ReactFlowComponent,
+  COMPONENT_CLASS,
+  COMPONENT_CATEGORY,
+  NODE_CATEGORY,
+  IConfig,
+  IModelProcessorConfig,
+  PROCESSOR_TYPE,
+  MODEL_TYPE,
 } from '../../common';
+import {
+  Document,
+  KnnIndexer,
+  MLTransformer,
+  NeuralQuery,
+  SparseEncoderTransformer,
+  TextEmbeddingTransformer,
+} from '../component_types';
+import { MarkerType } from 'reactflow';
 
 // Append 16 random characters
 export function generateId(prefix: string): string {
@@ -305,4 +324,432 @@ export function getStateOptions(): EuiFilterSelectItem[] {
       checked: 'on',
     } as EuiFilterSelectItem,
   ];
+}
+
+/*
+ **************** ReactFlow workspace utils **********************
+ */
+
+export function uiConfigToWorkspaceFlow(
+  config: WorkflowConfig
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  const ingestWorkspaceFlow = ingestConfigToWorkspaceFlow(config.ingest);
+  nodes.push(...ingestWorkspaceFlow.nodes);
+  edges.push(...ingestWorkspaceFlow.edges);
+
+  const searchWorkspaceFlow = searchConfigToWorkspaceFlow(config.search);
+  nodes.push(...searchWorkspaceFlow.nodes);
+  edges.push(...searchWorkspaceFlow.edges);
+
+  return {
+    nodes,
+    edges,
+  };
+}
+
+function ingestConfigToWorkspaceFlow(
+  ingestConfig: IngestConfig
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  // Parent ingest node
+  const parentNode = {
+    id: generateId(COMPONENT_CATEGORY.INGEST),
+    position: { x: 400, y: 400 },
+    type: NODE_CATEGORY.INGEST_GROUP,
+    data: { label: COMPONENT_CATEGORY.INGEST },
+    style: {
+      width: 1300,
+      height: 400,
+    },
+    className: 'reactflow__group-node__ingest',
+    selectable: false,
+    draggable: false,
+    deletable: false,
+  } as ReactFlowComponent;
+
+  nodes.push(parentNode);
+
+  // Get nodes from the sub-configurations
+  const sourceWorkspaceFlow = sourceConfigToWorkspaceFlow(
+    ingestConfig.source,
+    parentNode.id
+  );
+  const enrichWorkspaceFlow = enrichConfigToWorkspaceFlow(
+    ingestConfig.enrich,
+    parentNode.id
+  );
+  const indexWorkspaceFlow = indexConfigToWorkspaceFlow(
+    ingestConfig.index,
+    parentNode.id
+  );
+
+  nodes.push(
+    ...sourceWorkspaceFlow.nodes,
+    ...enrichWorkspaceFlow.nodes,
+    ...indexWorkspaceFlow.nodes
+  );
+  edges.push(
+    ...sourceWorkspaceFlow.edges,
+    ...enrichWorkspaceFlow.edges,
+    ...indexWorkspaceFlow.edges
+  );
+
+  // Link up the set of localized nodes/edges per sub-workflow
+  edges.push(
+    ...getIngestEdges(
+      sourceWorkspaceFlow,
+      enrichWorkspaceFlow,
+      indexWorkspaceFlow
+    )
+  );
+
+  return {
+    nodes,
+    edges,
+  };
+}
+
+// TODO: make more generic.
+// Currently hardcoding a single Document node as the source.
+function sourceConfigToWorkspaceFlow(
+  sourceConfig: IConfig,
+  parentNodeId: string
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  const docNodeId = generateId(COMPONENT_CLASS.DOCUMENT);
+  nodes.push({
+    id: docNodeId,
+    position: { x: 100, y: 70 },
+    data: initComponentData(new Document().toObj(), docNodeId),
+    type: NODE_CATEGORY.CUSTOM,
+    parentNode: parentNodeId,
+    extent: 'parent',
+    draggable: true,
+    deletable: false,
+  });
+
+  return {
+    nodes,
+    edges,
+  };
+}
+
+function enrichConfigToWorkspaceFlow(
+  enrichConfig: EnrichConfig,
+  parentNodeId: string
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  // TODO: few assumptions are made here, such as there will always be
+  // a single model-related processor. In the future make this more flexible and generic.
+  const modelProcessorConfig = enrichConfig.processors.find(
+    (processorConfig) => processorConfig.type === PROCESSOR_TYPE.MODEL
+  ) as IModelProcessorConfig;
+
+  let transformer = {} as MLTransformer;
+  let transformerNodeId = '';
+  switch (modelProcessorConfig.modelType) {
+    case MODEL_TYPE.TEXT_EMBEDDING: {
+      transformer = new TextEmbeddingTransformer();
+      transformerNodeId = generateId(
+        COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER
+      );
+      break;
+    }
+    case MODEL_TYPE.SPARSE_ENCODER: {
+      transformer = new SparseEncoderTransformer();
+      transformerNodeId = generateId(
+        COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER
+      );
+      break;
+    }
+  }
+
+  nodes.push({
+    id: transformerNodeId,
+    position: { x: 500, y: 70 },
+    data: initComponentData(transformer, transformerNodeId),
+    type: NODE_CATEGORY.CUSTOM,
+    parentNode: parentNodeId,
+    extent: 'parent',
+    draggable: true,
+    deletable: false,
+  });
+  return {
+    nodes,
+    edges,
+  };
+}
+
+function indexConfigToWorkspaceFlow(
+  indexConfig: IndexConfig,
+  parentNodeId: string
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  const indexNodeId = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  nodes.push({
+    id: indexNodeId,
+    position: { x: 900, y: 70 },
+    data: initComponentData(new KnnIndexer().toObj(), indexNodeId),
+    type: NODE_CATEGORY.CUSTOM,
+    parentNode: parentNodeId,
+    extent: 'parent',
+    draggable: true,
+    deletable: false,
+  });
+
+  return {
+    nodes,
+    edges,
+  };
+}
+
+// Given the set of localized flows per sub-configuration, generate the global ingest-level edges.
+// This takes the assumption the flow is linear, and all sub-configuration flows are fully connected.
+function getIngestEdges(
+  sourceFlow: WorkspaceFlowState,
+  enrichFlow: WorkspaceFlowState,
+  indexFlow: WorkspaceFlowState
+): ReactFlowEdge[] {
+  const startAndEndNodesSource = getStartAndEndNodes(sourceFlow);
+  const startAndEndNodesEnrich = getStartAndEndNodes(enrichFlow);
+  const startAndEndNodesIndex = getStartAndEndNodes(indexFlow);
+
+  const sourceToEnrichEdgeId = generateId('edge');
+  const enrichToIndexEdgeId = generateId('edge');
+
+  return [
+    {
+      id: sourceToEnrichEdgeId,
+      key: sourceToEnrichEdgeId,
+      source: startAndEndNodesSource.endNode.id,
+      target: startAndEndNodesEnrich.startNode.id,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 20,
+        height: 20,
+      },
+      zIndex: 2,
+      deletable: false,
+    },
+    {
+      id: enrichToIndexEdgeId,
+      key: enrichToIndexEdgeId,
+      source: startAndEndNodesEnrich.endNode.id,
+      target: startAndEndNodesIndex.startNode.id,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 20,
+        height: 20,
+      },
+      zIndex: 2,
+      deletable: false,
+    },
+  ] as ReactFlowEdge[];
+}
+
+// TODO: implement this
+function searchConfigToWorkspaceFlow(
+  searchConfig: SearchConfig
+): WorkspaceFlowState {
+  const nodes = [] as ReactFlowComponent[];
+  const edges = [] as ReactFlowEdge[];
+
+  return {
+    nodes,
+    edges,
+  };
+}
+
+// Get start and end nodes in a flow. This assumes the flow is linear and fully connected,
+// such that there will always be a single start and single end node.
+function getStartAndEndNodes(
+  workspaceFlow: WorkspaceFlowState
+): { startNode: ReactFlowComponent; endNode: ReactFlowComponent } {
+  if (workspaceFlow.nodes.length === 1) {
+    return {
+      startNode: workspaceFlow.nodes[0],
+      endNode: workspaceFlow.nodes[0],
+    };
+  }
+
+  const nodeIdsWithTarget = workspaceFlow.edges.map((edge) => edge.target);
+  const nodeIdsWithSource = workspaceFlow.edges.map((edge) => edge.source);
+
+  return {
+    startNode: workspaceFlow.nodes.filter(
+      (node) => !nodeIdsWithTarget.includes(node.id)
+    )[0],
+    endNode: workspaceFlow.nodes.filter(
+      (node) => !nodeIdsWithSource.includes(node.id)
+    )[0],
+  };
+}
+
+function fetchSemanticSearchWorkspaceFlow(): WorkspaceFlowState {
+  const ingestId0 = generateId(COMPONENT_CLASS.DOCUMENT);
+  const ingestId1 = generateId(COMPONENT_CLASS.TEXT_EMBEDDING_TRANSFORMER);
+  const ingestId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  const ingestGroupId = generateId(COMPONENT_CATEGORY.INGEST);
+  const searchGroupId = generateId(COMPONENT_CATEGORY.SEARCH);
+  const searchId0 = generateId(COMPONENT_CLASS.NEURAL_QUERY);
+  const searchId1 = generateId(COMPONENT_CLASS.SPARSE_ENCODER_TRANSFORMER);
+  const searchId2 = generateId(COMPONENT_CLASS.KNN_INDEXER);
+  const edgeId0 = generateId('edge');
+  const edgeId1 = generateId('edge');
+  const edgeId2 = generateId('edge');
+  const edgeId3 = generateId('edge');
+
+  const ingestNodes = [
+    {
+      id: ingestId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new Document().toObj(), ingestId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: ingestId1,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new TextEmbeddingTransformer().toObj(),
+        ingestId1
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: ingestId2,
+      position: { x: 900, y: 70 },
+      data: initComponentData(new KnnIndexer().toObj(), ingestId2),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: ingestGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
+  const searchNodes = [
+    {
+      id: searchGroupId,
+      position: { x: 400, y: 1000 },
+      type: NODE_CATEGORY.SEARCH_GROUP,
+      data: { label: COMPONENT_CATEGORY.SEARCH },
+      style: {
+        width: 1300,
+        height: 400,
+      },
+      className: 'reactflow__group-node__search',
+      selectable: true,
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId0,
+      position: { x: 100, y: 70 },
+      data: initComponentData(new NeuralQuery().toObj(), searchId0),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId1,
+      position: { x: 500, y: 70 },
+      data: initComponentData(
+        new TextEmbeddingTransformer().toPlaceholderObj(),
+        searchId1
+      ),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+    {
+      id: searchId2,
+      position: { x: 900, y: 70 },
+      data: initComponentData(new KnnIndexer().toPlaceholderObj(), searchId2),
+      type: NODE_CATEGORY.CUSTOM,
+      parentNode: searchGroupId,
+      extent: 'parent',
+      draggable: true,
+      deletable: false,
+    },
+  ] as ReactFlowComponent[];
+
+  return {
+    nodes: [...ingestNodes, ...searchNodes],
+    edges: [
+      {
+        id: edgeId0,
+        key: edgeId0,
+        source: ingestId0,
+        target: ingestId1,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId1,
+        key: edgeId1,
+        source: ingestId1,
+        target: ingestId2,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId2,
+        key: edgeId2,
+        source: searchId0,
+        target: searchId1,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+      {
+        id: edgeId3,
+        key: edgeId3,
+        source: searchId1,
+        target: searchId2,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+        },
+        zIndex: 2,
+        deletable: false,
+      },
+    ] as ReactFlowEdge[],
+  };
 }


### PR DESCRIPTION
### Description

This PR sets up the basic conversion logic to generate the ReactFlow workspace's nodes/edges based on a WorkflowConfig. As an example, given a config with ingest processors defined under `ingest.enrich`, UI will generate a Transformer component and connect it between the initial request, and the index, to visualize the data flow. Example in screenshot below. 

More specifics:
- updates the nodes/edges initialization in `Workflow` to be dynamically generated based on the `config`, instead of using the persisted `workspace_flow`. (we may deprecate `workspace_flow` as we may not need to persist that for now, until we want drag-and-drop support)
- implements `uiConfigToWorkspaceFlow` and all of its sub/helper fns. Some are implemented and some are stubbed, will be filled out as the config details and fields we want to support are finalized. At a high level, we will have a few static/consistent workspace components for all workflows, such as an 'index' component under both 'Ingest' and 'Search' flows. As users add processors under ingest/search pipelines, we will dynamically add components and link them up in the workspace. 

Screenshot:

![Screenshot](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/6e96e1d3-137c-408d-8d7f-71a0774e167c)

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
