### PR TITLE
Integrate query into form (not persisted in config)

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -59,7 +59,7 @@ export type IngestConfig = {
 };
 
 export type SearchConfig = {
-  request: IConfig;
+  request: {};
   enrichRequest: ProcessorsConfig;
   enrichResponse: ProcessorsConfig;
 };

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -58,6 +58,9 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // ingest state
   const [ingestDocs, setIngestDocs] = useState<string>('');
 
+  // query state
+  const [query, setQuery] = useState<string>('');
+
   // Temp UI config state. For persisting changes to the UI config that may
   // not be saved in the backend (e.g., adding / removing an ingest processor)
   const [uiConfig, setUiConfig] = useState<WorkflowConfig | undefined>(
@@ -123,7 +126,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Initialize the form state based on the current UI config
   useEffect(() => {
     if (uiConfig) {
-      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs);
+      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs, query);
       const initFormSchema = uiConfigToSchema(uiConfig);
       setFormValues(initFormValues);
       setFormSchema(initFormSchema);
@@ -187,6 +190,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                       setQueryResponse={setQueryResponse}
                       ingestDocs={ingestDocs}
                       setIngestDocs={setIngestDocs}
+                      query={query}
+                      setQuery={setQuery}
                     />
                   </EuiResizablePanel>
                   <EuiResizableButton />

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -13,7 +13,7 @@ import { WorkflowConfig } from '../../../../../common';
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
-  setQuery: (query: {}) => void;
+  setQuery: (query: string) => void;
   onFormChange: () => void;
 }
 
@@ -24,7 +24,10 @@ export function SearchInputs(props: SearchInputsProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <ConfigureSearchRequest setQuery={props.setQuery} />
+        <ConfigureSearchRequest
+          setQuery={props.setQuery}
+          onFormChange={props.onFormChange}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -91,11 +91,7 @@ function fetchEmptyMetadata(): UIState {
         },
       },
       search: {
-        request: {
-          id: 'request',
-          name: 'Request',
-          fields: [],
-        },
+        request: {},
         enrichRequest: {
           processors: [],
         },

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -26,11 +26,12 @@ import {
 // and can be extremely large. so we pass that as a standalone field
 export function uiConfigToFormik(
   config: WorkflowConfig,
-  ingestDocs: string
+  ingestDocs: string,
+  query: string
 ): WorkflowFormValues {
   const formikValues = {} as WorkflowFormValues;
   formikValues['ingest'] = ingestConfigToFormik(config.ingest, ingestDocs);
-  formikValues['search'] = searchConfigToFormik(config.search);
+  formikValues['search'] = searchConfigToFormik(config.search, query);
   return formikValues;
 }
 
@@ -81,12 +82,12 @@ function indexConfigToFormik(indexConfig: IndexConfig): FormikValues {
 }
 
 function searchConfigToFormik(
-  searchConfig: SearchConfig | undefined
+  searchConfig: SearchConfig | undefined,
+  query: string
 ): FormikValues {
   let searchFormikValues = {} as FormikValues;
   if (searchConfig) {
-    // TODO: implement for request
-    searchFormikValues['request'] = {};
+    searchFormikValues['request'] = query || getInitialValue('json');
     searchFormikValues['enrichRequest'] = processorsConfigToFormik(
       searchConfig.enrichRequest
     );

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -39,6 +39,30 @@ function ingestConfigToSchema(
   return yup.object(ingestSchemaObj);
 }
 
+function indexConfigToSchema(indexConfig: IndexConfig): Schema {
+  const indexSchemaObj = {} as { [key: string]: Schema };
+  indexSchemaObj['name'] = getFieldSchema(indexConfig.name.type);
+  indexSchemaObj['mappings'] = getFieldSchema(indexConfig.mappings.type);
+  indexSchemaObj['settings'] = getFieldSchema(indexConfig.settings.type);
+  return yup.object(indexSchemaObj);
+}
+
+function searchConfigToSchema(
+  searchConfig: SearchConfig | undefined
+): ObjectSchema<any> {
+  const searchSchemaObj = {} as { [key: string]: Schema };
+  if (searchConfig) {
+    searchSchemaObj['request'] = getFieldSchema('json');
+    searchSchemaObj['enrichRequest'] = processorsConfigToSchema(
+      searchConfig.enrichRequest
+    );
+    searchSchemaObj['enrichResponse'] = processorsConfigToSchema(
+      searchConfig.enrichResponse
+    );
+  }
+  return yup.object(searchSchemaObj);
+}
+
 function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {
   const processorsSchemaObj = {} as { [key: string]: Schema };
   processorsConfig.processors.forEach((processorConfig) => {
@@ -50,23 +74,6 @@ function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {
   });
 
   return yup.object(processorsSchemaObj);
-}
-
-function indexConfigToSchema(indexConfig: IndexConfig): Schema {
-  const indexSchemaObj = {} as { [key: string]: Schema };
-  indexSchemaObj['name'] = getFieldSchema(indexConfig.name.type);
-  indexSchemaObj['mappings'] = getFieldSchema(indexConfig.mappings.type);
-  indexSchemaObj['settings'] = getFieldSchema(indexConfig.settings.type);
-  return yup.object(indexSchemaObj);
-}
-
-// TODO: implement this
-function searchConfigToSchema(
-  searchConfig: SearchConfig | undefined
-): ObjectSchema<any> {
-  const searchSchemaObj = {} as { [key: string]: Schema };
-
-  return yup.object(searchSchemaObj);
 }
 
 /*

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -33,10 +33,6 @@ import { generateId } from './utils';
  **************** Config -> workspace utils **********************
  */
 
-/*
- **************** ReactFlow workspace utils **********************
- */
-
 const PARENT_NODE_HEIGHT = 350;
 const NODE_HEIGHT_Y = 70;
 const NODE_WIDTH = 300; // based off of the value set in reactflow-styles.scss


### PR DESCRIPTION
### Description

Similar to the way we persist the ingest documents, we persist the query in the same form. This means:
1/ integrating with the overall form for schema/validation and temporary persistence
2/ not integrating with the underlying, persisted, indexed, config.

More details:
- persist the query state at the top-level `ResizableWorkspace` like the ingest docs
- update the query request form `ConfigureSearchRequest` to be similar to the ingest docs form, utilizing the `JsonField` component (which handles the auto-formatting as well)
- update `validateAndRunQuery()` to ensure there is a valid, non-empty query, when attempting to click 'Run query' button
- final updates to the formik and schema conversion fns to include the query field

Demo video showing validation, auto-formatting, persistence across page navigation, and finally the query execution:

[screen-capture (39).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/19d68be0-e832-4b5a-8e12-f521495285b3)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
