### PR TITLE
Onboard ML inference processors for search request / search response (form)

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -190,3 +190,9 @@ export const FETCH_ALL_QUERY_BODY = {
   size: 1000,
 };
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
+
+export enum PROCESSOR_CONTEXT {
+  INGEST = 'ingest',
+  SEARCH_REQUEST = 'search_request',
+  SEARCH_RESPONSE = 'search_response',
+}

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -41,7 +41,7 @@ export interface IProcessorConfig extends IConfig {
   type: PROCESSOR_TYPE;
 }
 
-export type EnrichConfig = {
+export type ProcessorsConfig = {
   processors: IProcessorConfig[];
 };
 
@@ -51,14 +51,14 @@ export type IndexConfig = {
 
 export type IngestConfig = {
   source: IConfig;
-  enrich: EnrichConfig;
+  enrich: ProcessorsConfig;
   index: IndexConfig;
 };
 
 export type SearchConfig = {
   request: IConfig;
-  enrichRequest: IConfig;
-  enrichResponse: IConfig;
+  enrichRequest: ProcessorsConfig;
+  enrichResponse: ProcessorsConfig;
 };
 
 export type WorkflowConfig = {

--- a/public/configs/index.ts
+++ b/public/configs/index.ts
@@ -4,3 +4,5 @@
  */
 
 export * from './ingest_processors';
+export * from './search_request_processors';
+export * from './search_response_processors';

--- a/public/configs/search_request_processors/index.ts
+++ b/public/configs/search_request_processors/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './ml_search_request_processor';

--- a/public/configs/search_request_processors/ml_search_request_processor.ts
+++ b/public/configs/search_request_processors/ml_search_request_processor.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { generateId } from '../../utils';
+import { MLProcessor } from '../ml_processor';
+
+/**
+ * The ML processor in the context of search request
+ */
+export class MLSearchRequestProcessor extends MLProcessor {
+  constructor() {
+    super();
+    this.id = generateId('ml_processor_search_request');
+  }
+}

--- a/public/configs/search_response_processors/index.ts
+++ b/public/configs/search_response_processors/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './ml_search_response_processor';

--- a/public/configs/search_response_processors/ml_search_response_processor.ts
+++ b/public/configs/search_response_processors/ml_search_response_processor.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { generateId } from '../../utils';
+import { MLProcessor } from '../ml_processor';
+
+/**
+ * The ML processor in the context of search response
+ */
+export class MLSearchResponseProcessor extends MLProcessor {
+  constructor() {
+    super();
+    this.id = generateId('ml_processor_search_response');
+  }
+}

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -5,3 +5,4 @@
 
 export { MultiSelectFilter } from './multi_select_filter';
 export { DeleteWorkflowModal } from './delete_workflow_modal';
+export { ProcessorsTitle } from './processors_title';

--- a/public/general_components/processors_title.tsx
+++ b/public/general_components/processors_title.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexItem, EuiTitle } from '@elastic/eui';
+
+interface ProcessorsTitleProps {
+  title: string;
+  processorCount: number;
+}
+
+/**
+ * General component for formatting processor titles
+ */
+export function ProcessorsTitle(props: ProcessorsTitleProps) {
+  return (
+    <EuiFlexItem grow={false} style={{ flex: 1, flexDirection: 'row' }}>
+      <EuiTitle size="s">
+        <div>
+          <h2
+            style={{ display: 'inline-block' }}
+          >{`${props.title} (${props.processorCount}) -`}</h2>
+          &nbsp;
+          <h2 style={{ display: 'inline-block', fontStyle: 'italic' }}>
+            optional
+          </h2>
+        </div>
+      </EuiTitle>
+    </EuiFlexItem>
+  );
+}

--- a/public/general_components/processors_title.tsx
+++ b/public/general_components/processors_title.tsx
@@ -16,7 +16,7 @@ interface ProcessorsTitleProps {
  */
 export function ProcessorsTitle(props: ProcessorsTitleProps) {
   return (
-    <EuiFlexItem grow={false} style={{ flex: 1, flexDirection: 'row' }}>
+    <EuiFlexItem grow={false}>
       <EuiTitle size="s">
         <div>
           <h2

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -4,9 +4,10 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsList } from './processors_list';
 import { WorkflowConfig } from '../../../../../common';
+import { ProcessorsTitle } from '../../../../general_components';
 
 interface EnrichDataProps {
   onFormChange: () => void;
@@ -20,11 +21,10 @@ interface EnrichDataProps {
 export function EnrichData(props: EnrichDataProps) {
   return (
     <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Enrich data</h4>
-        </EuiTitle>
-      </EuiFlexItem>
+      <ProcessorsTitle
+        title="Enrich data"
+        processorCount={props.uiConfig.ingest.enrich.processors?.length || 0}
+      />
       <EuiFlexItem>
         <ProcessorsList
           onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -5,8 +5,8 @@
 
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { ProcessorsList } from './processors_list';
-import { WorkflowConfig } from '../../../../../common';
+import { ProcessorsList } from '../processors_list';
+import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
 import { ProcessorsTitle } from '../../../../general_components';
 
 interface EnrichDataProps {
@@ -30,6 +30,7 @@ export function EnrichData(props: EnrichDataProps) {
           onFormChange={props.onFormChange}
           uiConfig={props.uiConfig}
           setUiConfig={props.setUiConfig}
+          context={PROCESSOR_CONTEXT.INGEST}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -20,8 +20,8 @@ export function IngestData(props: IngestDataProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Ingest data</h4>
+        <EuiTitle size="s">
+          <h2>Ingest data</h2>
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -34,8 +34,8 @@ export function SourceData(props: SourceDataProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Source data</h4>
+        <EuiTitle size="s">
+          <h2>Source data</h2>
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -15,8 +15,8 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Configure search request</h4>
+        <EuiTitle size="s">
+          <h2>Configure query</h2>
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -4,12 +4,15 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsTitle } from '../../../../general_components';
-import { WorkflowConfig } from '../../../../../common';
+import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
+import { ProcessorsList } from '../processors_list';
 
 interface EnrichSearchRequestProps {
   uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
+  onFormChange: () => void;
 }
 
 /**
@@ -21,11 +24,16 @@ export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
       <ProcessorsTitle
         title="Enhance query request"
         processorCount={
-          props.uiConfig.search.enrichRequest.processors?.length || 0
+          props.uiConfig.search?.enrichRequest?.processors?.length || 0
         }
       />
       <EuiFlexItem>
-        <EuiText grow={false}>TODO</EuiText>
+        <ProcessorsList
+          onFormChange={props.onFormChange}
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
+          context={PROCESSOR_CONTEXT.SEARCH_REQUEST}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -4,9 +4,13 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { ProcessorsTitle } from '../../../../general_components';
+import { WorkflowConfig } from '../../../../../common';
 
-interface EnrichSearchRequestProps {}
+interface EnrichSearchRequestProps {
+  uiConfig: WorkflowConfig;
+}
 
 /**
  * Input component for enriching a search request (configuring search request processors, etc.)
@@ -14,11 +18,12 @@ interface EnrichSearchRequestProps {}
 export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
   return (
     <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Enrich search request</h4>
-        </EuiTitle>
-      </EuiFlexItem>
+      <ProcessorsTitle
+        title="Enhance query request"
+        processorCount={
+          props.uiConfig.search.enrichRequest.processors?.length || 0
+        }
+      />
       <EuiFlexItem>
         <EuiText grow={false}>TODO</EuiText>
       </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -24,7 +24,7 @@ export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
       <ProcessorsTitle
         title="Enhance query request"
         processorCount={
-          props.uiConfig.search?.enrichRequest?.processors?.length || 0
+          props.uiConfig.search.enrichRequest.processors?.length || 0
         }
       />
       <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -4,12 +4,15 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsTitle } from '../../../../general_components';
-import { WorkflowConfig } from '../../../../../common';
+import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
+import { ProcessorsList } from '../processors_list';
 
 interface EnrichSearchResponseProps {
   uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
+  onFormChange: () => void;
 }
 
 /**
@@ -21,11 +24,16 @@ export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
       <ProcessorsTitle
         title="Enhance query results"
         processorCount={
-          props.uiConfig.search.enrichRequest.processors?.length || 0
+          props.uiConfig.search?.enrichRequest?.processors?.length || 0
         }
       />
       <EuiFlexItem>
-        <EuiText grow={false}>TODO</EuiText>
+        <ProcessorsList
+          onFormChange={props.onFormChange}
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
+          context={PROCESSOR_CONTEXT.SEARCH_RESPONSE}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -4,9 +4,13 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { ProcessorsTitle } from '../../../../general_components';
+import { WorkflowConfig } from '../../../../../common';
 
-interface EnrichSearchResponseProps {}
+interface EnrichSearchResponseProps {
+  uiConfig: WorkflowConfig;
+}
 
 /**
  * Input component for enriching a search response (configuring search response processors, etc.)
@@ -14,11 +18,12 @@ interface EnrichSearchResponseProps {}
 export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
   return (
     <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h4>Enrich search response</h4>
-        </EuiTitle>
-      </EuiFlexItem>
+      <ProcessorsTitle
+        title="Enhance query results"
+        processorCount={
+          props.uiConfig.search.enrichRequest.processors?.length || 0
+        }
+      />
       <EuiFlexItem>
         <EuiText grow={false}>TODO</EuiText>
       </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -24,7 +24,7 @@ export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
       <ProcessorsTitle
         title="Enhance query results"
         processorCount={
-          props.uiConfig.search?.enrichRequest?.processors?.length || 0
+          props.uiConfig.search.enrichResponse.processors?.length || 0
         }
       />
       <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -12,6 +12,8 @@ import { WorkflowConfig } from '../../../../../common';
 
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
+  onFormChange: () => void;
 }
 
 /**
@@ -27,13 +29,21 @@ export function SearchInputs(props: SearchInputsProps) {
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EnrichSearchRequest uiConfig={props.uiConfig} />
+        <EnrichSearchRequest
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
+          onFormChange={props.onFormChange}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EnrichSearchResponse uiConfig={props.uiConfig} />
+        <EnrichSearchResponse
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
+          onFormChange={props.onFormChange}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -27,13 +27,13 @@ export function SearchInputs(props: SearchInputsProps) {
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EnrichSearchRequest />
+        <EnrichSearchRequest uiConfig={props.uiConfig} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EnrichSearchResponse />
+        <EnrichSearchResponse uiConfig={props.uiConfig} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -242,7 +242,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 setUiConfig={props.setUiConfig}
               />
             ) : (
-              <SearchInputs uiConfig={props.uiConfig} />
+              <SearchInputs
+                uiConfig={props.uiConfig}
+                setUiConfig={props.setUiConfig}
+                onFormChange={props.onFormChange}
+              />
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false} style={{ marginBottom: '-10px' }}>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -216,6 +216,15 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               ]}
             ></EuiStepsHorizontal>
           </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiTitle>
+              <h2>
+                {selectedStep === CREATE_STEP.INGEST
+                  ? 'Define ingest pipeline'
+                  : 'Define search pipeline'}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
           <EuiFlexItem
             grow={true}
             style={{

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -15,6 +15,7 @@ import {
   EuiLoadingSpinner,
   EuiPanel,
   EuiStepsHorizontal,
+  EuiTitle,
 } from '@elastic/eui';
 import {
   Workflow,
@@ -219,7 +220,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           <EuiFlexItem grow={false}>
             <EuiTitle>
               <h2>
-                {selectedStep === CREATE_STEP.INGEST
+                {selectedStep === STEP.INGEST
                   ? 'Define ingest pipeline'
                   : 'Define search pipeline'}
               </h2>

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -69,6 +69,7 @@ function fetchEmptyMetadata(): UIState {
       ingest: {
         source: {
           id: 'source',
+          name: 'Source',
           fields: [],
         },
         enrich: {
@@ -85,15 +86,14 @@ function fetchEmptyMetadata(): UIState {
       search: {
         request: {
           id: 'request',
+          name: 'Request',
           fields: [],
         },
         enrichRequest: {
-          id: 'enrichRequest',
-          fields: [],
+          processors: [],
         },
         enrichResponse: {
-          id: 'enrichResponse',
-          fields: [],
+          processors: [],
         },
       },
     },

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -143,7 +143,10 @@ export function formikToUiConfig(
     formValues.ingest,
     updatedConfig.ingest
   );
-  updatedConfig['search'] = {} as SearchConfig;
+  updatedConfig['search'] = formikToSearchUiConfig(
+    formValues.search,
+    updatedConfig.search
+  ) as SearchConfig;
 
   return {
     ...updatedConfig,
@@ -168,6 +171,31 @@ function formikToIngestUiConfig(
   };
 }
 
+function formikToIndexUiConfig(
+  indexFormValues: FormikValues,
+  existingConfig: IndexConfig
+): IndexConfig {
+  existingConfig['name'].value = indexFormValues['name'];
+  return existingConfig;
+}
+
+function formikToSearchUiConfig(
+  searchFormValues: FormikValues,
+  existingConfig: SearchConfig
+): SearchConfig {
+  return {
+    ...existingConfig,
+    enrichRequest: formikToProcessorsUiConfig(
+      searchFormValues['enrichRequest'],
+      existingConfig.enrichRequest
+    ),
+    enrichResponse: formikToProcessorsUiConfig(
+      searchFormValues['enrichResponse'],
+      existingConfig.enrichResponse
+    ),
+  };
+}
+
 function formikToProcessorsUiConfig(
   formValues: FormikValues,
   existingConfig: ProcessorsConfig
@@ -178,14 +206,6 @@ function formikToProcessorsUiConfig(
       processorField.value = processorFormValues[processorField.id];
     });
   });
-  return existingConfig;
-}
-
-function formikToIndexUiConfig(
-  indexFormValues: FormikValues,
-  existingConfig: IndexConfig
-): IndexConfig {
-  existingConfig['name'].value = indexFormValues['name'];
   return existingConfig;
 }
 


### PR DESCRIPTION
### Description

This PR onboards the ML inference processor in the context of search request processors and search response processors in the `WorkflowInputs` form. Specifically:
- refactors interfaces and the `ProcessorsList` component to be generic and handle ingest / search request / search response processor contexts
- adds processor configs under `configs/` for the new processors
- updates `EnrichSearchRequest` and `EnrichSearchResponse` components to take in `ProcessorsList`
- updates and adds the utility fns to handle conversion of the search config processors to/from a config to form, and vice versa
- updates the initial Semantic Search use case to have a default empty list of processors
- title updates to the form - adds a generic `ProcessorsTitle` to be reused across the processor forms, and be consistent with UX mockups and to dynamically show the processors count

Onboarding to integrate within the reactflow workspace and the underlying workflow template will be done in a separate PR.

Demo video, showing the new processors, and consistent functionality regarding inputs/persisted state on save / etc.

[screen-capture (44).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/ec6838b0-67d1-4c58-9969-8a5806a9b1a5)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
