### PR TITLE
Add ingest guardrails; add auto-refresh after provisioning/reprovisioning

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -26,7 +26,9 @@ export function SourceData(props: SourceDataProps) {
     try {
       const json = JSON.parse(jsonStr);
       props.setIngestDocs([json]);
-    } catch (e) {}
+    } catch (e) {
+      props.setIngestDocs([]);
+    }
   }, [jsonStr]);
 
   return (


### PR DESCRIPTION
### Description

This PR adds 2 minor improvements:
- basic guardrails on clicking `Run Ingestion` - now will not execute if the json is empty or invalid
- auto-state updates of the workflow after running `Run Ingestion`. The workflow state is updated and resources are populated without a manual refresh (in the future, may have dedicated refresh button(s) for updating as well, since provisioning time is indeterminate)

Demo showing the doc guardrails (toast) and state updates after executing

[screen-capture (40).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/71fa3cde-84b0-4b37-a856-dc0690a8d9e7)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
