### PR TITLE
Update create workflow, update workflow, and form validation logic

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -176,7 +176,6 @@ export enum COMPONENT_CLASS {
 /**
  * MISCELLANEOUS
  */
-export const NEW_WORKFLOW_ID_URL = 'new';
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -18,25 +18,16 @@ import {
 } from '../../../../common';
 
 interface WorkflowDetailHeaderProps {
-  isNewWorkflow: boolean;
   workflow?: Workflow;
 }
 
 export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   function getTitle() {
-    return props.workflow
-      ? props.workflow.name
-      : props.isNewWorkflow && !props.workflow
-      ? DEFAULT_NEW_WORKFLOW_NAME
-      : '';
+    return props.workflow ? props.workflow.name : DEFAULT_NEW_WORKFLOW_NAME;
   }
 
   function getState() {
-    return props.workflow?.state
-      ? props.workflow.state
-      : props.isNewWorkflow
-      ? DEFAULT_NEW_WORKFLOW_STATE
-      : null;
+    return props.workflow ? props.workflow.state : DEFAULT_NEW_WORKFLOW_STATE;
   }
 
   return (

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -13,13 +13,11 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiResizableContainer,
-  EuiTitle,
 } from '@elastic/eui';
 import { getCore } from '../../services';
 
 import {
   Workflow,
-  WORKFLOW_STATE,
   WorkflowFormValues,
   WorkflowSchema,
   WorkflowConfig,
@@ -48,7 +46,6 @@ import '../../global-styles.scss';
 import { Tools } from './tools';
 
 interface ResizableWorkspaceProps {
-  isNewWorkflow: boolean;
   workflow?: Workflow;
 }
 
@@ -66,7 +63,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Overall workspace state
   const { isDirty } = useSelector((state: AppState) => state.workspace);
   const { loading } = useSelector((state: AppState) => state.workflows);
-  const [isFirstSave, setIsFirstSave] = useState<boolean>(props.isNewWorkflow);
 
   // Workflow state
   const [workflow, setWorkflow] = useState<Workflow | undefined>(
@@ -104,56 +100,20 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsToolsPanelOpen(!isToolsPanelOpen);
   };
 
-  // Save/provision/deprovision button state
-  const isSaveable =
-    props.workflow !== undefined && (isFirstSave ? true : isDirty);
-  const isProvisionable =
-    props.workflow !== undefined &&
-    !isDirty &&
-    !props.isNewWorkflow &&
-    formValidOnSubmit &&
-    props.workflow?.state === WORKFLOW_STATE.NOT_STARTED;
-  const isDeprovisionable =
-    props.workflow !== undefined &&
-    !props.isNewWorkflow &&
-    props.workflow?.state !== WORKFLOW_STATE.NOT_STARTED;
-  // TODO: maybe remove this field. It depends on final UX if we want the
-  // workspace to be readonly once provisioned or not.
-  const readonly = props.workflow === undefined || isDeprovisionable;
-
-  // Loading state
-  const [isProvisioning, setIsProvisioning] = useState<boolean>(false);
-  const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
-  const [isSaving, setIsSaving] = useState<boolean>(false);
-  const isCreating = isSaving && props.isNewWorkflow;
-  const isLoadingGlobal =
-    loading || isProvisioning || isDeprovisioning || isSaving || isCreating;
-
   // Hook to update some default values for the workflow, if applicable.
   // We need to handle different scenarios:
-  // 1. Rendering backend-only-created workflow / an already-created workflow with no ui_metadata.
+  // 1. Rendering backend-only-created workflow / an existing workflow with no ui_metadata.
   //    In this case, we revert to the home page with a warn toast that we don't support it, for now.
-  //    This is because we initially have guardrails and a static set of readonly nodes/edges that we handle.
-  // 2. Rendering empty/null workflow, if refreshing the editor page where there is no cached workflow and
-  //    no workflow ID in the URL.
-  //    In this case, revert to home page and a warn toast that we don't support it for now.
-  //    This is because we initially don't support building / drag-and-drop components.
-  // 3. Rendering a cached workflow via navigation from create workflow tab
-  // 4. Rendering a created workflow with ui_metadata.
+  // 2. Rendering a created workflow with ui_metadata.
   //    In these cases, just render what is persisted, no action needed.
   useEffect(() => {
     const missingUiFlow =
       props.workflow && !props.workflow?.ui_metadata?.config;
-    const missingCachedWorkflow = props.isNewWorkflow && !props.workflow;
-    if (missingUiFlow || missingCachedWorkflow) {
+    if (missingUiFlow) {
       history.replace(APP_PATH.WORKFLOWS);
-      if (missingCachedWorkflow) {
-        getCore().notifications.toasts.addWarning('No workflow found');
-      } else {
-        getCore().notifications.toasts.addWarning(
-          `There is no ui_metadata for workflow: ${props.workflow?.name}`
-        );
-      }
+      getCore().notifications.toasts.addWarning(
+        `There is no ui_metadata for workflow: ${props.workflow?.name}`
+      );
     } else {
       setWorkflow(props.workflow);
     }
@@ -191,7 +151,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     formikProps.validateForm().then((validationResults: {}) => {
       if (Object.keys(validationResults).length > 0) {
         setFormValidOnSubmit(false);
-        setIsSaving(false);
       } else {
         setFormValidOnSubmit(true);
         const updatedConfig = formikToUiConfig(
@@ -214,12 +173,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             })
           )
             .unwrap()
-            .then((result) => {
-              setIsSaving(false);
-            })
-            .catch((error: any) => {
-              setIsSaving(false);
-            });
+            .then((result) => {})
+            .catch((error: any) => {});
         } else {
           dispatch(createWorkflow(updatedWorkflow))
             .unwrap()
@@ -228,9 +183,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
               history.replace(`${APP_PATH.WORKFLOWS}/${workflow.id}`);
               history.go(0);
             })
-            .catch((error: any) => {
-              setIsSaving(false);
-            });
+            .catch((error: any) => {});
         }
       }
     });

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -21,7 +21,6 @@ import { ResizableWorkspace } from './resizable_workspace';
 import {
   DEFAULT_NEW_WORKFLOW_NAME,
   FETCH_ALL_QUERY_BODY,
-  NEW_WORKFLOW_ID_URL,
 } from '../../../common';
 
 // styling
