### PR TITLE
Add error field to workflow; propagate all runtime errors in tools tab

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -310,6 +310,8 @@ export type Workflow = WorkflowTemplate & {
   // won't exist until launched/provisioned in backend
   state?: WORKFLOW_STATE;
   // won't exist until launched/provisioned in backend
+  error?: string;
+  // won't exist until launched/provisioned in backend
   resourcesCreated?: WorkflowResource[];
 };
 

--- a/public/pages/workflow_detail/tools/errors/errors.tsx
+++ b/public/pages/workflow_detail/tools/errors/errors.tsx
@@ -4,14 +4,27 @@
  */
 
 import React from 'react';
-import { EuiText } from '@elastic/eui';
+import { EuiCodeBlock, EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
 
-interface ErrorsProps {}
+interface ErrorsProps {
+  errorMessage: string;
+}
 
 /**
  * The basic errors component for the Tools panel.
  * Displays any errors found while users configure and test their workflow.
  */
 export function Errors(props: ErrorsProps) {
-  return <EuiText>TODO: add errors details here</EuiText>;
+  return (
+    <>
+      {isEmpty(props.errorMessage) ? (
+        <EuiText>There are no errors.</EuiText>
+      ) : (
+        <EuiCodeBlock fontSize="m" isCopyable={false}>
+          {props.errorMessage}
+        </EuiCodeBlock>
+      )}
+    </>
+  );
 }

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -42,9 +42,7 @@ interface WorkflowDetailProps
 
 export function WorkflowDetail(props: WorkflowDetailProps) {
   const dispatch = useAppDispatch();
-  const { workflows, errorMessage } = useSelector(
-    (state: AppState) => state.workflows
-  );
+  const { workflows } = useSelector((state: AppState) => state.workflows);
 
   // selected workflow state
   const workflowId = props.match?.params?.workflowId;
@@ -66,14 +64,6 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     dispatch(getWorkflow(workflowId));
     dispatch(searchModels(FETCH_ALL_QUERY_BODY));
   }, []);
-
-  // Show a toast if an error message exists in state
-  useEffect(() => {
-    if (errorMessage) {
-      console.error(errorMessage);
-      getCore().notifications.toasts.addDanger(errorMessage);
-    }
-  }, [errorMessage]);
 
   return (
     <ReactFlowProvider>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -224,7 +224,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               dispatch(removeDirty());
             })
             .catch((error: any) => {
-              getCore().notifications.toasts.addDanger(error);
               props.setIngestResponse('');
               throw error;
             });
@@ -257,7 +256,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               dispatch(removeDirty());
             })
             .catch((error: any) => {
-              getCore().notifications.toasts.addDanger(error);
               props.setQueryResponse('');
               throw error;
             });
@@ -334,9 +332,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           // @ts-ignore
                           await dispatch(getWorkflow(props.workflow.id));
                         })
-                        .catch((error: any) => {
-                          getCore().notifications.toasts.addDanger(error);
-                        })
+                        .catch((error: any) => {})
                         .finally(() => {
                           setIsModalOpen(false);
                         });

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -54,7 +54,7 @@ function replaceActiveTab(activeTab: string, props: WorkflowsProps) {
  */
 export function Workflows(props: WorkflowsProps) {
   const dispatch = useAppDispatch();
-  const { workflows, loading, errorMessage } = useSelector(
+  const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
 
@@ -91,14 +91,6 @@ export function Workflows(props: WorkflowsProps) {
       BREADCRUMBS.WORKFLOWS,
     ]);
   });
