### PR TITLE
Support skipping ingest in `WorkflowInputs`

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Field, FieldProps } from 'formik';
+import { EuiRadioGroup, EuiRadioGroupOption } from '@elastic/eui';
+
+interface BooleanFieldProps {
+  fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
+  onFormChange: () => void;
+  enabledOption: EuiRadioGroupOption;
+  disabledOption: EuiRadioGroupOption;
+}
+
+/**
+ * An input field for a boolean value. Implemented as an EuiRadioGroup with 2 mutually exclusive options.
+ */
+export function BooleanField(props: BooleanFieldProps) {
+  return (
+    <Field name={props.fieldPath}>
+      {({ field, form }: FieldProps) => {
+        return (
+          <EuiRadioGroup
+            options={[props.enabledOption, props.disabledOption]}
+            idSelected={
+              field.value === undefined || field.value === true
+                ? props.enabledOption.id
+                : props.disabledOption.id
+            }
+            onChange={(id) => {
+              form.setFieldValue(field.name, !field.value);
+              props.onFormChange();
+            }}
+          />
+        );
+      }}
+    </Field>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
@@ -8,3 +8,4 @@ export { JsonField } from './json_field';
 export { SelectField } from './select_field';
 export { ModelField } from './model_field';
 export { MapField } from './map_field';
+export { BooleanField } from './boolean_field';

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -363,7 +363,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         fill={true}
                         onClick={() => setSelectedStep(STEP.SEARCH)}
                       >
-                        {`Next >`}
+                        {`Search pipeline >`}
                       </EuiButton>
                     </EuiFlexItem>
                   ) : onIngestAndUnprovisioned ? (
@@ -403,7 +403,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           fill={true}
                           onClick={() => setSelectedStep(STEP.SEARCH)}
                         >
-                          {`Next >`}
+                          {`Search pipeline >`}
                         </EuiButton>
                       </EuiFlexItem>
                     </>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -14,7 +14,9 @@ import {
   EuiHorizontalRule,
   EuiLoadingSpinner,
   EuiPanel,
+  EuiSpacer,
   EuiStepsHorizontal,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import {
@@ -40,6 +42,7 @@ import {
   configToTemplateFlows,
   hasProvisionedIngestResources,
 } from '../../../utils';
+import { BooleanField } from './input_fields';
 
 // styling
 import '../workspace/workspace-styles.scss';
@@ -57,9 +60,14 @@ interface WorkflowInputsProps {
   setQuery: (query: string) => void;
 }
 
-export enum STEP {
+enum STEP {
   INGEST = 'Ingestion pipeline',
   SEARCH = 'Search pipeline',
+}
+
+enum INGEST_OPTION {
+  CREATE = 'create',
+  SKIP = 'skip',
 }
 
 /**
@@ -81,8 +89,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   // maintain global states
   const onIngest = selectedStep === STEP.INGEST;
+  const ingestEnabled = values?.ingest?.enabled || false;
   const onIngestAndProvisioned = onIngest && ingestProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
+  const onIngestAndDisabled = onIngest && !ingestEnabled;
 
   useEffect(() => {
     setIngestProvisioned(hasProvisionedIngestResources(props.workflow));
@@ -265,42 +275,81 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                   onClick: () => {},
                 },
               ]}
-            ></EuiStepsHorizontal>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiTitle>
-              <h2>
-                {onIngestAndUnprovisioned
-                  ? 'Define ingest pipeline'
-                  : onIngestAndProvisioned
-                  ? 'Edit ingest pipeline'
-                  : 'Define search pipeline'}
-              </h2>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={true}
-            style={{
-              overflowY: 'scroll',
-              overflowX: 'hidden',
-            }}
-          >
-            {onIngest ? (
-              <IngestInputs
-                onFormChange={props.onFormChange}
-                setIngestDocs={props.setIngestDocs}
-                uiConfig={props.uiConfig}
-                setUiConfig={props.setUiConfig}
-              />
-            ) : (
-              <SearchInputs
-                uiConfig={props.uiConfig}
-                setUiConfig={props.setUiConfig}
-                setQuery={props.setQuery}
-                onFormChange={props.onFormChange}
-              />
+            />
+            {onIngest && (
+              <>
+                <EuiSpacer size="m" />
+                <BooleanField
+                  fieldPath="ingest.enabled"
+                  onFormChange={props.onFormChange}
+                  enabledOption={{
+                    id: INGEST_OPTION.CREATE,
+                    label: (
+                      <EuiFlexGroup direction="column" gutterSize="none">
+                        <EuiText color="default">
+                          Create an ingest pipeline
+                        </EuiText>
+                        <EuiText size="xs" color="subdued">
+                          Configure and ingest data into an index.
+                        </EuiText>
+                      </EuiFlexGroup>
+                    ),
+                  }}
+                  disabledOption={{
+                    id: INGEST_OPTION.SKIP,
+                    label: (
+                      <EuiFlexGroup direction="column" gutterSize="none">
+                        <EuiText color="default">
+                          Skip ingestion pipeline
+                        </EuiText>
+                        <EuiText size="xs" color="subdued">
+                          Use an existing index with data ingested.
+                        </EuiText>
+                      </EuiFlexGroup>
+                    ),
+                  }}
+                />
+              </>
             )}
           </EuiFlexItem>
+          {!onIngestAndDisabled && (
+            <>
+              <EuiFlexItem grow={false}>
+                <EuiTitle>
+                  <h2>
+                    {onIngestAndUnprovisioned
+                      ? 'Define ingest pipeline'
+                      : onIngestAndProvisioned
+                      ? 'Edit ingest pipeline'
+                      : 'Define search pipeline'}
+                  </h2>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={true}
+                style={{
+                  overflowY: 'scroll',
+                  overflowX: 'hidden',
+                }}
+              >
+                {onIngest ? (
+                  <IngestInputs
+                    onFormChange={props.onFormChange}
+                    setIngestDocs={props.setIngestDocs}
+                    uiConfig={props.uiConfig}
+                    setUiConfig={props.setUiConfig}
+                  />
+                ) : (
+                  <SearchInputs
+                    uiConfig={props.uiConfig}
+                    setUiConfig={props.setUiConfig}
+                    setQuery={props.setQuery}
+                    onFormChange={props.onFormChange}
+                  />
+                )}
+              </EuiFlexItem>
+            </>
+          )}
           <EuiFlexItem grow={false} style={{ marginBottom: '-10px' }}>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
@@ -308,7 +357,16 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFlexGroup direction="row" justifyContent="flexEnd">
-                  {onIngestAndUnprovisioned ? (
+                  {onIngest && !ingestEnabled ? (
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        fill={true}
+                        onClick={() => setSelectedStep(STEP.SEARCH)}
+                      >
+                        {`Next >`}
+                      </EuiButton>
+                    </EuiFlexItem>
+                  ) : onIngestAndUnprovisioned ? (
                     <>
                       <EuiFlexItem grow={false}>
                         <EuiButtonEmpty

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -41,6 +41,7 @@ function ingestConfigToFormik(
 ): FormikValues {
   let ingestFormikValues = {} as FormikValues;
   if (ingestConfig) {
+    ingestFormikValues['enabled'] = ingestConfig.enabled;
     ingestFormikValues['docs'] = ingestDocs || getInitialValue('json');
     ingestFormikValues['enrich'] = processorsConfigToFormik(
       ingestConfig.enrich

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -179,7 +179,18 @@ function indexConfigToTemplateNode(
   ingestPipelineNode?: CreateIngestPipelineNode,
   searchPipelineNode?: CreateSearchPipelineNode
 ): CreateIndexNode {
-  let finalSettings = indexConfig.settings.value as {};
+  let finalSettings = {};
+  let finalMappings = {};
+  try {
+    // @ts-ignore
+    finalSettings = JSON.parse(indexConfig.settings?.value);
+  } catch (e) {}
+  try {
+    // @ts-ignore
+    finalMappings = JSON.parse(indexConfig.mappings?.value);
+  } catch (e) {}
+
+  indexConfig.settings.value as {};
   let finalPreviousNodeInputs = {};
 
   function updateFinalInputsAndSettings(
@@ -218,7 +229,7 @@ function indexConfigToTemplateNode(
       index_name: indexConfig.name.value as string,
       configurations: {
         settings: finalSettings,
-        mappings: indexConfig.mappings.value as IndexMappings,
+        mappings: finalMappings,
       },
     },
   };

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -45,10 +45,10 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
   const nodes = [] as TemplateNode[];
   const edges = [] as TemplateEdge[];
 
-  if (config.ingest.enabled) {
-    nodes.push(...ingestConfigToTemplateNodes(config.ingest));
-  }
-  nodes.push(...searchConfigToTemplateNodes(config.search));
+  nodes.push(
+    ...ingestConfigToTemplateNodes(config.ingest),
+    ...searchConfigToTemplateNodes(config.search)
+  );
 
   const createIngestPipelineNode = nodes.find(
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE
@@ -82,7 +82,7 @@ function ingestConfigToTemplateNodes(
   );
   const hasProcessors = ingestProcessors.length > 0;
 
-  return hasProcessors
+  return hasProcessors && ingestConfig.enabled
     ? [
         {
           id: ingestPipelineName,

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -190,7 +190,6 @@ function indexConfigToTemplateNode(
     finalMappings = JSON.parse(indexConfig.mappings?.value);
   } catch (e) {}
 
-  indexConfig.settings.value as {};
   let finalPreviousNodeInputs = {};
 
   function updateFinalInputsAndSettings(

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -11,7 +11,6 @@ import {
   TemplateFlow,
   TemplateEdge,
   ModelFormValue,
-  IndexMappings,
   WORKFLOW_STEP_TYPE,
   WorkflowConfig,
   PROCESSOR_TYPE,
@@ -46,10 +45,10 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
   const nodes = [] as TemplateNode[];
   const edges = [] as TemplateEdge[];
 
-  nodes.push(
-    ...ingestConfigToTemplateNodes(config.ingest),
-    ...searchConfigToTemplateNodes(config.search)
-  );
+  if (config.ingest.enabled) {
+    nodes.push(...ingestConfigToTemplateNodes(config.ingest));
+  }
+  nodes.push(...searchConfigToTemplateNodes(config.search));
 
   const createIngestPipelineNode = nodes.find(
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE
@@ -58,13 +57,15 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
   ) as CreateSearchPipelineNode;
 
-  nodes.push(
-    indexConfigToTemplateNode(
-      config.ingest.index,
-      createIngestPipelineNode,
-      createSearchPipelineNode
-    )
-  );
+  if (config.ingest.enabled) {
+    nodes.push(
+      indexConfigToTemplateNode(
+        config.ingest.index,
+        createIngestPipelineNode,
+        createSearchPipelineNode
+      )
+    );
+  }
 
   return {
     nodes,

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -44,6 +44,7 @@ function formikToIngestUiConfig(
 ): IngestConfig {
   return {
     ...existingConfig,
+    enabled: ingestFormValues['enabled'],
     enrich: formikToProcessorsUiConfig(
       ingestFormValues['enrich'],
       existingConfig.enrich


### PR DESCRIPTION
### Description

This PR adds the option to skip ingest in the inputs. The selection is persisted in form state and in the indexed `WorkflowConfig`. More details:
- configures a generic `BooleanField` field integrated with formik for rendering and allowing the switching of the boolean form value
- exposes the skip option at the top-level of `WorkflowInputs`, only visible on ingest-side
- updates ingest state if skip is selected by hiding the rest of the input form
- updates the button state at the bottom of the input form when ingest is skipped or not skipped
- updates conversion fns between form / template / ui config to handle the boolean field. additionally, removes ingest-related template nodes (create ingest pipeline, create index) if disabled. This would leave the user with (at most) a single search pipeline.

Additional:
- bug fix on the template generation of the `create_index_step`. Specifically, the values were being saved as a `string`, needed to convert to `obj` to be parsed and constructed correctly on the backend when making the underlying API call.

Further work to add friction when changing from provisioned ingest resources -> skip is TBD, as design and UX is not finalized on that. The idea is that once a user switches to 'skip', we will need to deprovision and clean up any ingest-related resources (ingest pipeline, index) if applicable.

Demo video, showing the skip option, the updated states, and the persisted selection:

[screen-capture (42).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/98789094-3537-43fd-a7df-d0cd529c561e)


### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
