### PR TITLE
Multi-processor support & associated CRUD operations

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -6,11 +6,12 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { ProcessorsList } from './processors_list';
-import { Workflow } from '../../../../../common';
+import { WorkflowConfig } from '../../../../../common';
 
 interface EnrichDataProps {
-  workflow: Workflow;
   onFormChange: () => void;
+  uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
 }
 
 /**
@@ -26,8 +27,9 @@ export function EnrichData(props: EnrichDataProps) {
       </EuiFlexItem>
       <EuiFlexItem>
         <ProcessorsList
-          workflow={props.workflow}
           onFormChange={props.onFormChange}
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -4,17 +4,12 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiRadioGroup,
-  EuiTitle,
-} from '@elastic/eui';
-import { IConfigField, Workflow } from '../../../../../common';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { IConfigField, WorkflowConfig } from '../../../../../common';
 import { SelectField, TextField } from '../input_fields';
 
 interface IngestDataProps {
-  workflow: Workflow;
+  uiConfig: WorkflowConfig;
   onFormChange: () => void;
 }
 
@@ -31,10 +26,7 @@ export function IngestData(props: IngestDataProps) {
       </EuiFlexItem>
       <EuiFlexItem>
         <TextField
-          field={
-            props.workflow.ui_metadata?.config?.ingest?.index
-              ?.name as IConfigField
-          }
+          field={props.uiConfig.ingest.index?.name as IConfigField}
           fieldPath={'ingest.index.name'}
           onFormChange={props.onFormChange}
         />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -8,13 +8,14 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { SourceData } from './source_data';
 import { EnrichData } from './enrich_data';
 import { IngestData } from './ingest_data';
-import { Workflow } from '../../../../../common';
+import { WorkflowConfig } from '../../../../../common';
 
 interface IngestInputsProps {
-  workflow: Workflow;
   onFormChange: () => void;
   ingestDocs: {}[];
   setIngestDocs: (docs: {}[]) => void;
+  uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
 }
 
 /**
@@ -34,8 +35,9 @@ export function IngestInputs(props: IngestInputsProps) {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EnrichData
-          workflow={props.workflow}
           onFormChange={props.onFormChange}
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
@@ -43,7 +45,7 @@ export function IngestInputs(props: IngestInputsProps) {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <IngestData
-          workflow={props.workflow}
+          uiConfig={props.uiConfig}
           onFormChange={props.onFormChange}
         />
       </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
@@ -4,10 +4,19 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
 import { cloneDeep } from 'lodash';
 import { IConfig, PROCESSOR_TYPE, WorkflowConfig } from '../../../../../common';
 import { ConfigFieldList } from '../config_field_list';
+import { generateId } from '../../../../utils';
 
 interface ProcessorsListProps {
   onFormChange: () => void;
@@ -25,39 +34,61 @@ export function ProcessorsList(props: ProcessorsListProps) {
         (processor: IConfig, processorIndex) => {
           return (
             <EuiFlexItem key={processorIndex}>
-              <EuiText>
-                {processor.metadata?.label || 'Ingest processor'}
-              </EuiText>
-              <ConfigFieldList
-                config={processor}
-                baseConfigPath="ingest.enrich"
-                onFormChange={props.onFormChange}
-              />
+              <EuiPanel>
+                <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+                  <EuiFlexItem grow={false}>
+                    <EuiText>
+                      {processor.metadata?.label || 'Ingest processor'}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonIcon
+                      iconType={'trash'}
+                      color="danger"
+                      aria-label="Delete"
+                      onClick={() => {
+                        let newConfig = cloneDeep(
+                          props.uiConfig as WorkflowConfig
+                        );
+                        newConfig.ingest.enrich.processors = newConfig.ingest.enrich.processors.filter(
+                          (processorConfig) =>
+                            processorConfig.id !== processor.id
+                        );
+                        props.setUiConfig(newConfig);
+                      }}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                <EuiHorizontalRule size="full" margin="s" />
+                <ConfigFieldList
+                  config={processor}
+                  baseConfigPath="ingest.enrich"
+                  onFormChange={props.onFormChange}
+                />
+              </EuiPanel>
             </EuiFlexItem>
           );
         }
       )}
-      <EuiFlexItem>
-        <EuiButton
-          onClick={() => {
-            // 1. generate a new ui config with the added processor
-            // 2. hook back to base file with the updated ui config
-            // 3. base file updates the form values / form schema based on the updated config
-            // 4. new page is rendered with the updated list of final processors
-            let newConfig = cloneDeep(props.uiConfig as WorkflowConfig);
-            newConfig.ingest.enrich.processors = [
-              ...newConfig.ingest.enrich.processors,
-              {
-                type: PROCESSOR_TYPE.MODEL,
-                id: 'test-id',
-                fields: [],
-              },
-            ];
-            props.setUiConfig(newConfig);
-          }}
-        >
-          Add new processor
-        </EuiButton>
+      <EuiFlexItem grow={false}>
+        <div>
+          <EuiButton
+            onClick={() => {
+              let newConfig = cloneDeep(props.uiConfig as WorkflowConfig);
+              newConfig.ingest.enrich.processors = [
+                ...newConfig.ingest.enrich.processors,
+                {
+                  type: PROCESSOR_TYPE.MODEL,
+                  id: generateId('test-id'),
+                  fields: [],
+                },
+              ];
+              props.setUiConfig(newConfig);
+            }}
+          >
+            Add another processor
+          </EuiButton>
+        </div>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
@@ -4,13 +4,15 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { IConfig, Workflow } from '../../../../../common';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { cloneDeep } from 'lodash';
+import { IConfig, PROCESSOR_TYPE, WorkflowConfig } from '../../../../../common';
 import { ConfigFieldList } from '../config_field_list';
 
 interface ProcessorsListProps {
-  workflow: Workflow;
   onFormChange: () => void;
+  uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
 }
 
 /**
@@ -19,7 +21,7 @@ interface ProcessorsListProps {
 export function ProcessorsList(props: ProcessorsListProps) {
   return (
     <EuiFlexGroup direction="column">
-      {props.workflow.ui_metadata?.config.ingest?.enrich.processors.map(
+      {props.uiConfig?.ingest.enrich.processors.map(
         (processor: IConfig, processorIndex) => {
           return (
             <EuiFlexItem key={processorIndex}>
@@ -35,6 +37,28 @@ export function ProcessorsList(props: ProcessorsListProps) {
           );
         }
       )}
+      <EuiFlexItem>
+        <EuiButton
+          onClick={() => {
+            // 1. generate a new ui config with the added processor
+            // 2. hook back to base file with the updated ui config
+            // 3. base file updates the form values / form schema based on the updated config
+            // 4. new page is rendered with the updated list of final processors
+            let newConfig = cloneDeep(props.uiConfig as WorkflowConfig);
+            newConfig.ingest.enrich.processors = [
+              ...newConfig.ingest.enrich.processors,
+              {
+                type: PROCESSOR_TYPE.MODEL,
+                id: 'test-id',
+                fields: [],
+              },
+            ];
+            props.setUiConfig(newConfig);
+          }}
+        >
+          Add new processor
+        </EuiButton>
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -8,10 +8,10 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { ConfigureSearchRequest } from './configure_search_request';
 import { EnrichSearchRequest } from './enrich_search_request';
 import { EnrichSearchResponse } from './enrich_search_response';
-import { Workflow } from '../../../../../common';
+import { WorkflowConfig } from '../../../../../common';
 
 interface SearchInputsProps {
-  workflow: Workflow;
+  uiConfig: WorkflowConfig;
 }
 
 /**

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -38,8 +38,9 @@ import '../workspace/workspace-styles.scss';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;
-  formikProps: FormikProps<WorkflowFormValues>;
   onFormChange: () => void;
+  uiConfig: WorkflowConfig | undefined;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
   setIngestResponse: (ingestResponse: string) => void;
 }
 
@@ -54,6 +55,9 @@ export enum CREATE_STEP {
  */
 
 export function WorkflowInputs(props: WorkflowInputsProps) {
+  const { submitForm, validateForm, values } = useFormikContext<
+    WorkflowFormValues
+  >();
   const dispatch = useAppDispatch();
 
   // selected step state
@@ -102,24 +106,21 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   }
 
   // Utility fn to validate the form and update the workflow if valid