-
-  // Show a toast if an error message exists in state
-  useEffect(() => {
-    if (errorMessage) {
-      console.error(errorMessage);
-      getCore().notifications.toasts.addDanger(errorMessage);
-    }
-  }, [errorMessage]);
 
   // On initial render: fetch all workflows
   useEffect(() => {

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -89,6 +89,10 @@ const opensearchSlice = createSlice({
         state.loading = true;
         state.errorMessage = '';
       })
+      .addCase(ingest.pending, (state, action) => {
+        state.loading = true;
+        state.errorMessage = '';
+      })
       .addCase(catIndices.fulfilled, (state, action) => {
         const indicesMap = new Map<string, Index>();
         action.payload.forEach((index: Index) => {
@@ -102,11 +106,19 @@ const opensearchSlice = createSlice({
         state.loading = false;
         state.errorMessage = '';
       })
+      .addCase(ingest.fulfilled, (state, action) => {
+        state.loading = false;
+        state.errorMessage = '';
+      })
       .addCase(catIndices.rejected, (state, action) => {
         state.errorMessage = action.payload as string;
         state.loading = false;
       })
       .addCase(searchIndex.rejected, (state, action) => {
+        state.errorMessage = action.payload as string;
+        state.loading = false;
+      })
+      .addCase(ingest.rejected, (state, action) => {
         state.errorMessage = action.payload as string;
         state.loading = false;
       });

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -4,7 +4,7 @@
  */
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { Workflow, WorkflowDict, WorkflowTemplate } from '../../../common';
+import { WorkflowDict, WorkflowTemplate } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
 

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -243,6 +243,7 @@ export function reduceToTemplate(workflow: Workflow): WorkflowTemplate {
     lastUpdated,
     lastLaunched,
     state,
+    error,
     resourcesCreated,
     ...workflowTemplate
   } = workflow;

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -182,6 +182,7 @@ export class FlowFrameworkRoutesService {
       const workflowWithState = {
         ...workflow,
         state,
+        error: stateResponse.error,
         resourcesCreated,
       } as Workflow;
       return res.ok({ body: { workflow: workflowWithState } });

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -69,6 +69,7 @@ export function getWorkflowsFromResponses(
     const workflowState = getWorkflowStateFromResponse(
       workflowStateHit?._source?.state
     );
+    const workflowError = workflowStateHit?._source?.error;
     const workflowResourcesCreated = getResourcesCreatedFromResponse(
       workflowStateHit?._source?.resources_created
     );
@@ -76,6 +77,7 @@ export function getWorkflowsFromResponses(
       ...workflowDict[workflowHit._id],
       // @ts-ignore
       state: workflowState,
+      error: workflowError,
       resourcesCreated: workflowResourcesCreated,
     };
   });


### PR DESCRIPTION
### Description
This PR consolidates some of the error handling and finishes the `Errors` tab in the `Tools` component. `Tools` will automatically switch to the `Errors` tab if any of the following occur:
- error while performing the ingest/query OpenSearch APIs executing when testing ingest/search
- error while performing CRUD APIs on a workflow (create/update/provision/deprovision)
- underlying API error when performing provision/deprovision <-- these are special cases where the REST call returns success, but the `error` field within the workflow state will be populated if some intermediate step may have failed (e.g., index already exists when provisioning, error creating ingest pipeline, etc.)

To handle the last case, we need to persist the error found in redux store, similar to the workflow state. This PR adds the optional `error` to the `Workflow` interface and persists it when it is found in API responses on server-side (both the get workflow path, and the search workflow path that could be multiple workflows)

Other minor changes:
- cleans up some unnecessary toasts on the base Workflows and Workflow Editor pages, as well as in the helper fns when performing the different API dispatch calls.
- integrates ingest API into redux which was originally missed

Demo video shows an example of 2 different types of failures:
1/ error when running ingest due to the document being in an invalid format when passed to the LLM via the ML inference processor
2/ error when provisioning a workflow since the index name is already created

In both cases, the `Tools` tab automatically redirects to the `Errors` tab and displays the relevant message. Final formatting of the error message is TBD as there is no UX for that.

[screen-capture (2).webm](https://github.com/opensearch-project/dashboards-flow-framework/assets/62119629/72844c9e-1a14-496f-8dec-860953139aec)


### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
