### PR TITLE
Enable workflow updates and document ingest

### DIFF
--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -69,6 +69,9 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsWorkflowInputsPanelOpen(!isWorkflowInputsPanelOpen);
   };
 
+  // ingest state
+  const [ingestResponse, setIngestResponse] = useState<string>('');
+
   // Tools side panel state
   const [isToolsPanelOpen, setIsToolsPanelOpen] = useState<boolean>(true);
   const collapseFnVertical = useRef(
@@ -160,6 +163,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                       workflow={props.workflow}
                       formikProps={formikProps}
                       onFormChange={onFormChange}
+                      setIngestResponse={setIngestResponse}
                     />
                   </EuiResizablePanel>
                   <EuiResizableButton />
@@ -242,7 +246,10 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                               >
                                 <EuiFlexItem>
                                   <EuiPanel paddingSize="m">
-                                    <Tools workflow={workflow} />
+                                    <Tools
+                                      workflow={workflow}
+                                      ingestResponse={ingestResponse}
+                                    />
                                   </EuiPanel>
                                 </EuiFlexItem>
                               </EuiFlexGroup>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -235,24 +235,12 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                               onToggleCollapsedInternal={() =>
                                 onToggleToolsChange()
                               }
-                              style={{ marginBottom: '-24px' }}
+                              style={{ marginBottom: '-16px' }}
                             >
-                              <EuiFlexGroup
-                                direction="column"
-                                gutterSize="s"
-                                style={{
-                                  height: '100%',
-                                }}
-                              >
-                                <EuiFlexItem>
-                                  <EuiPanel paddingSize="m">
-                                    <Tools
-                                      workflow={workflow}
-                                      ingestResponse={ingestResponse}
-                                    />
-                                  </EuiPanel>
-                                </EuiFlexItem>
-                              </EuiFlexGroup>
+                              <Tools
+                                workflow={workflow}
+                                ingestResponse={ingestResponse}
+                              />
                             </EuiResizablePanel>
                           </>
                         );

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -5,9 +5,11 @@
 
 import React, { useState } from 'react';
 import {
+  EuiCodeBlock,
   EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPanel,
   EuiSpacer,
   EuiTab,
   EuiTabs,
@@ -57,76 +59,102 @@ const inputTabs = [
  */
 export function Tools(props: ToolsProps) {
   const [selectedTabId, setSelectedTabId] = useState<string>(TAB_ID.INGEST);
+
+  console.log('ingestresponse in tools: ', props.ingestResponse);
   return (
-    <>
-      <EuiTitle>
-        <h2>Tools</h2>
-      </EuiTitle>
-      <EuiSpacer size="m" />
-      <>
-        <EuiTabs size="m" expand={false}>
-          {inputTabs.map((tab, idx) => {
-            return (
-              <EuiTab
-                onClick={() => setSelectedTabId(tab.id)}
-                isSelected={tab.id === selectedTabId}
-                disabled={tab.disabled}
-                key={idx}
-              >
-                {tab.name}
-              </EuiTab>
-            );
-          })}
-        </EuiTabs>
-        <EuiSpacer size="m" />
-        <EuiFlexGroup
-          direction="column"
-          justifyContent="spaceBetween"
-          style={{
-            height: '80%',
-          }}
+    <EuiPanel paddingSize="m" grow={true} style={{ height: '100%' }}>
+      <EuiFlexGroup
+        direction="column"
+        //justifyContent="spaceBetween"
+        style={{
+          height: '100%',
+        }}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiTitle>
+            <h2>Tools</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiTabs size="m" expand={false}>
+            {inputTabs.map((tab, idx) => {
+              return (
+                <EuiTab
+                  onClick={() => setSelectedTabId(tab.id)}
+                  isSelected={tab.id === selectedTabId}
+                  disabled={tab.disabled}
+                  key={idx}
+                >
+                  {tab.name}
+                </EuiTab>
+              );
+            })}
+          </EuiTabs>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+          style={
+            {
+              // overflowY: 'scroll',
+              // overflowX: 'hidden',
+            }
+          }
         >
-          {selectedTabId === TAB_ID.INGEST && (
+          <EuiFlexGroup direction="column">
             <EuiFlexItem
               grow={true}
-              style={{
-                overflowY: 'scroll',
-                overflowX: 'hidden',
-              }}
+              // style={{
+              //   overflowY: 'scroll',
+              //   overflowX: 'hidden',
+              // }}
             >
-              <EuiCodeEditor
-                mode="json"
-                theme="textmate"
-                width="100%"
-                height="100%"
-                value={props.ingestResponse}
-                onChange={(input) => {}}
-                readOnly={true}
-                setOptions={{
-                  fontSize: '14px',
-                }}
-                aria-label="Code Editor"
-                tabSize={2}
-              />
+              <>
+                {selectedTabId === TAB_ID.INGEST && (
+                  //TODO: investigate existing editor more
+                  <EuiCodeEditor
+                    mode="json"
+                    theme="textmate"
+                    width="100%"
+                    height="100%"
+                    onScroll={(event) => {
+                      console.log('scroll event fired!');
+                    }}
+                    value={props.ingestResponse}
+                    onChange={(input) => {}}
+                    readOnly={true}
+                    setOptions={{
+                      fontSize: '14px',
+                    }}
+                    aria-label="Code Editor"
+                    tabSize={2}
+                  />
+                  // <EuiCodeBlock
+                  //   language="json"
+                  //   fontSize="m"
+                  //   paddingSize="m"
+                  //   // TODO: dynamically fetch the available space to determine the overflow height.
+                  //   overflowHeight={100}
+                  //   // style={{
+                  //   //   height: '100%',
+                  //   // }}
+                  // >
+                  //   {props.ingestResponse}
+                  // </EuiCodeBlock>
+                )}
+                {selectedTabId === TAB_ID.QUERY && (
+                  <EuiText>TODO: Run queries placeholder</EuiText>
+                )}
+                {selectedTabId === TAB_ID.ERRORS && (
+                  <EuiText>TODO: View errors placeholder</EuiText>
+                )}
+                {selectedTabId === TAB_ID.RESOURCES && (
+                  <Resources workflow={props.workflow} />
+                )}
+              </>
             </EuiFlexItem>
-          )}
-          {selectedTabId === TAB_ID.QUERY && (
-            <EuiFlexItem>
-              <EuiText>TODO: Run queries placeholder</EuiText>
-            </EuiFlexItem>
-          )}
-          {selectedTabId === TAB_ID.ERRORS && (
-            <EuiFlexItem>
-              <EuiText>TODO: View errors placeholder</EuiText>
-            </EuiFlexItem>
-          )}
-          {selectedTabId === TAB_ID.RESOURCES && (
-            <EuiFlexItem>
-              <Resources workflow={props.workflow} />
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-      </>
-    </>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 }

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -5,12 +5,10 @@
 
 import React, { useState } from 'react';
 import {
-  EuiCodeBlock,
   EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
-  EuiSpacer,
   EuiTab,
   EuiTabs,
   EuiText,
@@ -60,12 +58,10 @@ const inputTabs = [
 export function Tools(props: ToolsProps) {
   const [selectedTabId, setSelectedTabId] = useState<string>(TAB_ID.INGEST);
 
-  console.log('ingestresponse in tools: ', props.ingestResponse);
   return (
     <EuiPanel paddingSize="m" grow={true} style={{ height: '100%' }}>
       <EuiFlexGroup
         direction="column"
-        //justifyContent="spaceBetween"
         style={{
           height: '100%',
         }}
@@ -91,55 +87,28 @@ export function Tools(props: ToolsProps) {
             })}
           </EuiTabs>
         </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-          style={
-            {
-              // overflowY: 'scroll',
-              // overflowX: 'hidden',
-            }
-          }
-        >
+        <EuiFlexItem grow={true}>
           <EuiFlexGroup direction="column">
-            <EuiFlexItem
-              grow={true}
-              // style={{
-              //   overflowY: 'scroll',
-              //   overflowX: 'hidden',
-              // }}
-            >
+            <EuiFlexItem grow={true}>
               <>
                 {selectedTabId === TAB_ID.INGEST && (
-                  //TODO: investigate existing editor more
+                  // TODO: known issue with the editor where resizing the resizablecontainer does not
+                  // trigger vertical scroll updates. Updating the window, or reloading the component
+                  // by switching tabs etc. will refresh it correctly.
                   <EuiCodeEditor
                     mode="json"
                     theme="textmate"
                     width="100%"
                     height="100%"
-                    onScroll={(event) => {
-                      console.log('scroll event fired!');
-                    }}
                     value={props.ingestResponse}
                     onChange={(input) => {}}
                     readOnly={true}
                     setOptions={{
-                      fontSize: '14px',
+                      fontSize: '12px',
+                      autoScrollEditorIntoView: true,
                     }}
-                    aria-label="Code Editor"
                     tabSize={2}
                   />
-                  // <EuiCodeBlock
-                  //   language="json"
-                  //   fontSize="m"
-                  //   paddingSize="m"
-                  //   // TODO: dynamically fetch the available space to determine the overflow height.
-                  //   overflowHeight={100}
-                  //   // style={{
-                  //   //   height: '100%',
-                  //   // }}
-                  // >
-                  //   {props.ingestResponse}
-                  // </EuiCodeBlock>
                 )}
                 {selectedTabId === TAB_ID.QUERY && (
                   <EuiText>TODO: Run queries placeholder</EuiText>

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState } from 'react';
 import {
+  EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -18,6 +19,7 @@ import { Resources } from './resources';
 
 interface ToolsProps {
   workflow?: Workflow;
+  ingestResponse: string;
 }
 
 enum TAB_ID {
@@ -77,10 +79,35 @@ export function Tools(props: ToolsProps) {
           })}
         </EuiTabs>
         <EuiSpacer size="m" />
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup
+          direction="column"
+          justifyContent="spaceBetween"
+          style={{
+            height: '80%',
+          }}
+        >
           {selectedTabId === TAB_ID.INGEST && (
-            <EuiFlexItem>
-              <EuiText>TODO: Run ingestion placeholder</EuiText>
+            <EuiFlexItem
+              grow={true}
+              style={{
+                overflowY: 'scroll',
+                overflowX: 'hidden',
+              }}
+            >
+              <EuiCodeEditor
+                mode="json"
+                theme="textmate"
+                width="100%"
+                height="100%"
+                value={props.ingestResponse}
+                onChange={(input) => {}}
+                readOnly={true}
+                setOptions={{
+                  fontSize: '14px',
+                }}
+                aria-label="Code Editor"
+                tabSize={2}
+              />
             </EuiFlexItem>
           )}
           {selectedTabId === TAB_ID.QUERY && (

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -18,36 +18,10 @@ interface IngestDataProps {
   onFormChange: () => void;
 }
 
-enum OPTION {
-  NEW = 'new',
-  EXISTING = 'existing',
-}
-
-const options = [
-  {
-    id: OPTION.NEW,
-    label: 'Create a new index',
-  },
-  {
-    id: OPTION.EXISTING,
-    label: 'Choose existing index',
-  },
-];
-
 /**
  * Input component for configuring the data ingest (the OpenSearch index)
  */
 export function IngestData(props: IngestDataProps) {
-  const [selectedOption, setSelectedOption] = useState<OPTION>(OPTION.NEW);
-
-  useEffect(() => {
-    const indexName =
-      props.workflow.ui_metadata?.config?.ingest?.index?.name?.value;
-    if (indexName) {
-      setSelectedOption(OPTION.EXISTING);
-    }
-  }, [props.workflow.ui_metadata?.config?.ingest?.index]);
-
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
@@ -56,23 +30,14 @@ export function IngestData(props: IngestDataProps) {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiRadioGroup
-          options={options}
-          idSelected={selectedOption}
-          onChange={(optionId) => setSelectedOption(optionId as OPTION)}
+        <TextField
+          field={
+            props.workflow.ui_metadata?.config?.ingest?.index
+              ?.name as IConfigField
+          }
+          fieldPath={'ingest.index.name'}
+          onFormChange={props.onFormChange}
         />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        {selectedOption === OPTION.NEW ? (
-          <TextField
-            field={
-              props.workflow.ui_metadata?.config?.ingest?.index
-                ?.name as IConfigField
-            }
-            fieldPath={'ingest.index.name'}
-            onFormChange={props.onFormChange}
-          />
-        ) : null}
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -22,7 +22,12 @@ import {
 } from '../../../../common';
 import { IngestInputs } from './ingest_inputs';
 import { SearchInputs } from './search_inputs';
-import { updateWorkflow, useAppDispatch } from '../../../store';
+import {
+  deprovisionWorkflow,
+  provisionWorkflow,
+  updateWorkflow,
+  useAppDispatch,
+} from '../../../store';
 import { formikToUiConfig, reduceToTemplate } from '../../../utils';
 import { configToTemplateFlows } from '../utils';
 
@@ -57,73 +62,109 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   // we do not need/want to persist this in form state or in backend
   const [ingestDocs, setIngestDocs] = useState<{}[]>([]);
 
-  // Utility fn to update the workflow
-  function executeUpdate(updatedWorkflow: Workflow): void {
-    dispatch(
-      updateWorkflow({
-        workflowId: updatedWorkflow.id as string,
-        workflowTemplate: reduceToTemplate(updatedWorkflow),
-      })
-    )
+  // Utility fn to update the workflow, including any updated/new resources
+  // Eventually, should be able to use fine-grained provisioning to do a single API call
+  // instead of the currently-implemented deprovision -> update -> provision
+  async function updateWorkflowAndResources(
+    updatedWorkflow: Workflow
+  ): Promise<boolean> {
+    let success = false;
+    await dispatch(deprovisionWorkflow(updatedWorkflow.id as string))
       .unwrap()
-      .then((result) => {})
-      .catch((error: any) => {});
+      .then(async (result) => {
+        await dispatch(
+          updateWorkflow({
+            workflowId: updatedWorkflow.id as string,
+            workflowTemplate: reduceToTemplate(updatedWorkflow),
+          })
+        )
+          .unwrap()
+          .then(async (result) => {
+            await dispatch(provisionWorkflow(updatedWorkflow.id as string))
+              .unwrap()
+              .then((result) => {
+                success = true;
+              })
+              .catch((error: any) => {
+                console.error('Error provisioning updated workflow: ', error);
+              });
+          })
+          .catch((error: any) => {
+            console.error('Error updating workflow: ', error);
+          });
+      })
+      .catch((error: any) => {
+        console.error('Error deprovisioning workflow: ', error);
+      });
+    return success;
   }
 
   // Utility fn to validate the form and update the workflow if valid
-  function validateAndUpdateWorkflow(
+  async function validateAndUpdateWorkflow(
     formikProps: FormikProps<WorkflowFormValues>
-  ): void {
+  ): Promise<boolean> {
+    let success = false;
     // Submit the form to bubble up any errors.
     // Ideally we handle Promise accept/rejects with submitForm(), but there is
     // open issues for that - see https://github.com/jaredpalmer/formik/issues/2057
     // The workaround is to additionally execute validateForm() which will return any errors found.
     formikProps.submitForm();
-    formikProps.validateForm().then((validationResults: {}) => {
-      if (Object.keys(validationResults).length > 0) {
-        console.error('Form invalid');
-      } else {
-        const updatedConfig = formikToUiConfig(
-          formikProps.values,
-          props.workflow?.ui_metadata?.config as WorkflowConfig
-        );
-        const updatedWorkflow = {
-          ...props.workflow,
-          ui_metadata: {
-            ...props.workflow?.ui_metadata,
-            config: updatedConfig,
-          },
-          workflows: configToTemplateFlows(updatedConfig),
-        } as Workflow;
-        executeUpdate(updatedWorkflow);
-      }
-    });
+    await formikProps
+      .validateForm()
+      .then(async (validationResults: {}) => {
+        if (Object.keys(validationResults).length > 0) {
+          console.error('Form invalid');
+        } else {
+          const updatedConfig = formikToUiConfig(
+            formikProps.values,
+            props.workflow?.ui_metadata?.config as WorkflowConfig
+          );
+          const updatedWorkflow = {
+            ...props.workflow,
+            ui_metadata: {
+              ...props.workflow?.ui_metadata,
+              config: updatedConfig,
+            },
+            workflows: configToTemplateFlows(updatedConfig),
+          } as Workflow;
+          success = await updateWorkflowAndResources(updatedWorkflow);
+        }
+      })
+      .catch((error) => {
+        console.error('Error validating form: ', error);
+      });
+
+    return success;
   }
 
   // TODO: running props.validateAndSubmit(props.formikProps) will need to be ran before every ingest and
   // search, if the form is dirty / values have changed. This will update the workflow if needed.
   // Note that the temporary data (the ingest docs and the search query) will not need to be persisted
   // in the form (need to confirm if query-side / using search template, will need to persist something)
-  function validateAndRunIngestion(): void {
-    console.log('running ingestion...');
+  async function validateAndRunIngestion(): Promise<boolean> {
+    let success = false;
     try {
-      validateAndUpdateWorkflow(props.formikProps);
-      const indexName = props.formikProps.values.ingest.index.name;
-      const doc = ingestDocs[0];
-      // dispatch(ingest({ index: indexName, doc: docObj }))
-      //   .unwrap()
-      //   .then(async (resp) => {
-      //     //setResponse(result);
-      //     console.log('response: ', resp);
-      //   })
-      //   .catch((error: any) => {
-      //     getCore().notifications.toasts.addDanger(error);
-      //     // setResponse({});
-      //     console.log('error: ', error);
-      //   });
+      success = await validateAndUpdateWorkflow(props.formikProps);
+      if (success) {
+        const indexName = props.formikProps.values.ingest.index.name;
+        const doc = ingestDocs[0];
+        // dispatch(ingest({ index: indexName, doc: docObj }))
+        //   .unwrap()
+        //   .then(async (resp) => {
+        //     //setResponse(result);
+        //     console.log('response: ', resp);
+        //   })
+        //   .catch((error: any) => {
+        //     getCore().notifications.toasts.addDanger(error);
+        //     // setResponse({});
+        //     console.log('error: ', error);
+        //   });
+      }
     } catch (err) {
-      console.log('error: ', err);
+      console.log('Error ingesting documents: ', err);
     }
+
+    return success;
   }
 
   function validateAndRunQuery(): void {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -153,7 +153,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         dispatch(ingest({ index: indexName, doc }))
           .unwrap()
           .then(async (resp) => {
-            props.setIngestResponse(JSON.stringify(resp));
+            props.setIngestResponse(JSON.stringify(resp, undefined, 2));
           })
           .catch((error: any) => {
             getCore().notifications.toasts.addDanger(error);


### PR DESCRIPTION
### Description

This PR enables basic ingestion and viewing the ingestion response in the tools panel. Specifically:
- adds an `ingestResponse` var to persist at the global workspace level to be viewed from anywhere
- implements fns needed for performing validating/deprovision/update/provision of workflows if the user updates something (changes index name, changes/adds ingest processors, etc.). In the future we can leverage the backend fine-grained provisioning work to simplify this to 1 API call instead of 3, and allow for optimized deprovisioning (removing the requirement to deprovision things like indices or models, if a user updates some resource that is unrelated).
- perform validation/deprovision/update/provision when a user clicks 'Run ingestion'. This a pre-requisite for the configuration to be up-to-date before any sample docs are ingested. This will be used in an identical way on the search side.

Other improvements:
- makes Tools panel consistent with the other panels, allow scrolling overflow in the tab bodies
- clean up and simplify the index component to only support 'create new' per the latest UX mockups.

Demo video (updating workflow with a configured ingest pipeline and index name, ingesting the sample document, showing ingest response under the ingest tab in the tools panel):

[screen-capture (36).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/8867f8a9-f56c-43f7-8bb3-c6043841083c)

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