@@ -39,24 +38,18 @@ interface WorkflowDetailProps
  * The workflow details page. This is where users will configure, create, and
  * test their created workflows. Additionally, can be used to load existing workflows
  * to view details and/or make changes to them.
- * New, unsaved workflows are cached in the redux store and displayed here.
  */
 
 export function WorkflowDetail(props: WorkflowDetailProps) {
   const dispatch = useAppDispatch();
-  const { workflows, cachedWorkflow, errorMessage } = useSelector(
+  const { workflows, errorMessage } = useSelector(
     (state: AppState) => state.workflows
   );
 
   // selected workflow state
   const workflowId = props.match?.params?.workflowId;
-  const isNewWorkflow = workflowId === NEW_WORKFLOW_ID_URL;
-  const workflow = isNewWorkflow ? cachedWorkflow : workflows[workflowId];
-  const workflowName = workflow
-    ? workflow.name
-    : isNewWorkflow && !workflow
-    ? DEFAULT_NEW_WORKFLOW_NAME
-    : '';
+  const workflow = workflows[workflowId];
+  const workflowName = workflow ? workflow.name : DEFAULT_NEW_WORKFLOW_NAME;
 
   useEffect(() => {
     getCore().chrome.setBreadcrumbs([
@@ -67,12 +60,11 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   });
 
   // On initial load:
-  // - fetch workflow, if there is an existing workflow ID
+  // - fetch workflow
   // - fetch available models as their IDs may be used when building flows
   useEffect(() => {
-    if (!isNewWorkflow) {
-      dispatch(getWorkflow(workflowId));
-    }
+    dispatch(getWorkflow(workflowId));
+
     dispatch(searchModels(FETCH_ALL_QUERY_BODY));
   }, []);
 
@@ -88,15 +80,9 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     <ReactFlowProvider>
       <EuiPage>
         <EuiPageBody className="workflow-detail stretch-relative">
-          <WorkflowDetailHeader
-            workflow={workflow}
-            isNewWorkflow={isNewWorkflow}
-          />
+          <WorkflowDetailHeader workflow={workflow} />
           <ReactFlowProvider>
-            <ResizableWorkspace
-              isNewWorkflow={isNewWorkflow}
-              workflow={workflow}
-            />
+            <ResizableWorkspace workflow={workflow} />
           </ReactFlowProvider>
         </EuiPageBody>
       </EuiPage>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -13,6 +13,8 @@ import { Workflow } from '../../../../../common';
 interface IngestInputsProps {
   workflow: Workflow;
   onFormChange: () => void;
+  ingestDocs: {}[];
+  setIngestDocs: (docs: {}[]) => void;
 }
 
 /**
@@ -22,7 +24,10 @@ export function IngestInputs(props: IngestInputsProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <SourceData />
+        <SourceData
+          ingestDocs={props.ingestDocs}
+          setIngestDocs={props.setIngestDocs}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -3,15 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import {
+  EuiCodeEditor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+} from '@elastic/eui';
 
-interface SourceDataProps {}
+interface SourceDataProps {
+  ingestDocs: {}[];
+  setIngestDocs: (docs: {}[]) => void;
+}
 
 /**
  * Input component for configuring the source data for ingest.
  */
 export function SourceData(props: SourceDataProps) {
+  const [jsonStr, setJsonStr] = useState<string>('{}');
+
+  useEffect(() => {
+    try {
+      const json = JSON.parse(jsonStr);
+      props.setIngestDocs([json]);
+    } catch (e) {}
+  }, [jsonStr]);
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
@@ -19,8 +36,23 @@ export function SourceData(props: SourceDataProps) {
           <h4>Source data</h4>
         </EuiTitle>
       </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiText grow={false}>TODO</EuiText>
+      <EuiFlexItem grow={false}>
+        <EuiCodeEditor
+          mode="json"
+          theme="textmate"
+          width="100%"
+          height="25vh"
+          value={jsonStr}
+          onChange={(input) => {
+            setJsonStr(input);
+          }}
+          readOnly={false}
+          setOptions={{
+            fontSize: '14px',
+          }}
+          aria-label="Code Editor"
+          tabSize={2}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import { FormikProps } from 'formik';
 import {
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -16,7 +18,7 @@ import {
 import { Workflow, WorkflowFormValues } from '../../../../common';
 import { IngestInputs } from './ingest_inputs';
 import { SearchInputs } from './search_inputs';
-import { FormikProps } from 'formik';
+import { useAppDispatch } from '../../../store';
 
 // styling
 import '../workspace/workspace-styles.scss';
@@ -39,11 +41,47 @@ export enum CREATE_STEP {
  */
 
 export function WorkflowInputs(props: WorkflowInputsProps) {
+  const dispatch = useAppDispatch();
+
+  // selected step state
   const [selectedStep, setSelectedStep] = useState<CREATE_STEP>(
     CREATE_STEP.INGEST
   );
 
-  useEffect(() => {}, [selectedStep]);
+  // ingestion data state. We need to persist separately from the form, since
+  // we do not need/want to persist this in form state or in backend
+  const [ingestDocs, setIngestDocs] = useState<{}[]>([]);
+
+  // TODO: running props.validateAndSubmit(props.formikProps) will need to be ran before every ingest and
+  // search, if the form is dirty / values have changed. This will update the workflow if needed.
+  // Note that the temporary data (the ingest docs and the search query) will not need to be persisted
+  // in the form (need to confirm if query-side / using search template, will need to persist something)
+  function validateAndRunIngestion(): void {
+    console.log('running ingestion...');
+    try {
+      props.validateAndSubmit(props.formikProps);
+      const indexName = props.formikProps.values.ingest.index.name;
+      const doc = ingestDocs[0];
+      // dispatch(ingest({ index: indexName, doc: docObj }))
+      //   .unwrap()
+      //   .then(async (resp) => {
+      //     //setResponse(result);
+      //     console.log('response: ', resp);
+      //   })
+      //   .catch((error: any) => {
+      //     getCore().notifications.toasts.addDanger(error);
+      //     // setResponse({});
+      //     console.log('error: ', error);
+      //   });
+    } catch (err) {
+      console.log('error: ', err);
+    }
+  }
+
+  function validateAndRunQuery(): void {
+    console.log('running query...');
+    props.validateAndSubmit(props.formikProps);
+  }
 
   return (
     <EuiPanel paddingSize="m" grow={true} className="workspace-panel">
@@ -73,6 +111,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               <IngestInputs
                 workflow={props.workflow}
                 onFormChange={props.onFormChange}
+                ingestDocs={ingestDocs}
+                setIngestDocs={setIngestDocs}
               />
             ) : (
               <SearchInputs workflow={props.workflow} />
@@ -86,30 +126,42 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               <EuiFlexItem>
                 <EuiFlexGroup direction="row" justifyContent="flexEnd">
                   {selectedStep === CREATE_STEP.INGEST ? (
-                    <EuiFlexItem grow={false}>
-                      <EuiButton
-                        onClick={() => setSelectedStep(CREATE_STEP.SEARCH)}
-                      >
-                        Next
-                      </EuiButton>
-                    </EuiFlexItem>
+                    <>
+                      <EuiFlexItem grow={false}>
+                        <EuiButtonEmpty
+                          onClick={() => setSelectedStep(CREATE_STEP.SEARCH)}
+                        >
+                          Skip
+                        </EuiButtonEmpty>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiButton
+                          fill={true}
+                          onClick={() => {
+                            validateAndRunIngestion();
+                          }}
+                        >
+                          Run ingestion
+                        </EuiButton>
+                      </EuiFlexItem>
+                    </>
                   ) : (
                     <>
                       <EuiFlexItem grow={false}>
-                        <EuiButton
+                        <EuiButtonEmpty
                           onClick={() => setSelectedStep(CREATE_STEP.INGEST)}
                         >
                           Back
-                        </EuiButton>
+                        </EuiButtonEmpty>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiButton
                           disabled={false}
                           onClick={() => {
-                            props.validateAndSubmit(props.formikProps);
+                            validateAndRunQuery();
                           }}
                         >
-                          Create
+                          Run query
                         </EuiButton>
                       </EuiFlexItem>
                     </>

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -15,16 +15,8 @@ import {
 import { useSelector } from 'react-redux';
 import { UseCase } from './use_case';
 import { Workflow, WorkflowTemplate } from '../../../../common';
-import {
-  AppState,
-  cacheWorkflow,
-  useAppDispatch,
-  getWorkflowPresets,
-} from '../../../store';
-import {
-  enrichPresetWorkflowWithUiMetadata,
-  processWorkflowName,
-} from './utils';
+import { AppState, useAppDispatch, getWorkflowPresets } from '../../../store';
+import { enrichPresetWorkflowWithUiMetadata } from './utils';
 
 interface NewWorkflowProps {}
 
@@ -95,18 +87,7 @@ export function NewWorkflow(props: NewWorkflowProps) {
             {filteredWorkflows.map((workflow: Workflow, index) => {
               return (
                 <EuiFlexItem key={index}>
-                  <UseCase
-                    title={workflow.name}
-                    description={workflow.description || ''}
-                    onClick={() =>
-                      dispatch(
-                        cacheWorkflow({
-                          ...workflow,
-                          name: processWorkflowName(workflow.name),
-                        })
-                      )
-                    }
-                  />
+                  <UseCase workflow={workflow} />
                 </EuiFlexItem>
               );
             })}

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   EuiText,
   EuiFlexGroup,
@@ -13,21 +14,25 @@ import {
   EuiHorizontalRule,
   EuiButton,
 } from '@elastic/eui';
-import { NEW_WORKFLOW_ID_URL, PLUGIN_ID } from '../../../../common';
+import { Workflow } from '../../../../common';
 import { APP_PATH } from '../../../utils';
+import { processWorkflowName } from './utils';
+import { createWorkflow, useAppDispatch } from '../../../store';
 
 interface UseCaseProps {
-  title: string;
-  description: string;
-  onClick: () => {};
+  // onClick: () => {};
+  workflow: Workflow;
 }
 
 export function UseCase(props: UseCaseProps) {
+  const dispatch = useAppDispatch();
+  const history = useHistory();
+
   return (
     <EuiCard
       title={
         <EuiTitle size="s">
-          <h2>{props.title}</h2>
+          <h2>{props.workflow.name}</h2>
         </EuiTitle>
       }
       titleSize="s"
@@ -37,17 +42,34 @@ export function UseCase(props: UseCaseProps) {
       <EuiFlexGroup direction="column" gutterSize="l">
         <EuiHorizontalRule size="full" margin="m" />
         <EuiFlexItem grow={true}>
-          <EuiText>{props.description}</EuiText>
+          <EuiText>{props.workflow.description}</EuiText>
         </EuiFlexItem>
         <EuiFlexGroup direction="column" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiButton
               disabled={false}
               isLoading={false}
-              onClick={props.onClick}
-              href={`${PLUGIN_ID}#${APP_PATH.WORKFLOWS}/${NEW_WORKFLOW_ID_URL}`}
+              onClick={() => {
+                const workflowToCreate = {
+                  ...props.workflow,
+                  // TODO: handle duplicate name gracefully. it won't slash or produce errors, but nice-to-have
+                  // as long as not too expensive to fetch duplicate names
+                  name: processWorkflowName(props.workflow.name),
+                };
+
+                dispatch(createWorkflow(workflowToCreate))
+                  .unwrap()
+                  .then((result) => {
+                    const { workflow } = result;
+                    history.replace(`${APP_PATH.WORKFLOWS}/${workflow.id}`);
+                    history.go(0);
+                  })
+                  .catch((err: any) => {
+                    console.error(err);
+                  });
+              }}
             >
-              Go
+              Create
             </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -12,7 +12,6 @@ const initialState = {
   loading: false,
   errorMessage: '',
   workflows: {} as WorkflowDict,
-  cachedWorkflow: undefined as Workflow | undefined,
 };
 
 const WORKFLOWS_ACTION_PREFIX = 'workflows';
@@ -24,8 +23,6 @@ const UPDATE_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/update`;
 const PROVISION_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/provision`;
 const DEPROVISION_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/deprovision`;
 const DELETE_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/delete`;
-const CACHE_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/cache`;
-const CLEAR_CACHED_WORKFLOW_ACTION = `${WORKFLOWS_ACTION_PREFIX}/clearCache`;
 
 export const getWorkflow = createAsyncThunk(
   GET_WORKFLOW_ACTION,
@@ -164,20 +161,6 @@ export const deleteWorkflow = createAsyncThunk(
   }
 );
 
-export const cacheWorkflow = createAsyncThunk(
-  CACHE_WORKFLOW_ACTION,
-  async (workflow: Workflow) => {
-    return workflow;
-  }
-);
-
-// A no-op function to trigger a reducer case.
-// Will clear any stored workflow in the cachedWorkflow state
-export const clearCachedWorkflow = createAsyncThunk(
-  CLEAR_CACHED_WORKFLOW_ACTION,
-  async () => {}
-);
-
 const workflowsSlice = createSlice({
   name: 'workflows',
   initialState,
@@ -285,13 +268,6 @@ const workflowsSlice = createSlice({
         delete state.workflows[workflowId];
         state.loading = false;
         state.errorMessage = '';
-      })
-      .addCase(cacheWorkflow.fulfilled, (state, action) => {
-        const workflow = action.payload;
-        state.cachedWorkflow = workflow;
-      })
-      .addCase(clearCachedWorkflow.fulfilled, (state, action) => {
-        state.cachedWorkflow = undefined;
       })
       // Rejected states: set state consistently across all actions
       .addCase(getWorkflow.rejected, (state, action) => {


### PR DESCRIPTION
### Description

This PR updates and refactors a variety of functionality related to form validation and workflow updates, to match with the updated UX. Specifically:
- Updates the card buttons in `NewWorkflow` to read as `Create`, and update the functionality to actually create a preset workflow and load the editor page with the newly-created workflow automatically with the created ID
- Removes the notion of a `new`/temporary/cached workflow, and all related code, frontend state, and redux store logic for it. Now, the editor page can only be loaded using a created workflow in the backend with a persisted ID
- Updates the buttons in `WorkflowInputs` to match the UX. There will now be no explicit `create` buttons, and will only be `Ingest`/`Search` buttons to execute ingest and search. Internal updates to the workflow and fine-grained provisioning will happen behind the scenes
- Refactors the validation and workflow update logic into `WorkflowInputs` directly. This will slowly change over time as (potentially) auto-update and more of the internal update and execution logic has been implemented.
- Sets up stub functions to perform the internal update and execution logic (the actual ingest and search)
- Adds a code editor field for inputting sample ingest docs, and persists the state in the base `WorkflowInputs` component. This will be used when performing the actual ingest execution.

Demo video, showing auto-creation, and new buttons on `WorkflowInputs` component:

[screen-capture (35).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/62a7b66e-7fe7-4827-87f3-c7cf52e0c407)

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
