### PR TITLE
Finalize edit flow for ingest inputs

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -3,11 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSuperSelect,
+  EuiSuperSelectOption,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { useFormikContext } from 'formik';
 import { IConfigField, WorkspaceFormValues } from '../../../../../common';
 import { JsonField } from '../input_fields';
+import { AppState, catIndices, useAppDispatch } from '../../../../store';
 
 interface ConfigureSearchRequestProps {
   setQuery: (query: string) => void;
@@ -18,7 +29,20 @@ interface ConfigureSearchRequestProps {
  * Input component for configuring a search request
  */
 export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
+  const dispatch = useAppDispatch();
+
+  // Form state
   const { values } = useFormikContext<WorkspaceFormValues>();
+  const indexName = values.ingest.index.name;
+  const ingestEnabled = values.ingest.enabled;
+
+  // All indices state
+  const indices = useSelector((state: AppState) => state.opensearch.indices);
+
+  // Selected index state
+  const [selectedIndex, setSelectedIndex] = useState<string | undefined>(
+    undefined
+  );
 
   // Hook to listen when the query form value changes.
   // Try to set the query request if possible
@@ -28,12 +52,43 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
     }
   }, [values?.search?.request]);
 
+  // Initialization hook to fetch available indices (if applicable)
+  useEffect(() => {
+    if (!ingestEnabled) {
+      // Fetch all indices besides system indices
+      dispatch(catIndices('*,-.*'));
+    }
+  }, []);
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
         <EuiTitle size="s">
           <h2>Configure query</h2>
         </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFormRow label="Retrieval index">
+          {ingestEnabled ? (
+            <EuiFieldText value={indexName} readOnly={true} />
+          ) : (
+            <EuiSuperSelect
+              options={Object.values(indices).map(
+                (option) =>
+                  ({
+                    value: option.name,
+                    inputDisplay: <EuiText>{option.name}</EuiText>,
+                    disabled: false,
+                  } as EuiSuperSelectOption<string>)
+              )}
+              valueOfSelected={selectedIndex}
+              onChange={(option) => {
+                setSelectedIndex(option);
+              }}
+              isInvalid={selectedIndex !== undefined}
+            />
+          )}
+        </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <JsonField

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -450,27 +450,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         {`Search pipeline >`}
                       </EuiButton>
                     </EuiFlexItem>
-                  ) : onIngestAndUnprovisioned ? (
-                    <>
-                      <EuiFlexItem grow={false}>
-                        <EuiButtonEmpty
-                          onClick={() => setSelectedStep(STEP.SEARCH)}
-                        >
-                          Skip
-                        </EuiButtonEmpty>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiButton
-                          fill={true}
-                          onClick={() => {
-                            validateAndRunIngestion();
-                          }}
-                        >
-                          Run ingestion
-                        </EuiButton>
-                      </EuiFlexItem>
-                    </>
-                  ) : onIngestAndProvisioned ? (
+                  ) : onIngest ? (
                     <>
                       <EuiFlexItem grow={false}>
                         <EuiButton
@@ -478,6 +458,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           onClick={() => {
                             validateAndRunIngestion();
                           }}
+                          disabled={ingestProvisioned}
                         >
                           Run ingestion
                         </EuiButton>
@@ -486,6 +467,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         <EuiButton
                           fill={true}
                           onClick={() => setSelectedStep(STEP.SEARCH)}
+                          disabled={!ingestProvisioned}
                         >
                           {`Search pipeline >`}
                         </EuiButton>

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -29,3 +29,17 @@ export function hasProvisionedIngestResources(
   });
   return result;
 }
+
+export function hasProvisionedSearchResources(
+  workflow: Workflow | undefined
+): boolean {
+  let result = false;
+  workflow?.resourcesCreated?.some((resource) => {
+    if (
+      resource.stepType === WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
+    ) {
+      result = true;
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
### Description

This PR finalizes all create and edit states for the ingest flow configuration. Specifically:
- updates buttons to be consistent, and be enabled/disabled based on the form and edit state
- updates edit flow to have a 'Delete resources' button, which opens a confirmation modal to confirm deletion. if deletion is selected, revert to the create state, but defaulted to the 'skip' option.
- updates search flow to have a dynamic index configuration; if ingest is configured, enforce the search flow is against the configured index. if ingest is not configured/skipped, then provide a dropdown listing out available indices the user can select to run the search flow against

Demo video showing the create and edit states, new buttons, resource deletion confirmation, and the 2 different states of the configured index on the search flow:

[screen-capture (48).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/0361f1ca-9ca2-4b5e-89b0-60761a3ca7f5)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
