### PR TITLE
Update header to show last updated and close button

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -4,32 +4,46 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   EuiPageHeader,
-  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import {
   DEFAULT_NEW_WORKFLOW_STATE,
   WORKFLOW_STATE,
   Workflow,
+  toFormattedDate,
 } from '../../../../common';
+import { APP_PATH } from '../../../utils';
 
 interface WorkflowDetailHeaderProps {
   workflow?: Workflow;
 }
 
 export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
+  const history = useHistory();
   // workflow state
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowState, setWorkflowState] = useState<WORKFLOW_STATE>('');
+  const [workflowLastUpdated, setWorkflowLastUpdated] = useState<string>('');
 
   useEffect(() => {
     if (props.workflow) {
       setWorkflowName(props.workflow.name);
       setWorkflowState(props.workflow.state || DEFAULT_NEW_WORKFLOW_STATE);
+      try {
+        const formattedDate = toFormattedDate(
+          // @ts-ignore
+          props.workflow.lastUpdated
+        ).toString();
+        setWorkflowLastUpdated(formattedDate);
+      } catch (err) {
+        setWorkflowLastUpdated('');
+      }
     }
   }, [props.workflow]);
 
@@ -45,10 +59,18 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
         </EuiFlexGroup>
       }
       rightSideItems={[
-        // TODO: implement export functionality
-        <EuiButton fill={false} style={{ marginTop: '8px' }} onClick={() => {}}>
-          Export
-        </EuiButton>,
+        <EuiButtonEmpty
+          style={{ marginTop: '8px' }}
+          onClick={() => {
+            // TODO: add lightweight save here when available
+            history.replace(APP_PATH.WORKFLOWS);
+          }}
+        >
+          Close
+        </EuiButtonEmpty>,
+        <EuiText style={{ marginTop: '16px' }} color="subdued" size="s">
+          {`Last updated: ${workflowLastUpdated}`}
+        </EuiText>,
       ]}
       bottomBorder={false}
     />


### PR DESCRIPTION
### Description

This PR updates the workflow detail header to show the last updated time, and repurposes the "Export" button to be a "Close" button that navigates to the workflow list page. There will be dedicated export functionality later on, within the inputs panel. Final UX TBD.

Demo video, showing the updated time automatically refreshed, and the close button navigation.

[screen-capture (41).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/13a3de24-4e58-4cae-9a95-2a1e551777af)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
