### PR TITLE
Integrate with updated Flow Framework APIs

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -104,6 +104,10 @@ export function MapField(props: MapFieldProps) {
                               className="euiFieldText"
                               value={mapping.key}
                               onChange={(e) => {
+                                form.setFieldTouched(
+                                  `${props.fieldPath}.${idx}.key`,
+                                  true
+                                );
                                 form.setFieldValue(
                                   `${props.fieldPath}.${idx}.key`,
                                   e.target.value
@@ -119,6 +123,10 @@ export function MapField(props: MapFieldProps) {
                               className="euiFieldText"
                               value={mapping.value}
                               onChange={(e) => {
+                                form.setFieldTouched(
+                                  `${props.fieldPath}.${idx}.value`,
+                                  true
+                                );
                                 form.setFieldValue(
                                   `${props.fieldPath}.${idx}.value`,
                                   e.target.value

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -108,6 +108,7 @@ export function ModelField(props: ModelFieldProps) {
               )}
               valueOfSelected={field.value?.id || ''}
               onChange={(option: string) => {
+                form.setFieldTouched(props.fieldPath, true);
                 form.setFieldValue(props.fieldPath, {
                   id: option,
                 } as ModelFormValue);

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -313,6 +313,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         queryObj = JSON.parse(props.query);
       } catch (e) {}
       if (!isEmpty(queryObj)) {
+        // TODO: currently this will execute deprovision in child fns.
+        // In the future, we must omit deprovisioning the index, as it contains
+        // the data we are executing the query against. Tracking issue:
+        // https://github.com/opensearch-project/flow-framework/issues/717
         success = await validateAndUpdateWorkflow();
         if (success) {
           const indexName = values.ingest.index.name;

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -53,6 +53,7 @@ import {
   hasProvisionedIngestResources,
   hasProvisionedSearchResources,
   generateId,
+  getResourcesToBeForceDeleted,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import { ExportOptions } from './export_options';
@@ -129,7 +130,12 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     updatedWorkflow: Workflow
   ): Promise<boolean> {
     let success = false;
-    await dispatch(deprovisionWorkflow(updatedWorkflow.id as string))
+    await dispatch(
+      deprovisionWorkflow({
+        workflowId: updatedWorkflow.id as string,
+        resourceIds: getResourcesToBeForceDeleted(props.workflow),
+      })
+    )
       .unwrap()
       .then(async (result) => {
         await dispatch(
@@ -312,7 +318,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               <EuiModal onClose={() => setIsModalOpen(false)}>
                 <EuiModalHeader>
                   <EuiModalHeaderTitle>
-                    <p>{`Delete resources for workflow ${props.workflow.name}?`}</p>
+                    <p>{`Delete resources for workflow ${props.workflow?.name}?`}</p>
                   </EuiModalHeaderTitle>
                 </EuiModalHeader>
                 <EuiModalBody>
@@ -328,8 +334,14 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                   </EuiButtonEmpty>
                   <EuiButton
                     onClick={async () => {
-                      // @ts-ignore
-                      await dispatch(deprovisionWorkflow(props.workflow.id))
+                      await dispatch(
+                        deprovisionWorkflow({
+                          workflowId: props.workflow?.id as string,
+                          resourceIds: getResourcesToBeForceDeleted(
+                            props.workflow
+                          ),
+                        })
+                      )
                         .unwrap()
                         .then(async (result) => {
                           setFieldValue('ingest.enabled', false);

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -137,7 +137,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const debounceAutosave = useCallback(
     debounce(async () => {
       triggerAutosave();
-    }, 1000),
+    }, 10000),
     [autosave]
   );
 

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useFormikContext } from 'formik';
-import { isEmpty } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -31,6 +31,7 @@ import {
   Workflow,
   WorkflowConfig,
   WorkflowFormValues,
+  WorkflowTemplate,
 } from '../../../../common';
 import { IngestInputs } from './ingest_inputs';
 import { SearchInputs } from './search_inputs';
@@ -91,9 +92,13 @@ enum INGEST_OPTION {
  */
 
 export function WorkflowInputs(props: WorkflowInputsProps) {
-  const { submitForm, validateForm, setFieldValue, values } = useFormikContext<
-    WorkflowFormValues
-  >();
+  const {
+    submitForm,
+    validateForm,
+    setFieldValue,
+    values,
+    touched,
+  } = useFormikContext<WorkflowFormValues>();
   const dispatch = useAppDispatch();
 
   // Overall workspace state
@@ -117,6 +122,57 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const onIngestAndProvisioned = onIngest && ingestProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
   const onIngestAndDisabled = onIngest && !ingestEnabled;
+
+  const [autosave, setAutosave] = useState<boolean>(false);
+  function triggerAutosave(): void {
+    setAutosave(!autosave);
+  }
+
+  // Auto-save the UI metadata when users update form values.
+  // Only update the underlying workflow template (deprovision/provision) when
+  // users explicitly run ingest/search and need to have updated resources
+  // to test against.
+  // We use useCallback() with an autosave flag that is only set within the fn itself.
+  // This is so we can fetch the latest values (uiConfig, formik values) inside a memoized fn,
+  // but only when we need to
+  const debounceAutosave = useCallback(
+    debounce(async () => {
+      triggerAutosave();
+    }, 1000),
+    [autosave]
+  );
+
+  useEffect(() => {
+    (async () => {
+      if (!isEmpty(touched)) {
+        const updatedTemplate = {
+          name: props.workflow?.name,
+          ui_metadata: {
+            ...props.workflow?.ui_metadata,
+            config: formikToUiConfig(values, props.uiConfig as WorkflowConfig),
+          },
+        } as WorkflowTemplate;
+        await dispatch(
+          updateWorkflow({
+            workflowId: props.workflow?.id as string,
+            workflowTemplate: updatedTemplate,
+            updateFields: true,
+          })
+        )
+          .unwrap()
+          .then(async (result) => {})
+          .catch((error: any) => {
+            console.error('Error autosaving workflow: ', error);
+          });
+      }
+    })();
+  }, [autosave]);
+
+  useEffect(() => {
+    if (values?.ingest !== undefined) {
+      debounceAutosave();
+    }
+  }, [values?.ingest]);
 
   useEffect(() => {
     setIngestProvisioned(hasProvisionedIngestResources(props.workflow));

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -42,7 +42,10 @@ export interface RouteService {
     workflowTemplate: WorkflowTemplate
   ) => Promise<any | HttpFetchError>;
   provisionWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
-  deprovisionWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
+  deprovisionWorkflow: (
+    workflowId: string,
+    resourceIds?: string
+  ) => Promise<any | HttpFetchError>;
   deleteWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
   getWorkflowPresets: () => Promise<any | HttpFetchError>;
   catIndices: (pattern: string) => Promise<any | HttpFetchError>;
@@ -134,11 +137,12 @@ export function configureRoutes(core: CoreStart): RouteService {
         return e as HttpFetchError;
       }
     },
-    deprovisionWorkflow: async (workflowId: string) => {
+    deprovisionWorkflow: async (workflowId: string, resourceIds?: string) => {
       try {
-        const response = await core.http.post<{ respString: string }>(
-          `${DEPROVISION_WORKFLOW_NODE_API_PATH}/${workflowId}`
-        );
+        const path = resourceIds
+          ? `${DEPROVISION_WORKFLOW_NODE_API_PATH}/${workflowId}/${resourceIds}`
+          : `${DEPROVISION_WORKFLOW_NODE_API_PATH}/${workflowId}`;
+        const response = await core.http.post<{ respString: string }>(path);
         return response;
       } catch (e: any) {
         return e as HttpFetchError;

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -39,7 +39,8 @@ export interface RouteService {
   createWorkflow: (body: {}) => Promise<any | HttpFetchError>;
   updateWorkflow: (
     workflowId: string,
-    workflowTemplate: WorkflowTemplate
+    workflowTemplate: WorkflowTemplate,
+    updateFields: boolean
   ) => Promise<any | HttpFetchError>;
   provisionWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
   deprovisionWorkflow: (
@@ -113,11 +114,12 @@ export function configureRoutes(core: CoreStart): RouteService {
     },
     updateWorkflow: async (
       workflowId: string,
-      workflowTemplate: WorkflowTemplate
+      workflowTemplate: WorkflowTemplate,
+      updateFields: boolean
     ) => {
       try {
         const response = await core.http.put<{ respString: string }>(
-          `${UPDATE_WORKFLOW_NODE_API_PATH}/${workflowId}`,
+          `${UPDATE_WORKFLOW_NODE_API_PATH}/${workflowId}/${updateFields}`,
           {
             body: JSON.stringify(workflowTemplate),
           }

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -91,15 +91,20 @@ export const createWorkflow = createAsyncThunk(
 export const updateWorkflow = createAsyncThunk(
   UPDATE_WORKFLOW_ACTION,
   async (
-    workflowInfo: { workflowId: string; workflowTemplate: WorkflowTemplate },
+    workflowInfo: {
+      workflowId: string;
+      workflowTemplate: WorkflowTemplate;
+      updateFields?: boolean;
+    },
     { rejectWithValue }
   ) => {
-    const { workflowId, workflowTemplate } = workflowInfo;
+    const { workflowId, workflowTemplate, updateFields } = workflowInfo;
     const response:
       | any
       | HttpFetchError = await getRouteService().updateWorkflow(
       workflowId,
-      workflowTemplate
+      workflowTemplate,
+      updateFields || false
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue(

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -129,11 +129,16 @@ export const provisionWorkflow = createAsyncThunk(
 
 export const deprovisionWorkflow = createAsyncThunk(
   DEPROVISION_WORKFLOW_ACTION,
-  async (workflowId: string, { rejectWithValue }) => {
+  async (
+    deprovisionInfo: { workflowId: string; resourceIds?: string },
+    { rejectWithValue }
+  ) => {
+    const { workflowId, resourceIds } = deprovisionInfo;
     const response:
       | any
       | HttpFetchError = await getRouteService().deprovisionWorkflow(
-      workflowId
+      workflowId,
+      resourceIds
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue(

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -4,7 +4,11 @@
  */
 
 import yaml from 'js-yaml';
-import { WORKFLOW_STEP_TYPE, Workflow } from '../../common';
+import {
+  WORKFLOW_RESOURCE_TYPE,
+  WORKFLOW_STEP_TYPE,
+  Workflow,
+} from '../../common';
 
 // Append 16 random characters
 export function generateId(prefix?: string): string {
@@ -45,6 +49,27 @@ export function hasProvisionedSearchResources(
     }
   });
   return result;
+}
+
+// returns a comma-delimited string of all resource IDs that need to be force deleted.
+// see https://github.com/opensearch-project/flow-framework/pull/763
+export function getResourcesToBeForceDeleted(
+  workflow: Workflow | undefined
+): string | undefined {
+  const resources = workflow?.resourcesCreated?.filter(
+    (workflowResource) =>
+      workflowResource.type === WORKFLOW_RESOURCE_TYPE.INDEX_NAME ||
+      workflowResource.type === WORKFLOW_RESOURCE_TYPE.PIPELINE_ID
+  );
+
+  if (resources !== undefined && resources.length > 0) {
+    return resources
+      .map((resource) => resource.id)
+      .map(String)
+      .join(',');
+  } else {
+    return undefined;
+  }
 }
 
 export function getObjFromJsonOrYamlString(

--- a/server/cluster/flow_framework_plugin.ts
+++ b/server/cluster/flow_framework_plugin.ts
@@ -113,6 +113,23 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
     method: 'POST',
   });
 
+  flowFramework.forceDeprovisionWorkflow = ca({
+    url: {
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>/_deprovision?allow_delete=<%=resource_ids%>`,
+      req: {
+        workflow_id: {
+          type: 'string',
+          required: true,
+        },
+        resource_ids: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'POST',
+  });
+
   flowFramework.deleteWorkflow = ca({
     url: {
       fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>`,

--- a/server/cluster/flow_framework_plugin.ts
+++ b/server/cluster/flow_framework_plugin.ts
@@ -75,10 +75,14 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
 
   flowFramework.updateWorkflow = ca({
     url: {
-      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>`,
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>`,
       req: {
         workflow_id: {
           type: 'string',
+          required: true,
+        },
+        update_fields: {
+          type: 'boolean',
           required: true,
         },
       },

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -92,10 +92,11 @@ export function registerFlowFrameworkRoutes(
 
   router.put(
     {
-      path: `${UPDATE_WORKFLOW_NODE_API_PATH}/{workflow_id}`,
+      path: `${UPDATE_WORKFLOW_NODE_API_PATH}/{workflow_id}/{update_fields}`,
       validate: {
         params: schema.object({
           workflow_id: schema.string(),
+          update_fields: schema.boolean(),
         }),
         body: schema.any(),
       },
@@ -292,14 +293,18 @@ export class FlowFrameworkRoutesService {
     req: OpenSearchDashboardsRequest,
     res: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
-    const { workflow_id } = req.params as { workflow_id: string };
+    const { workflow_id, update_fields } = req.params as {
+      workflow_id: string;
+      update_fields: boolean;
+    };
     const workflowTemplate = req.body as WorkflowTemplate;
-
     try {
       await this.client
         .asScoped(req)
         .callAsCurrentUser('flowFramework.updateWorkflow', {
           workflow_id,
+          // default update_fields to false if not explicitly set otherwise
+          update_fields: update_fields,
           body: workflowTemplate,
         });
 


### PR DESCRIPTION
### Description

This PR integrates with 2 new enhancements to Flow Framework APIs:
1. Ability to force delete indices when deprovisioning https://github.com/opensearch-project/flow-framework/pull/763
2. Ability to update certain fields (e.g., `ui_metadata`, `name`) on a provisioned workflow https://github.com/opensearch-project/flow-framework/pull/757

With enhancement 1, we no longer have errors when deprovisioning / reprovisioning a workflow when the index config does not change. Before, this would produce exceptions on provision, due to the fact the index still exists, due to the fact we couldn't delete the index.

With enhancement 2, we can easily update and persist the UI form configuration (stored via `ui_metadata` field) without users explicitly clicking on an Ingest/Search button, which was doing the deep & full deprovision / provision actions - essentially giving us a "lightweight" save. Because of this, we can have some autosave functionality as users fill out their form. Current implementation is to perform a save behind-the-scenes when users touch any form field that is persisted. It is debounced (rate-limited) to save at a maximum of every 10s. We can tune this or change the scope of how/when we save later on as well.

Implementation details:
- audit all form fields to ensure Formik's `touched` is updated on every type of input (model dropdown, map, JSON)
- add autosave hooks in the base `WorkflowInputs` component to listen on & execute autosave in a debounced fashion when conditions are met
- improve deprovision to optionally handle a list of resource_ids to be force deleted. This is utilized on the 2 places we call deprovision on `WorkflowInputs` - in these cases, we want to force delete and re-create any created index as users test. On the search side, we will not want this. TODO comment has been added, and will be dealt with once fine-grained provisioning is supported
- improve update to optionally handle an `update_fields` parameter, specifying to only update metadata fields like `ui_metadata`

Demo video, showing 1/ multiple creations of the same index after adding an ingest pipeline with no errors, and 2/ autosaving. Input is entered in the form, and after refreshing the page, it is still visible and populated where the user last left off.

[screen-capture (5).webm](https://github.com/user-attachments/assets/dded912e-708a-4d03-9d3e-5771abc29327)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
