### PR TITLE
Add visual/json toggle and expose workflow template on editor

### DIFF
--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -240,7 +240,10 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                                 style={{ height: '100%' }}
                               >
                                 <EuiFlexItem>
-                                  <Workspace uiConfig={uiConfig} />
+                                  <Workspace
+                                    workflow={props.workflow}
+                                    uiConfig={uiConfig}
+                                  />
                                 </EuiFlexItem>
                               </EuiFlexGroup>
                             </EuiResizablePanel>

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
 import ReactFlow, {
   Controls,
   Background,
@@ -13,9 +13,16 @@ import ReactFlow, {
   BackgroundVariant,
   MarkerType,
 } from 'reactflow';
-import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiTitle,
+  EuiFilterGroup,
+  EuiFilterButton,
+  EuiCodeEditor,
+} from '@elastic/eui';
 import { setDirty, useAppDispatch } from '../../../store';
-import { IComponentData, WorkflowConfig } from '../../../../common';
+import { IComponentData, Workflow, WorkflowConfig } from '../../../../common';
 import {
   IngestGroupComponent,
   SearchGroupComponent,
@@ -31,6 +38,7 @@ import './workspace-styles.scss';
 import './workspace_edge/deletable-edge-styles.scss';
 
 interface WorkspaceProps {
+  workflow?: Workflow;
   uiConfig?: WorkflowConfig;
 }
 
@@ -43,6 +51,24 @@ const edgeTypes = { customEdge: DeletableEdge };
 
 export function Workspace(props: WorkspaceProps) {
   const dispatch = useAppDispatch();
+
+  // Visual/JSON toggle states
+  const [visualSelected, setVisualSelected] = useState<boolean>(true);
+  const [jsonSelected, setJsonSelected] = useState<boolean>(false);
+  function toggleSelection(): void {
+    setVisualSelected(!visualSelected);
+    setJsonSelected(!jsonSelected);
+  }
+
+  // JSON state
+  const [provisionTemplate, setProvisionTemplate] = useState<string>('');
+  useEffect(() => {
+    if (props.workflow?.workflows.provision) {
+      const templateAsObj = props.workflow?.workflows.provision as {};
+      const templateAsStr = JSON.stringify(templateAsObj, undefined, 2);
+      setProvisionTemplate(templateAsStr);
+    }
+  }, [props.workflow]);
 
   // ReactFlow state
   const reactFlowWrapper = useRef(null);
@@ -88,46 +114,92 @@ export function Workspace(props: WorkspaceProps) {
       gutterSize="none"
       justifyContent="spaceBetween"
     >
-      <EuiFlexItem className="euiPanel euiPanel--hasShadow euiPanel--borderRadiusMedium">
+      <EuiFlexItem
+        className="euiPanel euiPanel--hasShadow euiPanel--borderRadiusMedium"
+        style={{ overflowX: 'hidden' }}
+      >
         {/**
          * We have these wrapper divs & reactFlowWrapper ref to control and calculate the
          * ReactFlow bounds when calculating node positioning.
          */}
+        <div>
+          <EuiFlexGroup direction="row" style={{ padding: '12px' }}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle>
+                <h2>Preview</h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFilterGroup>
+                <EuiFilterButton
+                  size="l"
+                  hasActiveFilters={visualSelected}
+                  onClick={() => toggleSelection()}
+                >
+                  Visual
+                </EuiFilterButton>
+                <EuiFilterButton
+                  size="l"
+                  hasActiveFilters={jsonSelected}
+                  onClick={() => toggleSelection()}
+                >
+                  JSON
+                </EuiFilterButton>
+              </EuiFilterGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </div>
         <div className="reactflow-parent-wrapper">
           <div className="reactflow-wrapper" ref={reactFlowWrapper}>
-            <ReactFlow
-              id="workspace"
-              nodes={nodes}
-              edges={edges}
-              nodeTypes={nodeTypes}
-              // TODO: add custom edge types back if we want to support custom deletable buttons
-              // edgeTypes={edgeTypes}
-              onNodesChange={onNodesChange}
-              onEdgesChange={onEdgesChange}
-              onConnect={onConnect}
-              className="reactflow-workspace"
-              fitView
-              minZoom={0.2}
-              edgesUpdatable={false}
-              edgesFocusable={false}
-              nodesDraggable={false}
-              nodesConnectable={false}
-              nodesFocusable={false}
-              draggable={true}
-              panOnDrag={true}
-              elementsSelectable={false}
-            >
-              <Controls
-                showFitView={false}
-                showZoom={false}
-                showInteractive={false}
-                position="top-left"
-              ></Controls>
-              <Background
-                color="#343741"
-                variant={'dots' as BackgroundVariant}
+            {visualSelected ? (
+              <ReactFlow
+                id="workspace"
+                nodes={nodes}
+                edges={edges}
+                nodeTypes={nodeTypes}
+                // TODO: add custom edge types back if we want to support custom deletable buttons
+                // edgeTypes={edgeTypes}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={onConnect}
+                className="reactflow-workspace"
+                fitView
+                minZoom={0.2}
+                edgesUpdatable={false}
+                edgesFocusable={false}
+                nodesDraggable={false}
+                nodesConnectable={false}
+                nodesFocusable={false}
+                draggable={true}
+                panOnDrag={true}
+                elementsSelectable={false}
+              >
+                <Controls
+                  showFitView={false}
+                  showZoom={false}
+                  showInteractive={false}
+                  position="top-left"
+                ></Controls>
+                <Background
+                  color="#343741"
+                  variant={'dots' as BackgroundVariant}
+                />
+              </ReactFlow>
+            ) : (
+              <EuiCodeEditor
+                mode="json"
+                theme="textmate"
+                width="100%"
+                height="100%"
+                value={provisionTemplate}
+                readOnly={true}
+                setOptions={{
+                  fontSize: '12px',
+                  autoScrollEditorIntoView: true,
+                }}
+                tabSize={2}
               />
-            </ReactFlow>
+            )}
           </div>
         </div>
       </EuiFlexItem>


### PR DESCRIPTION
### Description
Adds a toggle between the visual view (the ReactFlow workspace) and the JSON view (the `provision` sub-workflow in the [workflow template](https://opensearch.org/docs/latest/automating-configurations/workflow-templates/)). This is where the logic to build out any ingest pipeline / search pipeline / index will be persisted and understandable by the backend.

Demo video, showing the toggling and the dynamically-updated template as resources get built out and updated.

[screen-capture (40).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/990486a8-3093-4ffa-8b00-26e11a2e4252)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
