### PR TITLE
Add guardrails to doc and query JSON inputs

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -113,6 +113,12 @@ export enum COMPONENT_CLASS {
 }
 
 /**
+ * LINKS
+ */
+export const ML_INFERENCE_DOCS_LINK =
+  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters';
+
+/**
  * MISCELLANEOUS
  */
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -29,13 +29,6 @@ export interface IConfigField {
   type: ConfigFieldType;
   id: string;
   value?: ConfigFieldValue;
-  // TODO: remove below fields out of this interface and directly into the necessary components.
-  // This is to minimize what we persist here, which is added into ui_metadata and indexed.
-  // Once the config for ML inference processors is finalized, we can migrate these out.
-  label?: string;
-  placeholder?: string;
-  helpText?: string;
-  helpLink?: string;
 }
 export interface IConfig {
   id: string;
@@ -71,7 +64,7 @@ export type IngestConfig = {
 };
 
 export type SearchConfig = {
-  request: {};
+  request: IConfigField;
   enrichRequest: ProcessorsConfig;
   enrichResponse: ProcessorsConfig;
 };

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -128,7 +128,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Initialize the form state based on the current UI config
   useEffect(() => {
     if (uiConfig) {
-      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs, query);
+      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs);
       const initFormSchema = uiConfigToSchema(uiConfig);
       setFormValues(initFormValues);
       setFormSchema(initFormSchema);

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -4,9 +4,10 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useFormikContext } from 'formik';
+import { useFormikContext, getIn } from 'formik';
 import {
   EuiButton,
+  EuiCodeBlock,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
@@ -61,7 +62,7 @@ export function SourceData(props: SourceDataProps) {
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <p>{`Add sample JSON documents`}</p>
+              <p>{`Configure sample JSON documents`}</p>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
@@ -117,15 +118,13 @@ export function SourceData(props: SourceDataProps) {
             size="s"
             onClick={() => setIsLoadModalOpen(true)}
           >
-            Add
+            Configure
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <JsonField
-            fieldPath={'ingest.docs'}
-            readOnly={true}
-            onFormChange={() => {}}
-          />
+          <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
+            {getIn(values, 'ingest.docs')}
+          </EuiCodeBlock>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -34,8 +34,8 @@ interface SourceDataProps {
 export function SourceData(props: SourceDataProps) {
   const { values, setFieldValue } = useFormikContext<WorkspaceFormValues>();
 
-  // load modal state
-  const [isLoadModalOpen, setIsLoadModalOpen] = useState<boolean>(false);
+  // edit modal state
+  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
 
   // files state. when a file is read, update the form value.
   const fileReader = new FileReader();
@@ -55,14 +55,14 @@ export function SourceData(props: SourceDataProps) {
 
   return (
     <>
-      {isLoadModalOpen && (
+      {isEditModalOpen && (
         <EuiModal
-          onClose={() => setIsLoadModalOpen(false)}
+          onClose={() => setIsEditModalOpen(false)}
           style={{ width: '70vw' }}
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <p>{`Configure sample JSON documents`}</p>
+              <p>{`Edit source data`}</p>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
@@ -96,7 +96,7 @@ export function SourceData(props: SourceDataProps) {
           </EuiModalBody>
           <EuiModalFooter>
             <EuiButton
-              onClick={() => setIsLoadModalOpen(false)}
+              onClick={() => setIsEditModalOpen(false)}
               fill={false}
               color="primary"
             >
@@ -116,9 +116,9 @@ export function SourceData(props: SourceDataProps) {
             fill={false}
             style={{ width: '100px' }}
             size="s"
-            onClick={() => setIsLoadModalOpen(true)}
+            onClick={() => setIsEditModalOpen(true)}
           >
-            Configure
+            Edit
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -3,12 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useFormikContext } from 'formik';
 import {
+  EuiButton,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
@@ -24,6 +32,9 @@ interface SourceDataProps {
  */
 export function SourceData(props: SourceDataProps) {
   const { values, setFieldValue } = useFormikContext<WorkspaceFormValues>();
+
+  // load modal state
+  const [isLoadModalOpen, setIsLoadModalOpen] = useState<boolean>(false);
 
   // files state. when a file is read, update the form value.
   const fileReader = new FileReader();
@@ -42,36 +53,81 @@ export function SourceData(props: SourceDataProps) {
   }, [values?.ingest?.docs]);
 
   return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="s">
-          <h2>Source data</h2>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiFilePicker
-          accept="application/json"
-          multiple={false}
-          initialPromptText="Select a JSON file containing documents"
-          onChange={(files) => {
-            if (files && files.length > 0) {
-              fileReader.readAsText(files[0]);
-            }
-          }}
-          display="default"
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <JsonField
-          label="Upload JSON documents"
-          fieldPath={'ingest.docs'}
-          helpText="Documents should be formatted as a valid JSON array."
-          // when ingest doc values change, don't update the form
-          // since we initially only support running ingest once per configuration
-          onFormChange={() => {}}
-          editorHeight="25vh"
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <>
+      {isLoadModalOpen && (
+        <EuiModal
+          onClose={() => setIsLoadModalOpen(false)}
+          style={{ width: '70vw' }}
+        >
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <p>{`Add sample JSON documents`}</p>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <>
+              <EuiText color="subdued">
+                Upload a JSON file or enter manually.
+              </EuiText>{' '}
+              <EuiSpacer size="s" />
+              <EuiFilePicker
+                accept="application/json"
+                multiple={false}
+                initialPromptText="Upload file"
+                onChange={(files) => {
+                  if (files && files.length > 0) {
+                    fileReader.readAsText(files[0]);
+                  }
+                }}
+                display="default"
+              />
+              <EuiSpacer size="s" />
+              <JsonField
+                fieldPath={'ingest.docs'}
+                helpText="Documents should be formatted as a valid JSON array."
+                // when ingest doc values change, don't update the form
+                // since we initially only support running ingest once per configuration
+                onFormChange={() => {}}
+                editorHeight="25vh"
+                readOnly={false}
+              />
+            </>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButton
+              onClick={() => setIsLoadModalOpen(false)}
+              fill={false}
+              color="primary"
+            >
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h2>Source data</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill={false}
+            style={{ width: '100px' }}
+            size="s"
+            onClick={() => setIsLoadModalOpen(true)}
+          >
+            Add
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <JsonField
+            fieldPath={'ingest.docs'}
+            readOnly={true}
+            onFormChange={() => {}}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -11,10 +11,11 @@ import { WorkspaceFormValues } from '../../../../../common';
 interface JsonFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onFormChange: () => void;
-  label: string;
+  label?: string;
   helpLink?: string;
   helpText?: string;
   editorHeight?: string;
+  readOnly?: boolean;
 }
 
 /**
@@ -79,7 +80,7 @@ export function JsonField(props: JsonFieldProps) {
                   props.onFormChange();
                 }
               }}
-              readOnly={false}
+              readOnly={props.readOnly || false}
               setOptions={{
                 fontSize: '14px',
               }}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -25,6 +25,7 @@ import {
   IProcessorConfig,
   IngestPipelineConfig,
   JSONPATH_ROOT_SELECTOR,
+  ML_INFERENCE_DOCS_LINK,
   PROCESSOR_CONTEXT,
   SimulateIngestPipelineDoc,
   SimulateIngestPipelineResponse,
@@ -135,9 +136,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 fieldPath={props.inputMapFieldPath}
                 label="Input map"
                 helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
-                helpLink={
-                  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
-                }
+                helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
                 valuePlaceholder="Document field"
                 onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -19,6 +19,7 @@ import {
   PROCESSOR_CONTEXT,
   WorkflowConfig,
   JSONPATH_ROOT_SELECTOR,
+  ML_INFERENCE_DOCS_LINK,
 } from '../../../../../common';
 import { MapField, ModelField } from '../input_fields';
 import { isEmpty } from 'lodash';
@@ -128,9 +129,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 fieldPath={inputMapFieldPath}
                 label="Input map"
                 helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
-                helpLink={
-                  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
-                }
+                helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
                 valuePlaceholder="Document field"
                 onFormChange={props.onFormChange}
@@ -141,9 +140,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 fieldPath={outputMapFieldPath}
                 label="Output map"
                 helpText={`An array specifying how to map the model’s output to new fields.`}
-                helpLink={
-                  'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters'
-                }
+                helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="New document field"
                 valuePlaceholder="Model output field"
                 onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -5,8 +5,10 @@
 
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useFormikContext, getIn } from 'formik';
 import {
   EuiButton,
+  EuiCodeBlock,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -21,7 +23,6 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { useFormikContext } from 'formik';
 import { WorkspaceFormValues } from '../../../../../common';
 import { JsonField } from '../input_fields';
 import { AppState, catIndices, useAppDispatch } from '../../../../store';
@@ -141,12 +142,9 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <JsonField
-            fieldPath={'search.request'}
-            onFormChange={props.onFormChange}
-            editorHeight="25vh"
-            readOnly={true}
-          />
+          <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
+            {getIn(values, 'search.request')}
+          </EuiCodeBlock>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -6,17 +6,23 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
+  EuiButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
   EuiSuperSelect,
   EuiSuperSelectOption,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { useFormikContext } from 'formik';
-import { IConfigField, WorkspaceFormValues } from '../../../../../common';
+import { WorkspaceFormValues } from '../../../../../common';
 import { JsonField } from '../input_fields';
 import { AppState, catIndices, useAppDispatch } from '../../../../store';
 
@@ -44,6 +50,9 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
     undefined
   );
 
+  // Query modal state
+  const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
+
   // Hook to listen when the query form value changes.
   // Try to set the query request if possible
   useEffect(() => {
@@ -61,43 +70,85 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
   }, []);
 
   return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="s">
-          <h2>Configure query</h2>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiFormRow label="Retrieval index">
-          {ingestEnabled ? (
-            <EuiFieldText value={indexName} readOnly={true} />
-          ) : (
-            <EuiSuperSelect
-              options={Object.values(indices).map(
-                (option) =>
-                  ({
-                    value: option.name,
-                    inputDisplay: <EuiText>{option.name}</EuiText>,
-                    disabled: false,
-                  } as EuiSuperSelectOption<string>)
-              )}
-              valueOfSelected={selectedIndex}
-              onChange={(option) => {
-                setSelectedIndex(option);
-              }}
-              isInvalid={selectedIndex !== undefined}
+    <>
+      {isQueryModalOpen && (
+        <EuiModal
+          onClose={() => setIsQueryModalOpen(false)}
+          style={{ width: '70vw' }}
+        >
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <p>{`Configure query`}</p>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <JsonField
+              label="Query"
+              fieldPath={'search.request'}
+              onFormChange={props.onFormChange}
+              editorHeight="25vh"
+              readOnly={false}
             />
-          )}
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <JsonField
-          label="Define query"
-          fieldPath={'search.request'}
-          onFormChange={props.onFormChange}
-          editorHeight="25vh"
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButton
+              onClick={() => setIsQueryModalOpen(false)}
+              fill={false}
+              color="primary"
+            >
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h2>Configure query</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFormRow label="Retrieval index">
+            {ingestEnabled ? (
+              <EuiFieldText value={indexName} readOnly={true} />
+            ) : (
+              <EuiSuperSelect
+                options={Object.values(indices).map(
+                  (option) =>
+                    ({
+                      value: option.name,
+                      inputDisplay: <EuiText>{option.name}</EuiText>,
+                      disabled: false,
+                    } as EuiSuperSelectOption<string>)
+                )}
+                valueOfSelected={selectedIndex}
+                onChange={(option) => {
+                  setSelectedIndex(option);
+                }}
+                isInvalid={selectedIndex === undefined}
+              />
+            )}
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill={false}
+            style={{ width: '100px' }}
+            size="s"
+            onClick={() => setIsQueryModalOpen(true)}
+          >
+            Configure
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <JsonField
+            fieldPath={'search.request'}
+            onFormChange={props.onFormChange}
+            editorHeight="25vh"
+            readOnly={true}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -51,8 +51,8 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
     undefined
   );
 
-  // Query modal state
-  const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
+  // Edit modal state
+  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
 
   // Hook to listen when the query form value changes.
   // Try to set the query request if possible
@@ -72,14 +72,14 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
 
   return (
     <>
-      {isQueryModalOpen && (
+      {isEditModalOpen && (
         <EuiModal
-          onClose={() => setIsQueryModalOpen(false)}
+          onClose={() => setIsEditModalOpen(false)}
           style={{ width: '70vw' }}
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <p>{`Configure query`}</p>
+              <p>{`Edit query`}</p>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
@@ -93,7 +93,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
           </EuiModalBody>
           <EuiModalFooter>
             <EuiButton
-              onClick={() => setIsQueryModalOpen(false)}
+              onClick={() => setIsEditModalOpen(false)}
               fill={false}
               color="primary"
             >
@@ -136,9 +136,9 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
             fill={false}
             style={{ width: '100px' }}
             size="s"
-            onClick={() => setIsQueryModalOpen(true)}
+            onClick={() => setIsEditModalOpen(true)}
           >
-            Configure
+            Edit
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_NEW_WORKFLOW_NAME,
   UIState,
   WORKFLOW_TYPE,
+  FETCH_ALL_QUERY_BODY,
 } from '../../../../common';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
@@ -64,7 +65,11 @@ function fetchEmptyMetadata(): UIState {
         },
       },
       search: {
-        request: {},
+        request: {
+          id: 'request',
+          type: 'json',
+          value: JSON.stringify(FETCH_ALL_QUERY_BODY, undefined, 2),
+        },
         enrichRequest: {
           processors: [],
         },

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -15,6 +15,7 @@ import {
   ConfigFieldType,
   ConfigFieldValue,
   ModelFormValue,
+  FETCH_ALL_QUERY_BODY,
 } from '../../common';
 
 /*
@@ -26,12 +27,11 @@ import {
 // and can be extremely large. so we pass that as a standalone field
 export function uiConfigToFormik(
   config: WorkflowConfig,
-  ingestDocs: string,
-  query: string
+  ingestDocs: string
 ): WorkflowFormValues {
   const formikValues = {} as WorkflowFormValues;
   formikValues['ingest'] = ingestConfigToFormik(config.ingest, ingestDocs);
-  formikValues['search'] = searchConfigToFormik(config.search, query);
+  formikValues['search'] = searchConfigToFormik(config.search);
   return formikValues;
 }
 
@@ -83,12 +83,12 @@ function indexConfigToFormik(indexConfig: IndexConfig): FormikValues {
 }
 
 function searchConfigToFormik(
-  searchConfig: SearchConfig | undefined,
-  query: string
+  searchConfig: SearchConfig | undefined
 ): FormikValues {
   let searchFormikValues = {} as FormikValues;
   if (searchConfig) {
-    searchFormikValues['request'] = query || getInitialValue('json');
+    searchFormikValues['request'] =
+      searchConfig.request.value || getInitialValue('json');
     searchFormikValues['enrichRequest'] = processorsConfigToFormik(
       searchConfig.enrichRequest
     );

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -72,6 +72,10 @@ function formikToSearchUiConfig(
 ): SearchConfig {
   return {
     ...existingConfig,
+    request: {
+      ...existingConfig.request,
+      value: searchFormValues['request'],
+    },
     enrichRequest: formikToProcessorsUiConfig(
       searchFormValues['enrichRequest'],
       existingConfig.enrichRequest


### PR DESCRIPTION
### Description

Naturally, the JSON schema of both the sample documents and the query have downstream impact on the ingest and search pipelines, respectively. To help prevent accidental changes, and to make the user make a more explicit choice when editing such fields, this moves those inputs into modals. Users have a readonly view of the values, but must click on an explicit 'Edit' to change the values.

More specifics:
- adds modals to `SourceData` (ingest) and `ConfigureSearchRequest` (search) components, and moves the form configuration inside such modals. Readonly codeblocks are added to the base form page for users to see the current values
- updates the search request to be formally integrated into the form and UI config. It is now consistent with other JSON form values, like index mappings and index settings. Note we store them as raw strings, and parse or stringify them when converting to / from the `Formik` form on the UI
- adds a useful default `match_all` query
- nit: adds constants for help links / URLs that were hardcoded within the component
- nit: finishes removing the unnecessary fields stored in the `IConfigField` interface as these have moved within the components themselves and are no longer persisted in `ui_metadata`.

Demo video, showing the readonly views, and the flows for editing the doc and query fields (button texts and modal titles subject to change)

[screen-capture (10).webm](https://github.com/user-attachments/assets/d9c61696-0de7-41ee-82e8-eb11b0a81e87)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
