### PR TITLE
Add export step

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "formik": "2.4.2",
+    "js-yaml": "^4.1.0",
     "reactflow": "^11.8.3",
     "yup": "^1.3.2"
   },

--- a/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
@@ -70,7 +70,7 @@ export function ExportOptions(props: SearchInputsProps) {
       {props.workflow !== undefined && (
         <EuiFlexItem grow={false}>
           <EuiCodeBlock
-            language={selectedOption === EXPORT_OPTION.JSON ? 'json' : 'yaml'}
+            language={selectedOption}
             fontSize="m"
             isCopyable={true}
           >

--- a/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import yaml from 'js-yaml';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiRadioGroup,
+} from '@elastic/eui';
+import { Workflow } from '../../../../../common';
+import { reduceToTemplate } from '../../../../utils';
+
+interface SearchInputsProps {
+  workflow?: Workflow;
+}
+
+enum EXPORT_OPTION {
+  JSON = 'json',
+  YAML = 'yaml',
+}
+
+const exportOptions = [
+  {
+    id: EXPORT_OPTION.JSON,
+    label: 'JSON',
+  },
+  {
+    id: EXPORT_OPTION.YAML,
+    label: 'YAML',
+  },
+];
+
+/**
+ * The base component containing all of the export options
+ */
+export function ExportOptions(props: SearchInputsProps) {
+  // format type state
+  const [selectedOption, setSelectedOption] = useState<EXPORT_OPTION>(
+    EXPORT_OPTION.JSON
+  );
+
+  // formatted string state
+  const [formattedConfig, setFormattedConfig] = useState<string>('');
+  useEffect(() => {
+    if (props.workflow) {
+      const workflowTemplate = reduceToTemplate(props.workflow);
+      if (selectedOption === EXPORT_OPTION.JSON) {
+        setFormattedConfig(JSON.stringify(workflowTemplate, undefined, 2));
+      } else if (selectedOption === EXPORT_OPTION.YAML) {
+        setFormattedConfig(yaml.dump(workflowTemplate));
+      }
+    }
+  }, [props.workflow, selectedOption]);
+
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiRadioGroup
+          options={exportOptions}
+          idSelected={selectedOption}
+          onChange={(option) => {
+            setSelectedOption(option as EXPORT_OPTION);
+          }}
+        />
+      </EuiFlexItem>
+      {props.workflow !== undefined && (
+        <EuiFlexItem grow={false}>
+          <EuiCodeBlock
+            language={selectedOption === EXPORT_OPTION.JSON ? 'json' : 'yaml'}
+            fontSize="m"
+          >
+            {formattedConfig}
+          </EuiCodeBlock>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/export_options/export_options.tsx
@@ -72,6 +72,7 @@ export function ExportOptions(props: SearchInputsProps) {
           <EuiCodeBlock
             language={selectedOption === EXPORT_OPTION.JSON ? 'json' : 'yaml'}
             fontSize="m"
+            isCopyable={true}
           >
             {formattedConfig}
           </EuiCodeBlock>

--- a/public/pages/workflow_detail/workflow_inputs/export_options/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/export_options/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './export_options';

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -43,6 +43,7 @@ import {
   hasProvisionedIngestResources,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
+import { ExportOptions } from './export_options';
 
 // styling
 import '../workspace/workspace-styles.scss';
@@ -63,6 +64,7 @@ interface WorkflowInputsProps {
 enum STEP {
   INGEST = 'Ingestion pipeline',
   SEARCH = 'Search pipeline',
+  EXPORT = 'Export',
 }
 
 enum INGEST_OPTION {
@@ -89,6 +91,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   // maintain global states
   const onIngest = selectedStep === STEP.INGEST;
+  const onSearch = selectedStep === STEP.SEARCH;
+  const onExport = selectedStep === STEP.EXPORT;
   const ingestEnabled = values?.ingest?.enabled || false;
   const onIngestAndProvisioned = onIngest && ingestProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
@@ -264,14 +268,20 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               steps={[
                 {
                   title: STEP.INGEST,
-                  isComplete: selectedStep === STEP.SEARCH,
-                  isSelected: selectedStep === STEP.INGEST,
+                  isComplete: onSearch || onExport,
+                  isSelected: onIngest,
                   onClick: () => {},
                 },
                 {
                   title: STEP.SEARCH,
+                  isComplete: onExport,
+                  isSelected: onSearch,
+                  onClick: () => {},
+                },
+                {
+                  title: STEP.EXPORT,
                   isComplete: false,
-                  isSelected: selectedStep === STEP.SEARCH,
+                  isSelected: onExport,
                   onClick: () => {},
                 },
               ]}
@@ -321,7 +331,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       ? 'Define ingest pipeline'
                       : onIngestAndProvisioned
                       ? 'Edit ingest pipeline'
-                      : 'Define search pipeline'}
+                      : onSearch
+                      ? 'Define search pipeline'
+                      : 'Export project as'}
                   </h2>
                 </EuiTitle>
               </EuiFlexItem>
@@ -339,13 +351,15 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     uiConfig={props.uiConfig}
                     setUiConfig={props.setUiConfig}
                   />
-                ) : (
+                ) : onSearch ? (
                   <SearchInputs
                     uiConfig={props.uiConfig}
                     setUiConfig={props.setUiConfig}
                     setQuery={props.setQuery}
                     onFormChange={props.onFormChange}
                   />
+                ) : (
+                  <ExportOptions workflow={props.workflow} />
                 )}
               </EuiFlexItem>
             </>
@@ -407,7 +421,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         </EuiButton>
                       </EuiFlexItem>
                     </>
-                  ) : (
+                  ) : onSearch ? (
                     <>
                       <EuiFlexItem grow={false}>
                         <EuiButtonEmpty
@@ -419,12 +433,44 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       <EuiFlexItem grow={false}>
                         <EuiButton
                           disabled={false}
-                          fill={true}
+                          fill={false}
                           onClick={() => {
                             validateAndRunQuery();
                           }}
                         >
                           Run query
+                        </EuiButton>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiButton
+                          disabled={false}
+                          fill={false}
+                          onClick={() => {
+                            setSelectedStep(STEP.EXPORT);
+                          }}
+                        >
+                          {`Export >`}
+                        </EuiButton>
+                      </EuiFlexItem>
+                    </>
+                  ) : (
+                    <>
+                      <EuiFlexItem grow={false}>
+                        <EuiButtonEmpty
+                          onClick={() => setSelectedStep(STEP.SEARCH)}
+                        >
+                          Back
+                        </EuiButtonEmpty>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiButton
+                          disabled={false}
+                          fill={true}
+                          onClick={() => {
+                            // TODO: final UX for export flow is TBD.
+                          }}
+                        >
+                          Export
                         </EuiButton>
                       </EuiFlexItem>
                     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,11 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.11.tgz#012c17cb2256ad8de78560da851ab914a7b9b40e"
   integrity sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 classcat@^5.0.3, classcat@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.4.tgz#e12d1dfe6df6427f260f03b80dc63571a5107ba6"
@@ -374,6 +379,13 @@ hoist-non-react-statics@^3.3.0:
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 lodash-es@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
### Description

This PR adds the basic export step in the workflow editor. Specifically:
- adds a third step in `WorkflowInputs` and corresponding state to show a third export step, and updates buttons
- adds `ExportOptions` component with the ability to choose different output formats. Currently the backend supports JSON and YAML ([ref](https://opensearch.org/docs/latest/automating-configurations/workflow-templates/)), so we can support those here as well. Final functionality and UX flows are TBD - currently just displaying the formatted template within the editor and the ability to copy it to clipboard. The "Export" button is a placeholder for now
- adds MIT-licensed [js-yaml](https://www.npmjs.com/package/js-yaml) for its lightweight conversion utilities and to produce the final yaml template.

Demo video, showing the final template in JSON/YAML formats:

[screen-capture (46).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/239ddbc9-7e53-4a5b-82e1-118738980c0a)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
