### PR TITLE
Dynamically update ingest workflow when adding processors

### DIFF
--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -231,11 +231,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                                 style={{ height: '100%' }}
                               >
                                 <EuiFlexItem>
-                                  <Workspace
-                                    id="ingest"
-                                    workflow={workflow}
-                                    readonly={false}
-                                  />
+                                  <Workspace uiConfig={uiConfig} />
                                 </EuiFlexItem>
                               </EuiFlexGroup>
                             </EuiResizablePanel>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/processors_list.tsx
@@ -17,6 +17,8 @@ import { cloneDeep } from 'lodash';
 import { useFormikContext } from 'formik';
 import {
   IConfig,
+  IModelProcessorConfig,
+  MODEL_TYPE,
   PROCESSOR_TYPE,
   WorkflowConfig,
   WorkflowFormValues,
@@ -39,6 +41,8 @@ export function ProcessorsList(props: ProcessorsListProps) {
   // Adding a processor to the config. Fetch the existing one
   // (getting any updated/interim values along the way) and add to
   // the list of processors
+  // TODO: enhance this to either choose from a list of preset
+  // processors, or at the least a usable generic processor
   function addProcessor(processorIdToAdd: string): void {
     const existingConfig = cloneDeep(props.uiConfig as WorkflowConfig);
     let newConfig = formikToUiConfig(values, existingConfig);
@@ -46,9 +50,10 @@ export function ProcessorsList(props: ProcessorsListProps) {
       ...newConfig.ingest.enrich.processors,
       {
         type: PROCESSOR_TYPE.MODEL,
+        modelType: MODEL_TYPE.TEXT_EMBEDDING,
         id: processorIdToAdd,
         fields: [],
-      },
+      } as IModelProcessorConfig,
     ];
     props.setUiConfig(newConfig);
   }
@@ -104,8 +109,6 @@ export function ProcessorsList(props: ProcessorsListProps) {
         <div>
           <EuiButton
             onClick={() => {
-              // TODO: enhance this to either choose from a list of preset
-              // processors, or at the least a usable generic processor
               addProcessor(generateId('test-processor'));
             }}
           >

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -15,7 +15,7 @@ import ReactFlow, {
 } from 'reactflow';
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { setDirty, useAppDispatch } from '../../../store';
-import { IComponentData, Workflow, WorkflowConfig } from '../../../../common';
+import { IComponentData, WorkflowConfig } from '../../../../common';
 import {
   IngestGroupComponent,
   SearchGroupComponent,
@@ -31,9 +31,7 @@ import './workspace-styles.scss';
 import './workspace_edge/deletable-edge-styles.scss';
 
 interface WorkspaceProps {
-  workflow?: Workflow;
-  readonly: boolean;
-  id: string;
+  uiConfig?: WorkflowConfig;
 }
 
 const nodeTypes = {
@@ -77,15 +75,12 @@ export function Workspace(props: WorkspaceProps) {
 
   // Initialization. Generate the nodes and edges based on the workflow config.
   useEffect(() => {
-    const workflow = { ...props.workflow };
-    if (workflow?.ui_metadata?.config) {
-      const proposedWorkspaceFlow = uiConfigToWorkspaceFlow(
-        workflow.ui_metadata?.config as WorkflowConfig
-      );
+    if (props.uiConfig) {
+      const proposedWorkspaceFlow = uiConfigToWorkspaceFlow(props.uiConfig);
       setNodes(proposedWorkspaceFlow.nodes);
       setEdges(proposedWorkspaceFlow.edges);
     }
-  }, [props.workflow]);
+  }, [props.uiConfig]);
 
   return (
     <EuiFlexGroup
@@ -101,7 +96,7 @@ export function Workspace(props: WorkspaceProps) {
         <div className="reactflow-parent-wrapper">
           <div className="reactflow-wrapper" ref={reactFlowWrapper}>
             <ReactFlow
-              id={props.id}
+              id="workspace"
               nodes={nodes}
               edges={edges}
               nodeTypes={nodeTypes}
@@ -113,14 +108,14 @@ export function Workspace(props: WorkspaceProps) {
               className="reactflow-workspace"
               fitView
               minZoom={0.2}
-              edgesUpdatable={!props.readonly}
-              edgesFocusable={!props.readonly}
-              nodesDraggable={!props.readonly}
-              nodesConnectable={!props.readonly}
-              nodesFocusable={!props.readonly}
-              draggable={!props.readonly}
-              panOnDrag={!props.readonly}
-              elementsSelectable={!props.readonly}
+              edgesUpdatable={false}
+              edgesFocusable={false}
+              nodesDraggable={false}
+              nodesConnectable={false}
+              nodesFocusable={false}
+              draggable={true}
+              panOnDrag={true}
+              elementsSelectable={false}
             >
               <Controls
                 showFitView={false}


### PR DESCRIPTION
### Description

This PR adds support to dynamically update the reactflow nodes/edges when ingest processors are added/removed. Also cleans up & simplifies the params passed to the base `Workflow` component, as this adds the same decoupling logic as #168 , in that we use the `UiConfig` as the source of truth instead of the workflow.

Note: customization of processor types etc. will be in future PRs

Demo video:

[screen-capture (38).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/68da6564-faff-4456-b083-494835d7ad22)


### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
