### PR TITLE
Add name confirmation modal on create

### DIFF
--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   EuiText,
@@ -13,6 +13,14 @@ import {
   EuiCard,
   EuiHorizontalRule,
   EuiButton,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFormRow,
 } from '@elastic/eui';
 import { Workflow } from '../../../../common';
 import { APP_PATH } from '../../../utils';
@@ -20,7 +28,6 @@ import { processWorkflowName } from './utils';
 import { createWorkflow, useAppDispatch } from '../../../store';
 
 interface UseCaseProps {
-  // onClick: () => {};
   workflow: Workflow;
 }
 
@@ -28,35 +35,50 @@ export function UseCase(props: UseCaseProps) {
   const dispatch = useAppDispatch();
   const history = useHistory();
 
+  // name modal state
+  const [isNameModalOpen, setIsNameModalOpen] = useState<boolean>(false);
+
+  // workflow name state
+  const [workflowName, setWorkflowName] = useState<string>(
+    processWorkflowName(props.workflow.name)
+  );
+
   return (
-    <EuiCard
-      title={
-        <EuiTitle size="s">
-          <h2>{props.workflow.name}</h2>
-        </EuiTitle>
-      }
-      titleSize="s"
-      paddingSize="l"
-      layout="horizontal"
-    >
-      <EuiFlexGroup direction="column" gutterSize="l">
-        <EuiHorizontalRule size="full" margin="m" />
-        <EuiFlexItem grow={true}>
-          <EuiText>{props.workflow.description}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexGroup direction="column" alignItems="center">
-          <EuiFlexItem grow={false}>
+    <>
+      {isNameModalOpen && (
+        <EuiModal onClose={() => setIsNameModalOpen(false)}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <p>{`Set a unique name for your workflow`}</p>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiFormRow
+              label={'Name'}
+              error={'Name cannot be empty'}
+              isInvalid={workflowName === ''}
+            >
+              <EuiFieldText
+                placeholder={processWorkflowName(props.workflow.name)}
+                compressed={false}
+                value={workflowName}
+                onChange={(e) => {
+                  setWorkflowName(e.target.value);
+                }}
+              />
+            </EuiFormRow>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButtonEmpty onClick={() => setIsNameModalOpen(false)}>
+              Cancel
+            </EuiButtonEmpty>
             <EuiButton
-              disabled={false}
-              isLoading={false}
+              disabled={workflowName === ''}
               onClick={() => {
                 const workflowToCreate = {
                   ...props.workflow,
-                  // TODO: handle duplicate name gracefully. it won't slash or produce errors, but nice-to-have
-                  // as long as not too expensive to fetch duplicate names
-                  name: processWorkflowName(props.workflow.name),
+                  name: workflowName,
                 };
-
                 dispatch(createWorkflow(workflowToCreate))
                   .unwrap()
                   .then((result) => {
@@ -68,12 +90,44 @@ export function UseCase(props: UseCaseProps) {
                     console.error(err);
                   });
               }}
+              fill={true}
+              color="primary"
             >
               Create
             </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+      <EuiCard
+        title={
+          <EuiTitle size="s">
+            <h2>{props.workflow.name}</h2>
+          </EuiTitle>
+        }
+        titleSize="s"
+        paddingSize="l"
+        layout="horizontal"
+      >
+        <EuiFlexGroup direction="column" gutterSize="l">
+          <EuiHorizontalRule size="full" margin="m" />
+          <EuiFlexItem grow={true}>
+            <EuiText>{props.workflow.description}</EuiText>
           </EuiFlexItem>
+          <EuiFlexGroup direction="column" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                disabled={false}
+                isLoading={false}
+                onClick={() => {
+                  setIsNameModalOpen(true);
+                }}
+              >
+                Go
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexGroup>
-      </EuiFlexGroup>
-    </EuiCard>
+      </EuiCard>
+    </>
   );
 }


### PR DESCRIPTION
### Description
This PR tunes the creation flow slightly to allow setting a custom name on workflow creation from the new workflow page. Also changes the default button text in the cards to `Go`. Defaults the workflow name to the same as before. Also has validation that the name cannot be empty.

Demo video showing the new flow and validation:

[screen-capture (49).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/17889c20-ec29-4bb9-9126-6f0104738785)

### Issues Resolved
Makes progress on #66 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
