### PR TITLE
Add invalid workflow state; support JSON doc uploads

### DIFF
--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -8,8 +8,14 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
-import { EuiFlexGroup, EuiFlexItem, EuiResizableContainer } from '@elastic/eui';
-import { getCore } from '../../services';
+import {
+  EuiCodeBlock,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiResizableContainer,
+  EuiText,
+} from '@elastic/eui';
 
 import {
   Workflow,
@@ -17,7 +23,11 @@ import {
   WorkflowFormValues,
   WorkflowSchema,
 } from '../../../common';
-import { APP_PATH, uiConfigToFormik, uiConfigToSchema } from '../../utils';
+import {
+  reduceToTemplate,
+  uiConfigToFormik,
+  uiConfigToSchema,
+} from '../../utils';
 import { AppState, setDirty, useAppDispatch } from '../../store';
 import { WorkflowInputs } from './workflow_inputs';
 import { Workspace } from './workspace';
@@ -40,7 +50,6 @@ const TOOLS_PANEL_ID = 'tools_panel_id';
  */
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   const dispatch = useAppDispatch();
-  const history = useHistory();
 
   // Overall workspace state
   const { isDirty } = useSelector((state: AppState) => state.workspace);
@@ -97,20 +106,15 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsToolsPanelOpen(!isToolsPanelOpen);
   };
 
-  // Hook to update some default values for the workflow, if applicable.
-  // We need to handle different scenarios:
-  // 1. Rendering backend-only-created workflow / an existing workflow with no ui_metadata.
-  //    In this case, we revert to the home page with a warn toast that we don't support it, for now.
-  // 2. Rendering a created workflow with ui_metadata.
-  //    In these cases, just render what is persisted, no action needed.
+  // workflow state
+  const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
+
+  // Hook to check if the workflow is valid or not
   useEffect(() => {
     const missingUiFlow =
       props.workflow && !props.workflow?.ui_metadata?.config;
     if (missingUiFlow) {
-      history.replace(APP_PATH.WORKFLOWS);
-      getCore().notifications.toasts.addWarning(
-        `There is no ui_metadata for workflow: ${props.workflow?.name}`
-      );
+      setIsValidWorkflow(false);
     } else {
       setWorkflow(props.workflow);
     }
@@ -143,7 +147,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     }
   }
 
-  return (
+  return isValidWorkflow ? (
     <Formik
       enableReinitialize={true}
       initialValues={formValues}
@@ -282,5 +286,28 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
         </Form>
       )}
     </Formik>
+  ) : (
+    <>
+      <EuiEmptyPrompt
+        iconType={'cross'}
+        title={<h2>Unable to view workflow details</h2>}
+        titleSize="s"
+        body={
+          <>
+            <EuiText>
+              Only valid workflows created from this OpenSearch Dashboards
+              application are editable and viewable.
+            </EuiText>
+          </>
+        }
+      />
+      <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
+        {JSON.stringify(
+          reduceToTemplate(props.workflow as Workflow),
+          undefined,
+          2
+        )}
+      </EuiCodeBlock>
+    </>
   );
 }

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -5,7 +5,6 @@
 
 import React, { useRef, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 import {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -21,8 +21,6 @@ interface IngestInputsProps {
  * The base component containing all of the ingest-related inputs
  */
 export function IngestInputs(props: IngestInputsProps) {
-  // TODO: add some toggle to enable/disable ingest altogether.
-  // UX not finalized on where that will live currently
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -5,7 +5,12 @@
 
 import React, { useEffect } from 'react';
 import { useFormikContext } from 'formik';
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import {
+  EuiFilePicker,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+} from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import { IConfigField, WorkspaceFormValues } from '../../../../../common';
 
@@ -18,7 +23,16 @@ interface SourceDataProps {
  * Input component for configuring the source data for ingest.
  */
 export function SourceData(props: SourceDataProps) {
-  const { values } = useFormikContext<WorkspaceFormValues>();
+  const { values, setFieldValue } = useFormikContext<WorkspaceFormValues>();
+
+  // files state. when a file is read, update the form value.
+  // TODO: double check json arr works, to handle multiple docs.
+  const fileReader = new FileReader();
+  fileReader.onload = (e) => {
+    if (e.target) {
+      setFieldValue('ingest.docs', e.target.result);
+    }
+  };
 
   // Hook to listen when the docs form value changes.
   // Try to set the ingestDocs if possible
@@ -34,6 +48,18 @@ export function SourceData(props: SourceDataProps) {
         <EuiTitle size="s">
           <h2>Source data</h2>
         </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFilePicker
+          multiple={false}
+          initialPromptText="Select a json file containing documents"
+          onChange={(files) => {
+            if (files && files.length > 0) {
+              fileReader.readAsText(files[0]);
+            }
+          }}
+          display="default"
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <JsonField

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -26,7 +26,6 @@ export function SourceData(props: SourceDataProps) {
   const { values, setFieldValue } = useFormikContext<WorkspaceFormValues>();
 
   // files state. when a file is read, update the form value.
-  // TODO: double check json arr works, to handle multiple docs.
   const fileReader = new FileReader();
   fileReader.onload = (e) => {
     if (e.target) {
@@ -51,8 +50,9 @@ export function SourceData(props: SourceDataProps) {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFilePicker
+          accept="application/json"
           multiple={false}
-          initialPromptText="Select a json file containing documents"
+          initialPromptText="Select a JSON file containing documents"
           onChange={(files) => {
             if (files && files.length > 0) {
               fileReader.readAsText(files[0]);


### PR DESCRIPTION
### Description

This PR achieves 2 small things:
1. Adds an invalid workflow state (layout/wording TBD). When a workflow doesn't have proper ui_metadata configured, shows some descriptive text and the current template of the workflow to provide some utility & visibility.
2. Adds a FilePicker to select any local JSON file (limited to `.json` files only for now), and when loaded, populates the input form with its contents. Further guardrails, different filetypes, etc. have not been finalized.

Demo showing the invalid state and the filepicker, and loading in a file `test.json` that contains the simple json `{ "hello": "world" }`

[screen-capture (47).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/1ca82ded-c05f-401c-8434-472e972649ea)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
