### PR TITLE
Finish onboarding of the ML inference processor

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -31,15 +31,10 @@ export interface IConfigField {
   helpLink?: string;
   selectType?: ConfigSelectType;
 }
-
-export interface IConfigMetadata {
-  label?: string;
-}
-
 export interface IConfig {
   id: string;
+  name: string;
   fields: IConfigField[];
-  metadata?: IConfigMetadata;
 }
 
 export interface IProcessorConfig extends IConfig {

--- a/public/configs/base_config.ts
+++ b/public/configs/base_config.ts
@@ -23,6 +23,10 @@ export abstract class BaseConfig implements IConfig {
   // Persist a standard toObj() fn that all component classes can use. This is necessary
   // so we have standard JS Object when serializing comoponent state in redux.
   toObj() {
-    return Object.assign({}, this);
+    return {
+      id: this.id,
+      name: this.name,
+      fields: this.fields,
+    } as IConfig;
   }
 }

--- a/public/configs/ingest_processors/ml_ingest_processor.ts
+++ b/public/configs/ingest_processors/ml_ingest_processor.ts
@@ -12,7 +12,6 @@ import { MLProcessor } from '../ml_processor';
 export class MLIngestProcessor extends MLProcessor {
   constructor() {
     super();
-    this.id = generateId('ml_ingest_processor');
-    this.name = 'ML ingest processor';
+    this.id = generateId('ml_processor_ingest');
   }
 }

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -3,15 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BaseConfig } from './base_config';
+import { PROCESSOR_TYPE } from '../../common';
+import { Processor } from './processor';
 
 /**
- * A generic ML processor config. Used in ingest and search flows.
+ * A base ML processor config. Used in ingest and search flows.
  * The interfaces are identical across ingest / search request / search response processors.
  */