-  async function validateAndUpdateWorkflow(
-    formikProps: FormikProps<WorkflowFormValues>
-  ): Promise<boolean> {
+  async function validateAndUpdateWorkflow(): Promise<boolean> {
     let success = false;
     // Submit the form to bubble up any errors.
     // Ideally we handle Promise accept/rejects with submitForm(), but there is
     // open issues for that - see https://github.com/jaredpalmer/formik/issues/2057
     // The workaround is to additionally execute validateForm() which will return any errors found.
-    formikProps.submitForm();
-    await formikProps
-      .validateForm()
+    submitForm();
+    await validateForm()
       .then(async (validationResults: {}) => {
         if (Object.keys(validationResults).length > 0) {
           console.error('Form invalid');
         } else {
           const updatedConfig = formikToUiConfig(
-            formikProps.values,
-            props.workflow?.ui_metadata?.config as WorkflowConfig
+            values,
+            props.uiConfig as WorkflowConfig
           );
           const updatedWorkflow = {
             ...props.workflow,
@@ -139,16 +140,16 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     return success;
   }
 
-  // TODO: running props.validateAndSubmit(props.formikProps) will need to be ran before every ingest and
+  // TODO: running props.validateAndSubmit() will need to be ran before every ingest and
   // search, if the form is dirty / values have changed. This will update the workflow if needed.
   // Note that the temporary data (the ingest docs and the search query) will not need to be persisted
   // in the form (need to confirm if query-side / using search template, will need to persist something)
   async function validateAndRunIngestion(): Promise<boolean> {
     let success = false;
     try {
-      success = await validateAndUpdateWorkflow(props.formikProps);
+      success = await validateAndUpdateWorkflow();
       if (success && ingestDocs.length > 0) {
-        const indexName = props.formikProps.values.ingest.index.name;
+        const indexName = values.ingest.index.name;
         const doc = ingestDocs[0];
         dispatch(ingest({ index: indexName, doc }))
           .unwrap()
@@ -170,12 +171,12 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   function validateAndRunQuery(): void {
     console.log('running query...');
-    validateAndUpdateWorkflow(props.formikProps);
+    validateAndUpdateWorkflow();
   }
 
   return (
     <EuiPanel paddingSize="m" grow={true} className="workspace-panel">
-      {props.workflow === undefined ? (
+      {props.uiConfig === undefined ? (
         <EuiLoadingSpinner size="xl" />
       ) : (
         <EuiFlexGroup
@@ -199,13 +200,14 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           >
             {selectedStep === CREATE_STEP.INGEST ? (
               <IngestInputs
-                workflow={props.workflow}
                 onFormChange={props.onFormChange}
                 ingestDocs={ingestDocs}
                 setIngestDocs={setIngestDocs}
+                uiConfig={props.uiConfig}
+                setUiConfig={props.setUiConfig}
               />
             ) : (
-              <SearchInputs workflow={props.workflow} />
+              <SearchInputs uiConfig={props.uiConfig} />
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false} style={{ marginBottom: '-10px' }}>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -249,6 +249,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       <EuiFlexItem grow={false}>
                         <EuiButton
                           disabled={false}
+                          fill={true}
                           onClick={() => {
                             validateAndRunQuery();
                           }}


### PR DESCRIPTION
### Description

This PR updates the 'Enrich data' section on ingest-related workflow inputs to support multiple processors, including the ability to add and delete them. Specifically:
- persists a standalone `UiConfig` prop to pass to all of the downstream form inputs, instead of the workflow. This way, we can decouple the form from being tied to the backend-persisted workflow config. Now, we can have a flexible, updatable `UiConfig` that we can add/remove fields (including adding/removing processors) without saving/updating in the backend. We add callbacks to the base fn to re-generate the form values & form schema when changes are made. When the users finally save, we will take this dynamic `UiConfig` field and update the underlying backend workflow with it
- adds `addProcessor()` and `deleteProcessor()` fns to the `ProcessorsList`, and using that functionality in the existing 'Add processor' button, and the new delete button. Both of these fns will take the existing config (getting any updated/interim values along the way), update the config, and letting the base `ResizableWorkspace` component re-generate the form values / form schema
- general component updates to the processors list (nesting within a panel, adding buttons, formatting updates)
- minor improvements to formik propagation - using `useFormikContext()` instead of passing formik props explicitly into `WorkflowInputs` and `ProcessorsList`

Note: the ability to choose some preset processors and/or provide a more useful generated ingest processor will be in subsequent PRs. This is just focusing on allowing the ability to update the list and persist it correctly.

Demo video, showing add/delete of processors, and when saving, showing the changes persisted on refresh:

[screen-capture (37).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/267462da-7c52-4970-92db-a19b9d48ef11)


### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
