### PR TITLE
Integrate with JSONPath; complete input transform (ingest)

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -129,6 +129,7 @@ export const FETCH_ALL_QUERY_BODY = {
   size: 1000,
 };
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
+export const JSONPATH_ROOT_SELECTOR = '$.';
 
 export enum PROCESSOR_CONTEXT {
   INGEST = 'ingest',

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     ]
   },
   "dependencies": {
+    "@types/jsonpath": "^0.2.4",
     "formik": "2.4.2",
     "js-yaml": "^4.1.0",
+    "jsonpath": "^1.1.1",
     "reactflow": "^11.8.3",
     "yup": "^1.3.2"
   },

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -55,31 +55,6 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
             );
             break;
           }
-          // case 'map': {
-          //   el = (
-          //     <EuiFlexItem key={idx}>
-          //       <MapField
-          //         field={field}
-          //         fieldPath={`${props.baseConfigPath}.${configId}.${field.id}`}
-          //         onFormChange={props.onFormChange}
-          //       />
-          //       <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
-          //     </EuiFlexItem>
-          //   );
-          //   break;
-          // }
-          // case 'json': {
-          //   el = (
-          //     <EuiFlexItem key={idx}>
-          //       <JsonField
-          //         label={field.label}
-          //         placeholder={field.placeholder || ''}
-          //       />
-          //       <EuiSpacer size={INPUT_FIELD_SPACER_SIZE} />
-          //     </EuiFlexItem>
-          //   );
-          //   break;
-          // }
         }
         return el;
       })}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -37,7 +37,7 @@ interface MapFieldProps {
  * Input component for configuring field mappings
  */
 export function MapField(props: MapFieldProps) {
-  const { setFieldValue, errors, touched } = useFormikContext<
+  const { setFieldValue, setFieldTouched, errors, touched } = useFormikContext<
     WorkflowFormValues
   >();
 
@@ -45,6 +45,7 @@ export function MapField(props: MapFieldProps) {
   function addMapEntry(curEntries: MapFormValue): void {
     const updatedEntries = [...curEntries, { key: '', value: '' } as MapEntry];
     setFieldValue(props.fieldPath, updatedEntries);
+    setFieldTouched(props.fieldPath, true);
     props.onFormChange();
   }
 
@@ -56,6 +57,7 @@ export function MapField(props: MapFieldProps) {
     const updatedEntries = [...curEntries];
     updatedEntries.splice(entryIndexToDelete, 1);
     setFieldValue(props.fieldPath, updatedEntries);
+    setFieldTouched(props.fieldPath, true);
     props.onFormChange();
   }
 

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -28,6 +28,8 @@ interface MapFieldProps {
   label: string;
   helpLink?: string;
   helpText?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
   onFormChange: () => void;
 }
 
@@ -97,10 +99,7 @@ export function MapField(props: MapFieldProps) {
                           startControl={
                             <input
                               type="string"
-                              // TODO: find a way to config/title the placeholder text.
-                              // For example, K/V values have different meanings if input
-                              // map or output map for ML inference processors.
-                              placeholder="Input"
+                              placeholder={props.keyPlaceholder || 'Input'}
                               className="euiFieldText"
                               value={mapping.key}
                               onChange={(e) => {
@@ -119,7 +118,7 @@ export function MapField(props: MapFieldProps) {
                           endControl={
                             <input
                               type="string"
-                              placeholder="Output"
+                              placeholder={props.valuePlaceholder || 'Output'}
                               className="euiFieldText"
                               value={mapping.value}
                               onChange={(e) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -9,7 +9,6 @@ import { isEmpty, get } from 'lodash';
 import jsonpath from 'jsonpath';
 import {
   EuiButton,
-  EuiButtonEmpty,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -44,7 +43,6 @@ interface InputTransformModalProps {
   inputMapField: IConfigField;
   inputMapFieldPath: string;
   onClose: () => void;
-  onConfirm: () => void;
   onFormChange: () => void;
 }
 
@@ -66,7 +64,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Configure advanced input transforms`}</p>
+          <p>{`Configure input`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
@@ -234,9 +232,8 @@ export function InputTransformModal(props: InputTransformModalProps) {
         </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
-        <EuiButton onClick={props.onConfirm} fill={true} color="primary">
-          Save
+        <EuiButton onClick={props.onClose} fill={false} color="primary">
+          Close
         </EuiButton>
       </EuiModalFooter>
     </EuiModal>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -79,10 +79,6 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           inputMapFieldPath={inputMapFieldPath}
           onFormChange={props.onFormChange}
           onClose={() => setIsInputTransformModalOpen(false)}
-          onConfirm={() => {
-            console.log('saving transform input configuration...');
-            setIsInputTransformModalOpen(false);
-          }}
         />
       )}
       {isOutputTransformModalOpen && (
@@ -156,7 +152,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           ) : (
             <>
               <EuiButton
-                style={{ width: '300px' }}
+                style={{ width: '200px' }}
                 fill={false}
                 onClick={() => {
                   setIsInputTransformModalOpen(true);
@@ -167,7 +163,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <EuiSpacer size="s" />
 
               <EuiButton
-                style={{ width: '300px' }}
+                style={{ width: '200px' }}
                 fill={false}
                 onClick={() => {
                   setIsOutputTransformModalOpen(true);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
-import { EuiButton, EuiRadioGroup, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
 import {
   WorkspaceFormValues,
   IProcessorConfig,
@@ -63,6 +63,9 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           uiConfig={props.uiConfig}
           config={props.config}
           context={props.context}
+          inputMapField={inputMapField}
+          inputMapFieldPath={inputMapFieldPath}
+          onFormChange={props.onFormChange}
           onClose={() => setIsInputTransformModalOpen(false)}
           onConfirm={() => {
             console.log('saving transform input configuration...');
@@ -108,6 +111,8 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             helpLink={
               'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
             }
+            keyPlaceholder="Model input field"
+            valuePlaceholder="Document field"
             onFormChange={props.onFormChange}
           />
           <EuiSpacer size="l" />
@@ -129,6 +134,8 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             helpLink={
               'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
             }
+            keyPlaceholder="New document field"
+            valuePlaceholder="Model output field"
             onFormChange={props.onFormChange}
           />
         </>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -5,13 +5,20 @@
 
 import React, { useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
-import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFilterButton,
+  EuiFilterGroup,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import {
   WorkspaceFormValues,
   IProcessorConfig,
   IConfigField,
   PROCESSOR_CONTEXT,
   WorkflowConfig,
+  JSONPATH_ROOT_SELECTOR,
 } from '../../../../../common';
 import { MapField, ModelField } from '../input_fields';
 import { isEmpty } from 'lodash';
@@ -56,6 +63,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     boolean
   >(false);
 
+  // advanced / simple transform state
+  const [isSimpleTransformSelected, setIsSimpleTransformSelected] = useState<
+    boolean
+  >(true);
+
   return (
     <>
       {isInputTransformModalOpen && (
@@ -91,53 +103,82 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         <>
           <EuiSpacer size="s" />
           <EuiText size="s">{`Configure data transformations (optional)`}</EuiText>
+          <EuiText size="s" color="subdued">
+            {`Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
+                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
+          </EuiText>
           <EuiSpacer size="s" />
+          <EuiFilterGroup>
+            <EuiFilterButton
+              grow={false}
+              hasActiveFilters={isSimpleTransformSelected}
+              onClick={() => setIsSimpleTransformSelected(true)}
+            >
+              Simple
+            </EuiFilterButton>
+            <EuiFilterButton
+              grow={false}
+              hasActiveFilters={!isSimpleTransformSelected}
+              onClick={() => setIsSimpleTransformSelected(false)}
+            >
+              Advanced
+            </EuiFilterButton>
+          </EuiFilterGroup>
           <EuiSpacer size="s" />
-          <EuiButton
-            style={{ width: '300px' }}
-            fill={false}
-            onClick={() => {
-              setIsInputTransformModalOpen(true);
-            }}
-          >
-            Advanced input configuration
-          </EuiButton>
+          {isSimpleTransformSelected ? (
+            <>
+              <MapField
+                field={inputMapField}
+                fieldPath={inputMapFieldPath}
+                label="Input map"
+                helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
+                helpLink={
+                  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
+                }
+                keyPlaceholder="Model input field"
+                valuePlaceholder="Document field"
+                onFormChange={props.onFormChange}
+              />
+              <EuiSpacer size="l" />
+              <MapField
+                field={outputMapField}
+                fieldPath={outputMapFieldPath}
+                label="Output map"
+                helpText={`An array specifying how to map the model’s output to new fields.`}
+                helpLink={
+                  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
+                }
+                keyPlaceholder="New document field"
+                valuePlaceholder="Model output field"
+                onFormChange={props.onFormChange}
+              />
+            </>
+          ) : (
+            <>
+              <EuiButton
+                style={{ width: '300px' }}
+                fill={false}
+                onClick={() => {
+                  setIsInputTransformModalOpen(true);
+                }}
+              >
+                Configure input
+              </EuiButton>
+              <EuiSpacer size="s" />
+
+              <EuiButton
+                style={{ width: '300px' }}
+                fill={false}
+                onClick={() => {
+                  setIsOutputTransformModalOpen(true);
+                }}
+              >
+                Configure output
+              </EuiButton>
+            </>
+          )}
+
           <EuiSpacer size="s" />
-          <MapField
-            field={inputMapField}
-            fieldPath={inputMapFieldPath}
-            label="Input map"
-            helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
-            helpLink={
-              'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
-            }
-            keyPlaceholder="Model input field"
-            valuePlaceholder="Document field"
-            onFormChange={props.onFormChange}
-          />
-          <EuiSpacer size="l" />
-          <EuiButton
-            style={{ width: '300px' }}
-            fill={false}
-            onClick={() => {
-              setIsOutputTransformModalOpen(true);
-            }}
-          >
-            Advanced output configuration
-          </EuiButton>
-          <EuiSpacer size="s" />
-          <MapField
-            field={outputMapField}
-            fieldPath={outputMapFieldPath}
-            label="Output map"
-            helpText={`An array specifying how to map the model’s output to new fields.`}
-            helpLink={
-              'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
-            }
-            keyPlaceholder="New document field"
-            valuePlaceholder="Model output field"
-            onFormChange={props.onFormChange}
-          />
         </>
       )}
     </>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -54,6 +54,7 @@ import {
   hasProvisionedIngestResources,
   hasProvisionedSearchResources,
   generateId,
+  sleep,
   getResourcesToBeForceDeleted,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
@@ -183,7 +184,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   // Utility fn to update the workflow, including any updated/new resources
   // Eventually, should be able to use fine-grained provisioning to do a single API call
-  // instead of the currently-implemented deprovision -> update -> provision
+  // instead of the currently-implemented deprovision -> update -> provision.
+  // To simplify and minimize errors, we set various sleep calls in between the actions
+  // to allow time for full deprovisioning / provisioning to occur, such as index deletion
+  // & index re-creation.
+  // TODO: update to fine-grained provisioning when available.
   async function updateWorkflowAndResources(
     updatedWorkflow: Workflow
   ): Promise<boolean> {
@@ -204,9 +209,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         )
           .unwrap()
           .then(async (result) => {
+            await sleep(1000);
             await dispatch(provisionWorkflow(updatedWorkflow.id as string))
               .unwrap()
-              .then((result) => {
+              .then(async (result) => {
+                await sleep(1000);
                 success = true;
                 // Kicking off an async task to re-fetch the workflow details
                 // after some amount of time. Provisioning will finish in an indeterminate

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -162,7 +162,12 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           })
         )
           .unwrap()
-          .then(async (result) => {})
+          .then(async (result) => {
+            // get any updates after autosave
+            new Promise((f) => setTimeout(f, 1000)).then(async () => {
+              dispatch(getWorkflow(props.workflow?.id as string));
+            });
+          })
           .catch((error: any) => {
             console.error('Error autosaving workflow: ', error);
           });

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -21,6 +21,10 @@ export function generateId(prefix?: string): string {
   }_${uniqueChar()}${uniqueChar()}${uniqueChar()}${uniqueChar()}`;
 }
 
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function hasProvisionedIngestResources(
   workflow: Workflow | undefined
 ): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,11 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.11.tgz#012c17cb2256ad8de78560da851ab914a7b9b40e"
   integrity sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==
 
+"@types/jsonpath@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.4.tgz#065be59981c1420832835af656377622271154be"
+  integrity sha512-K3hxB8Blw0qgW6ExKgMbXQv2UPZBoE2GqLpVY+yr7nMD2Pq86lsuIzyAaiQ7eMqFL5B6di6pxSkogLJEyEHoGA==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -355,10 +360,52 @@ d3-zoom@^3.0.0:
     d3-selection "2 - 3"
     d3-transition "2 - 3"
 
+deep-is@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
 deepmerge@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
+escodegen@^1.8.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
+  integrity sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==
+
+esprima@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+estraverse@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+fast-levenshtein@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 formik@2.4.2:
   version "2.4.2"
@@ -387,6 +434,23 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsonpath@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.1.1.tgz#0ca1ed8fb65bb3309248cc9d5466d12d5b0b9901"
+  integrity sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.12.1"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
@@ -396,6 +460,23 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
 property-expr@^2.0.5:
   version "2.0.6"
@@ -424,6 +505,18 @@ reactflow@^11.8.3:
     "@reactflow/node-resizer" "2.1.5"
     "@reactflow/node-toolbar" "1.2.7"
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
+
 tiny-case@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
@@ -444,15 +537,32 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
+  dependencies:
+    prelude-ls "~1.1.2"
+
 type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+
 use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+word-wrap@~1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 yup@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
### Description

This PR completes the end-to-end flow of input transforms on the ingest side, by way of adding JSONPath parsing support within the ML inference input map configs. More specifically:
- adds MIT-licensed JSONPath (base [JS](https://www.npmjs.com/package/jsonpath) and [TS](https://www.npmjs.com/search?q=%40types%2Fjsonpath)) packages to the plugin
- finishes base functionality of `InputTransformModal` - adds the map form field within the modal, completes generation logic of the output JSON after applying JSONPath and/or dot notation to the specified inputs in the map. Note the logic used here is the same as the ML inference processor logic, when parsing the map config. If no `$.` JSONPath base object selector is specified, it defaults to using dot notation. We do the same logic to produce consistent results when actually used in the ML inference processor
- removes cancel/save of `InputTransformModal` to just be `close`, since the autosave will handle it
- adds simple/advanced toggle in the ML processor form inputs component, refactors some of the buttons and map field inputs based on simple vs. advanced being selected
- adds `keyPlaceholder`/`valuePlaceholder` props to `MapField` to be able to reuse in the output maps and for other contexts (ingest / search req / search resp) later on

Testing
- confirmed consistent parsing for dot notation / JSONPath / invalid inputs and combinations of all of them, when input in the transform modal, and when actually executed in the processor with an ingest command

Demo video, showing end-to-end flow of configuring an ML inference processor's input_map using both dot notation and JSONPath, getting sample results in the advanced transform modal, and finally running a concrete ingest command against the configured processor:

[screen-capture (8).webm](https://github.com/user-attachments/assets/252ef4c8-faf4-43a1-a019-86531090096e)

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
