### PR TITLE
Support importing local workflow templates

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -287,12 +287,13 @@ export type TemplateFlows = {
 
 // A stateless template of a workflow
 export type WorkflowTemplate = {
+  // Name is the only required field: see https://opensearch.org/docs/latest/automating-configurations/api/create-workflow/#request-fields
   name: string;
-  description: string;
+  description?: string;
   // TODO: finalize on version type when that is implemented
   // https://github.com/opensearch-project/flow-framework/issues/526
-  version: any;
-  workflows: TemplateFlows;
+  version?: any;
+  workflows?: TemplateFlows;
   use_case?: USE_CASE;
   // UI state and any ReactFlow state may not exist if a workflow is created via API/backend-only.
   ui_metadata?: UIState;

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -286,27 +286,31 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       )}
     </Formik>
   ) : (
-    <>
-      <EuiEmptyPrompt
-        iconType={'cross'}
-        title={<h2>Unable to view workflow details</h2>}
-        titleSize="s"
-        body={
-          <>
-            <EuiText>
-              Only valid workflows created from this OpenSearch Dashboards
-              application are editable and viewable.
-            </EuiText>
-          </>
-        }
-      />
-      <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
-        {JSON.stringify(
-          reduceToTemplate(props.workflow as Workflow),
-          undefined,
-          2
-        )}
-      </EuiCodeBlock>
-    </>
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem grow={3}>
+        <EuiEmptyPrompt
+          iconType={'cross'}
+          title={<h2>Unable to view workflow details</h2>}
+          titleSize="s"
+          body={
+            <>
+              <EuiText>
+                Only valid workflows created from this OpenSearch Dashboards
+                application are editable and viewable.
+              </EuiText>
+            </>
+          }
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={7}>
+        <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
+          {JSON.stringify(
+            reduceToTemplate(props.workflow as Workflow),
+            undefined,
+            2
+          )}
+        </EuiCodeBlock>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -23,6 +23,7 @@ import {
   WorkflowSchema,
 } from '../../../common';
 import {
+  isValidUiWorkflow,
   reduceToTemplate,
   uiConfigToFormik,
   uiConfigToSchema,
@@ -110,8 +111,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
 
   // Hook to check if the workflow is valid or not
   useEffect(() => {
-    const missingUiFlow =
-      props.workflow && !props.workflow?.ui_metadata?.config;
+    const missingUiFlow = props.workflow && !isValidUiWorkflow(props.workflow);
     if (missingUiFlow) {
       setIsValidWorkflow(false);
     } else {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
-import { IConfigField, WorkspaceFormValues } from '../../../../../common';
+import { WorkspaceFormValues } from '../../../../../common';
 
 interface SourceDataProps {
   setIngestDocs: (docs: string) => void;

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiButtonEmpty,
+  EuiButton,
+  EuiText,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiFilePicker,
+  EuiCallOut,
+  EuiFlexItem,
+} from '@elastic/eui';
+import {
+  getObjFromJsonOrYamlString,
+  isValidUiWorkflow,
+  isValidWorkflow,
+} from '../../../utils';
+import { getCore } from '../../../services';
+import {
+  createWorkflow,
+  searchWorkflows,
+  useAppDispatch,
+} from '../../../store';
+import { FETCH_ALL_QUERY_BODY, Workflow } from '../../../../common';
+import { WORKFLOWS_TAB } from '../workflows';
+
+interface ImportWorkflowModalProps {
+  isImportModalOpen: boolean;
+  setIsImportModalOpen(isOpen: boolean): void;
+  setSelectedTabId(tabId: WORKFLOWS_TAB): void;
+}
+
+/**
+ * The import workflow modal. Allows uploading local JSON or YAML files to be uploaded, parsed, and
+ * created as new workflows. Automatic validation is handled to:
+ * 1/ allow upload (valid workflow with UI data),
+ * 2/ warn and allow upload (valid workflow but missing/no UI data), and
+ * 3/ prevent upload (invalid workflow).
+ */
+export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
+  const dispatch = useAppDispatch();
+
+  // file contents & file obj state
+  const [fileContents, setFileContents] = useState<string | undefined>(
+    undefined
+  );
+  const [fileObj, setFileObj] = useState<object | undefined>(undefined);
+  useEffect(() => {
+    setFileObj(getObjFromJsonOrYamlString(fileContents));
+  }, [fileContents]);
+
+  // file reader to read the file and set the fileContents var
+  const fileReader = new FileReader();
+  fileReader.onload = (e) => {
+    if (e.target) {
+      setFileContents(e.target.result as string);
+    }
+  };
+
+  function onModalClose(): void {
+    props.setIsImportModalOpen(false);
+    setFileContents(undefined);
+    setFileObj(undefined);
+  }
+
+  return (
+    <EuiModal onClose={() => onModalClose()} style={{ width: '40vw' }}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Import a workflow (JSON/YAML)`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiFlexGroup
+          direction="column"
+          justifyContent="center"
+          alignItems="center"
+        >
+          {fileContents !== undefined && !isValidWorkflow(fileObj) && (
+            <>
+              <EuiFlexItem>
+                <EuiCallOut
+                  title="The uploaded file is not a valid workflow, remove the file and upload a compatible workflow in JSON or YAML format."
+                  iconType={'alert'}
+                  color="danger"
+                />
+              </EuiFlexItem>
+              <EuiSpacer size="m" />
+            </>
+          )}
+          {isValidWorkflow(fileObj) && !isValidUiWorkflow(fileObj) && (
+            <>
+              <EuiFlexItem>
+                <EuiCallOut
+                  title="The uploaded file may not be compatible with Search Studio. You may not be able to edit or run this file with Search Studio."
+                  iconType={'help'}
+                  color="warning"
+                />
+              </EuiFlexItem>
+              <EuiSpacer size="m" />
+            </>
+          )}
+          <EuiFlexItem grow={false}>
+            <EuiFilePicker
+              multiple={false}
+              initialPromptText="Select or drag and drop a file"
+              onChange={(files) => {
+                if (files && files.length > 0) {
+                  fileReader.readAsText(files[0]);
+                }
+              }}
+              display="large"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s" color="subdued">
+              Must be in JSON or YAML format.
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={() => onModalClose()}>Cancel</EuiButtonEmpty>
+        <EuiButton
+          disabled={!isValidWorkflow(fileObj)}
+          onClick={() => {
+            dispatch(createWorkflow(fileObj as Workflow))
+              .unwrap()
+              .then((result) => {
+                const { workflow } = result;
+                dispatch(searchWorkflows(FETCH_ALL_QUERY_BODY));
+                props.setSelectedTabId(WORKFLOWS_TAB.MANAGE);
+                getCore().notifications.toasts.addSuccess(
+                  `Successfully imported ${workflow.name}`
+                );
+              })
+              .catch((error: any) => {
+                getCore().notifications.toasts.addDanger(error);
+              })
+              .finally(() => {
+                onModalClose();
+              });
+          }}
+          fill={true}
+          color="primary"
+        >
+          {isValidWorkflow(fileObj) && !isValidUiWorkflow(fileObj)
+            ? 'Import anyway'
+            : 'Import'}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflows/import_workflow/index.ts
+++ b/public/pages/workflows/import_workflow/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { ImportWorkflowModal } from './import_workflow_modal';

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -19,7 +19,6 @@ import {
   EuiTitle,
   EuiFlyoutBody,
   EuiText,
-  EuiLink,
 } from '@elastic/eui';
 import { AppState, deleteWorkflow, useAppDispatch } from '../../../store';
 import { UIState, WORKFLOW_TYPE, Workflow } from '../../../../common';
@@ -181,15 +180,7 @@ export function WorkflowList(props: WorkflowListProps) {
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
           <EuiFlexGroup direction="row" style={{ marginLeft: '0px' }}>
-            <EuiText color="subdued">{`Manage existing workflows or`}</EuiText>
-            &nbsp;
-            <EuiText>
-              <EuiLink
-                onClick={() => props.setSelectedTabId(WORKFLOWS_TAB.CREATE)}
-              >
-                create a new workflow
-              </EuiLink>
-            </EuiText>
+            <EuiText color="subdued">{`Manage existing workflows`}</EuiText>
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -163,16 +163,38 @@ export function Workflows(props: WorkflowsProps) {
                   </h2>
                 </EuiTitle>
               }
-              rightSideItems={[
-                <EuiButton
-                  style={{ marginTop: '8px' }}
-                  onClick={() => {
-                    setIsImportModalOpen(true);
-                  }}
-                >
-                  Import workflow
-                </EuiButton>,
-              ]}
+              rightSideItems={
+                selectedTabId === WORKFLOWS_TAB.MANAGE
+                  ? [
+                      <EuiButton
+                        style={{ marginTop: '8px' }}
+                        fill={true}
+                        onClick={() => {
+                          setSelectedTabId(WORKFLOWS_TAB.CREATE);
+                        }}
+                      >
+                        Create workflow
+                      </EuiButton>,
+                      <EuiButton
+                        style={{ marginTop: '8px' }}
+                        onClick={() => {
+                          setIsImportModalOpen(true);
+                        }}
+                      >
+                        Import workflow
+                      </EuiButton>,
+                    ]
+                  : [
+                      <EuiButton
+                        style={{ marginTop: '8px' }}
+                        onClick={() => {
+                          setIsImportModalOpen(true);
+                        }}
+                      >
+                        Import workflow
+                      </EuiButton>,
+                    ]
+              }
               bottomBorder={false}
             />
             {selectedTabId === WORKFLOWS_TAB.MANAGE ? (

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -4,7 +4,8 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation } from 'react-router-dom';
+import { RouteComponentProps, useHistory, useLocation } from 'react-router-dom';
+import yaml from 'js-yaml';
 import {
   EuiPageHeader,
   EuiTitle,
@@ -12,14 +13,31 @@ import {
   EuiPageBody,
   EuiPageContent,
   EuiSpacer,
+  EuiFlexGroup,
+  EuiButtonEmpty,
+  EuiButton,
+  EuiText,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiFormRow,
+  EuiFieldText,
+  EuiModalFooter,
+  EuiFilePicker,
 } from '@elastic/eui';
 import queryString from 'query-string';
 import { useSelector } from 'react-redux';
-import { BREADCRUMBS } from '../../utils';
+import { APP_PATH, BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
 import { WorkflowList } from './workflow_list';
 import { NewWorkflow } from './new_workflow';
-import { AppState, searchWorkflows, useAppDispatch } from '../../store';
+import {
+  AppState,
+  createWorkflow,
+  searchWorkflows,
+  useAppDispatch,
+} from '../../store';
 import { EmptyListMessage } from './empty_list_message';
 import { FETCH_ALL_QUERY_BODY } from '../../../common';
 
@@ -50,14 +68,43 @@ function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
  */
 export function Workflows(props: WorkflowsProps) {
   const dispatch = useAppDispatch();
+  const history = useHistory();
   const { workflows, loading, errorMessage } = useSelector(
     (state: AppState) => state.workflows
   );
 
+  // import modal state
+  const [isImportModalOpen, setIsImportModalOpen] = useState<boolean>(false);
+
+  // file contents state
+  const [fileContents, setFileContents] = useState<string | undefined>(
+    undefined
+  );
+  const fileReader = new FileReader();
+  fileReader.onload = (e) => {
+    if (e.target) {
+      setFileContents(e.target.result as string);
+    }
+  };
+
+  // tab state
   const tabFromUrl = queryString.parse(useLocation().search)[
     ACTIVE_TAB_PARAM
   ] as WORKFLOWS_TAB;
   const [selectedTabId, setSelectedTabId] = useState<WORKFLOWS_TAB>(tabFromUrl);
+
+  function isValidJsonOrYaml(fileContents: string | undefined): boolean {
+    try {
+      JSON.parse(fileContents);
+      return true;
+    } catch (e) {}
+    try {
+      yaml.load(fileContents);
+      return true;
+    } catch (e) {}
+
+    return false;
+  }
 
   // If there is no selected tab or invalid tab, default to manage tab
   useEffect(() => {
@@ -98,58 +145,155 @@ export function Workflows(props: WorkflowsProps) {
   }, []);
 
   return (
-    <EuiPage>
-      <EuiPageBody>
-        <EuiPageHeader
-          pageTitle="Workflows"
-          tabs={[
-            {
-              id: WORKFLOWS_TAB.MANAGE,
-              label: 'Manage workflows',
-              isSelected: selectedTabId === WORKFLOWS_TAB.MANAGE,
-              onClick: () => {
-                setSelectedTabId(WORKFLOWS_TAB.MANAGE);
-                replaceActiveTab(WORKFLOWS_TAB.MANAGE, props);
+    <>
+      {isImportModalOpen && (
+        <EuiModal onClose={() => setIsImportModalOpen(false)}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <p>{`Import a workflow (JSON/YAML)`}</p>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <>
+              <EuiFilePicker
+                isInvalid={
+                  fileContents !== undefined && !isValidJsonOrYaml(fileContents)
+                }
+                multiple={false}
+                initialPromptText="Select or drag and drop a file"
+                onChange={(files) => {
+                  if (files && files.length > 0) {
+                    fileReader.readAsText(files[0]);
+                  }
+                }}
+                display="large"
+              />
+              <EuiSpacer size="s" />
+              <EuiText size="s" color="subdued">
+                Must be in JSON or YAML format.
+              </EuiText>
+              <EuiText size="s" color="danger">
+                {fileContents !== undefined && !isValidJsonOrYaml(fileContents)
+                  ? 'Selected file is invalid'
+                  : undefined}
+              </EuiText>
+            </>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButtonEmpty onClick={() => setIsImportModalOpen(false)}>
+              Cancel
+            </EuiButtonEmpty>
+            <EuiButton
+              disabled={
+                fileContents === undefined || !isValidJsonOrYaml(fileContents)
+              }
+              onClick={() => {
+                // const workflowToCreate = {
+                //   ...props.workflow,
+                //   name: workflowName,
+                // };
+                // dispatch(createWorkflow(workflowToCreate))
+                //   .unwrap()
+                //   .then((result) => {
+                //     const { workflow } = result;
+                //     history.replace(APP_PATH.WORKFLOWS);
+                //     history.go(0);
+                //   })
+                //   .catch((err: any) => {
+                //     console.error(err);
+                //   });
+              }}
+              fill={true}
+              color="primary"
+            >
+              Import
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+      <EuiPage>
+        <EuiPageBody>
+          <EuiPageHeader
+            pageTitle={
+              <EuiFlexGroup direction="column" style={{ margin: '0px' }}>
+                <EuiTitle size="l">
+                  <h2>Search Studio</h2>
+                </EuiTitle>
+                <EuiText color="subdued">
+                  Design, experiment, and prototype your solutions with
+                  workflows. Build your search and last mile ingestion flows.
+                </EuiText>
+              </EuiFlexGroup>
+            }
+            tabs={[
+              {
+                id: WORKFLOWS_TAB.MANAGE,
+                label: 'Manage workflows',
+                isSelected: selectedTabId === WORKFLOWS_TAB.MANAGE,
+                onClick: () => {
+                  setSelectedTabId(WORKFLOWS_TAB.MANAGE);
+                  replaceActiveTab(WORKFLOWS_TAB.MANAGE, props);
+                },
               },
-            },
-            {
-              id: WORKFLOWS_TAB.CREATE,
-              label: 'New workflow',
-              isSelected: selectedTabId === WORKFLOWS_TAB.CREATE,
-              onClick: () => {
-                setSelectedTabId(WORKFLOWS_TAB.CREATE);
-                replaceActiveTab(WORKFLOWS_TAB.CREATE, props);
-              },
-            },
-          ]}
-          bottomBorder={true}
-        />
-
-        <EuiPageContent>
-          <EuiTitle>
-            <h2>
-              {selectedTabId === WORKFLOWS_TAB.MANAGE && 'Workflows'}
-              {selectedTabId === WORKFLOWS_TAB.CREATE &&
-                'Create a new workflow'}
-            </h2>
-          </EuiTitle>
-          <EuiSpacer size="m" />
-          {selectedTabId === WORKFLOWS_TAB.MANAGE && (
-            <WorkflowList setSelectedTabId={setSelectedTabId} />
-          )}
-          {selectedTabId === WORKFLOWS_TAB.CREATE && <NewWorkflow />}
-          {selectedTabId === WORKFLOWS_TAB.MANAGE &&
-            Object.keys(workflows || {}).length === 0 &&
-            !loading && (
-              <EmptyListMessage
-                onClickNewWorkflow={() => {
+              {
+                id: WORKFLOWS_TAB.CREATE,
+                label: 'New workflow',
+                isSelected: selectedTabId === WORKFLOWS_TAB.CREATE,
+                onClick: () => {
                   setSelectedTabId(WORKFLOWS_TAB.CREATE);
                   replaceActiveTab(WORKFLOWS_TAB.CREATE, props);
-                }}
-              />
+                },
+              },
+            ]}
+            bottomBorder={true}
+          />
+
+          <EuiPageContent>
+            <EuiPageHeader
+              style={{ marginTop: '-8px' }}
+              pageTitle={
+                <EuiTitle size="m">
+                  <h2>
+                    {' '}
+                    {selectedTabId === WORKFLOWS_TAB.MANAGE
+                      ? 'Workflows'
+                      : 'Create from a template'}
+                  </h2>
+                </EuiTitle>
+              }
+              rightSideItems={[
+                <EuiButton
+                  style={{ marginTop: '8px' }}
+                  onClick={() => {
+                    setIsImportModalOpen(true);
+                  }}
+                >
+                  Import workflow
+                </EuiButton>,
+              ]}
+              bottomBorder={false}
+            />
+            {selectedTabId === WORKFLOWS_TAB.MANAGE ? (
+              <WorkflowList setSelectedTabId={setSelectedTabId} />
+            ) : (
+              <>
+                <EuiSpacer size="m" />
+                <NewWorkflow />
+              </>
             )}
-        </EuiPageContent>
-      </EuiPageBody>
-    </EuiPage>
+            {selectedTabId === WORKFLOWS_TAB.MANAGE &&
+              Object.keys(workflows || {}).length === 0 &&
+              !loading && (
+                <EmptyListMessage
+                  onClickNewWorkflow={() => {
+                    setSelectedTabId(WORKFLOWS_TAB.CREATE);
+                    replaceActiveTab(WORKFLOWS_TAB.CREATE, props);
+                  }}
+                />
+              )}
+          </EuiPageContent>
+        </EuiPageBody>
+      </EuiPage>
+    </>
   );
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -66,5 +66,9 @@ export function isValidWorkflow(workflowObj: object | undefined): boolean {
 }
 
 export function isValidUiWorkflow(workflowObj: object | undefined): boolean {
-  return workflowObj?.ui_metadata?.config !== undefined;
+  return (
+    isValidWorkflow(workflowObj) &&
+    workflowObj?.ui_metadata?.config !== undefined &&
+    workflowObj?.ui_metadata?.type !== undefined
+  );
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -45,15 +45,26 @@ export function hasProvisionedSearchResources(
   return result;
 }
 
-export function isValidJsonOrYaml(fileContents: string | undefined): boolean {
+export function getObjFromJsonOrYamlString(
+  fileContents: string | undefined
+): object | undefined {
   try {
-    JSON.parse(fileContents);
-    return true;
+    const jsonObj = JSON.parse(fileContents);
+    return jsonObj;
   } catch (e) {}
   try {
-    yaml.load(fileContents);
-    return true;
+    const yamlObj = yaml.load(fileContents) as object;
+    return yamlObj;
   } catch (e) {}
+  return undefined;
+}
 
-  return false;
+// Based off of https://opensearch.org/docs/latest/automating-configurations/api/create-workflow/#request-fields
+// Only "name" field is required
+export function isValidWorkflow(workflowObj: object | undefined): boolean {
+  return workflowObj?.name !== undefined;
+}
+
+export function isValidUiWorkflow(workflowObj: object | undefined): boolean {
+  return workflowObj?.ui_metadata?.config !== undefined;
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import yaml from 'js-yaml';
 import { WORKFLOW_STEP_TYPE, Workflow } from '../../common';
 
 // Append 16 random characters
@@ -42,4 +43,17 @@ export function hasProvisionedSearchResources(
     }
   });
   return result;
+}
+
+export function isValidJsonOrYaml(fileContents: string | undefined): boolean {
+  try {
+    JSON.parse(fileContents);
+    return true;
+  } catch (e) {}
+  try {
+    yaml.load(fileContents);
+    return true;
+  } catch (e) {}
+
+  return false;
 }


### PR DESCRIPTION
### Description

This PR adds support for importing locally saved workflow templates in JSON or YAML format. A new button is available on the base workflows page, for both the workflows list and the new workflow tabs. When clicked, opens up a modal where users can drag-and-drop or import a template from their local filesystem. The modal will validated and prevent or allow importing, depending on 3 different states:
1. Valid UI template (containing the required workflow fields, + containing `ui_metadata` field). No warnings, and users can import. _Note if this is manually done / misconfigured this may still fail; it is up to the user to not corrupt the values within `ui_metadata`_.
2. Valid template (containing the required workflow fields, but not containing `ui_metadata`). Warns that the workflow can be imported, but may not be visible from the editor etc. since there is no ui metadata to parse.
3. Invalid template (doesn't contain the required workflow fields, isn't a JSON or YAML file, isn't a parse-able JSON or YAML file, etc.). Tells user the workflow is invalid, blocks any import.


When a user clicks "Import", the plugin attempts to create that workflow on the selected cluster, and is then viewable the same way as any other workflow. Any failures are propagated in a toast message with details, no different than if they were to run the create workflow API directly with the contents of the file.

Demo video showing the 3 different states, and successful importing into the cluster via the modal:

[screen-capture.webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/e8d0df2d-dd3c-45db-aa1b-f1a87bf270c9)

Testing:
- JSON template pulled via `export` step can be imported and load everything correctly
- YAML templated pulled via `export` step can be imported and load everything correctly
- non-JSON/non-YAML files are rejected
- format issues with JSON or YAML files are rejected
- workflows with no ui_metadata show correct state
- workflows with valid ui_metadata show correct state

Other minor changes:
- improves spacing on invalid UI workflow state
- helper functions for determining the validity of a workflow template
- moves the create workflow button into a button on the right-hand side on the workflows list page
- minor wording and format updates to headers on the workflows page

### Issues Resolved
Makes progress on #66 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