-export abstract class MLProcessor extends BaseConfig {
+export abstract class MLProcessor extends Processor {
   constructor() {
     super();
+    this.type = PROCESSOR_TYPE.ML;
+    this.name = 'ML Inference Processor';
     this.fields = [
       {
         label: 'Model',

--- a/public/configs/processor.ts
+++ b/public/configs/processor.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IProcessorConfig, PROCESSOR_TYPE } from '../../common';
+import { BaseConfig } from './base_config';
+
+/**
+ * A base processor config class.
+ */
+export abstract class Processor extends BaseConfig {
+  type: PROCESSOR_TYPE;
+
+  // No-op constructor. If there are general / defaults for field values, add in here.
+  constructor() {
+    super();
+  }
+
+  toObj() {
+    return {
+      ...super.toObj(),
+      type: this.type,
+    } as IProcessorConfig;
+  }
+}

--- a/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
+++ b/public/pages/workflow_detail/utils/workflow_to_template_utils.ts
@@ -19,6 +19,7 @@ import {
   IProcessorConfig,
   MLInferenceProcessor,
   MapFormValue,
+  IngestProcessor,
 } from '../../../../common';
 import { generateId, processorConfigToFormik } from '../../../utils';
 
@@ -39,13 +40,9 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
   const nodes = [] as TemplateNode[];
   const edges = [] as TemplateEdge[];
 
-  // TODO: few assumptions are made here, such as there will always be
-  // a single ml-related processor. In the future make this more flexible and generic.
-  const mlProcessorConfig = config.ingest.enrich.processors.find(
-    (processorConfig) => processorConfig.type === PROCESSOR_TYPE.ML
-  ) as IProcessorConfig;
-
-  nodes.push(...mlProcessorConfigToTemplateNodes(mlProcessorConfig));
+  nodes.push(
+    ...processorConfigsToTemplateNodes(config.ingest.enrich.processors)
+  );
   nodes.push(
     indexConfigToTemplateNode(
       config.ingest.index,
@@ -62,62 +59,61 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
   };
 }
 
-// General fn to process all ML processor configs. Convert into a final ingest pipeline.
-// Optionally prepend a register pretrained model step if the selected model
-// is a pretrained and currently undeployed one.
-function mlProcessorConfigToTemplateNodes(
-  mlProcessorConfig: IProcessorConfig
+// General fn to process all processor configs. Generate a final
+// ingest pipeline containing all of the processors, maintaining order
+function processorConfigsToTemplateNodes(
+  processorConfigs: IProcessorConfig[]
 ): TemplateNode[] {
-  // TODO improvements to make here:
-  // 1. Consideration of multiple ingest processors and how to collect them all, and finally create
-  //    a single ingest pipeline with all of them, in the same order as done on the UI
-  switch (mlProcessorConfig.type) {
-    case PROCESSOR_TYPE.ML:
-    default: {
-      const { model, inputMap, outputMap } = processorConfigToFormik(
-        mlProcessorConfig
-      ) as {
-        model: ModelFormValue;
-        inputMap: MapFormValue;
-        outputMap: MapFormValue;
-      };
-      const ingestPipelineName = generateId('ingest_pipeline');
+  const processorsList = [] as IngestProcessor[];
 
-      let finalProcessor = {
-        ml_inference: {
-          model_id: model.id,
-        },
-      } as MLInferenceProcessor;
-      if (inputMap?.length > 0) {
-        finalProcessor.ml_inference.input_map = inputMap.map((mapEntry) => ({
-          [mapEntry.key]: mapEntry.value,
-        }));
-      }
-      if (outputMap?.length > 0) {
-        finalProcessor.ml_inference.output_map = outputMap.map((mapEntry) => ({
-          [mapEntry.key]: mapEntry.value,
-        }));
-      }
+  processorConfigs.forEach((processorConfig) => {
+    // TODO: support more processor types
+    switch (processorConfig.type) {
+      case PROCESSOR_TYPE.ML:
+      default: {
+        const { model, inputMap, outputMap } = processorConfigToFormik(
+          processorConfig
+        ) as {
+          model: ModelFormValue;
+          inputMap: MapFormValue;
+          outputMap: MapFormValue;
+        };
 
-      const finalIngestPipelineDescription =
-        'An ingest pipeline with an ML inference processor.';
-
-      const createIngestPipelineStep = {
-        id: ingestPipelineName,
-        type: WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE,
-        user_inputs: {
-          pipeline_id: ingestPipelineName,
-          model_id: model.id,
-          configurations: {
-            description: finalIngestPipelineDescription,
-            processors: [finalProcessor],
+        let processor = {
+          ml_inference: {
+            model_id: model.id,
           },
-        },
-      } as CreateIngestPipelineNode;
+        } as MLInferenceProcessor;
+        if (inputMap?.length > 0) {
+          processor.ml_inference.input_map = inputMap.map((mapEntry) => ({
+            [mapEntry.key]: mapEntry.value,
+          }));
+        }
+        if (outputMap?.length > 0) {
+          processor.ml_inference.output_map = outputMap.map((mapEntry) => ({
+            [mapEntry.key]: mapEntry.value,
+          }));
+        }
 
-      return [createIngestPipelineStep];
+        processorsList.push(processor);
+      }
     }
-  }
+  });
+
+  const ingestPipelineName = generateId('ingest_pipeline');
+  return [
+    {
+      id: ingestPipelineName,
+      type: WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE,
+      user_inputs: {
+        pipeline_id: ingestPipelineName,
+        configurations: {
+          description: 'An ingest pipeline',
+          processors: processorsList,
+        },
+      },
+    } as CreateIngestPipelineNode,
+  ];
 }
 
 // General fn to convert an index config to a final CreateIndexNode template node.

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { IConfigField, WorkflowConfig } from '../../../../../common';
-import { SelectField, TextField } from '../input_fields';
+import { TextField } from '../input_fields';
 
 interface IngestDataProps {
   uiConfig: WorkflowConfig;

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -108,18 +108,7 @@ function fetchSemanticSearchMetadata(): UIState {
   // We can reuse the base state. Only need to override a few things,
   // such as preset ingest processors.
   let baseState = fetchEmptyMetadata();
-  const processor = new MLIngestProcessor();
-  // @ts-ignore
-  baseState.config.ingest.enrich.processors = [
-    {
-      type: PROCESSOR_TYPE.ML,
-      id: processor.id,
-      fields: processor.fields,
-      metadata: {
-        label: processor.name,
-      },
-    },
-  ] as IProcessorConfig;
+  baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
   return baseState;
 }
 


### PR DESCRIPTION
### Description

This PR finishes the onboarding of the ML inference processor as an available processor to add and configure, and produce a usable final workflow template. Specifically:
- adds a `Processors` clickable context menu to select available processor types when adding a processor on the UI. Currently just ML inference processor type is supported
- finishes template support of creating a single ingest pipeline step from a dynamic list of processors of all types (previously stubbed to be a single ML processor)
- cleans up `configs/` interfaces and implements `toObj()` to easily convert processors into valid fields within `WorkflowConfig` without extra code


Demo showing the new button and the dynamic addition of multiple processors:

[screen-capture (41).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/36c94483-ec34-4142-8d0b-b6ba2cdaf262)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
