### PR TITLE
Support multiple input/output maps for ML processors

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -23,7 +23,8 @@ export type ConfigFieldType =
   | 'jsonArray'
   | 'select'
   | 'model'
-  | 'map';
+  | 'map'
+  | 'mapArray';
 export type ConfigFieldValue = string | {};
 export interface IConfigField {
   type: ConfigFieldType;
@@ -80,6 +81,8 @@ export type MapEntry = {
 };
 
 export type MapFormValue = MapEntry[];
+
+export type MapArrayFormValue = MapFormValue[];
 
 export type WorkflowFormValues = {
   ingest: FormikValues;

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -22,11 +22,11 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'inputMap',
-        type: 'map',
+        type: 'mapArray',
       },
       {
         id: 'outputMap',
-        type: 'map',
+        type: 'mapArray',
       },
     ];
   }

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
@@ -7,4 +7,5 @@ export { TextField } from './text_field';
 export { JsonField } from './json_field';
 export { ModelField } from './model_field';
 export { MapField } from './map_field';
+export { MapArrayField } from './map_array_field';
 export { BooleanField } from './boolean_field';

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -33,6 +33,7 @@ interface MapArrayFieldProps {
   keyPlaceholder?: string;
   valuePlaceholder?: string;
   onFormChange: () => void;
+  onMapAdd?: (curArray: MapArrayFormValue) => void;
   onMapDelete?: (idxToDelete: number) => void;
 }
 
@@ -49,6 +50,9 @@ export function MapArrayField(props: MapArrayFieldProps) {
     setFieldValue(props.fieldPath, [...curMapArray, []]);
     setFieldTouched(props.fieldPath, true);
     props.onFormChange();
+    if (props.onMapAdd) {
+      props.onMapAdd(curMapArray);
+    }
   }
 
   // Deleting a map

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -71,6 +71,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
       {({ field, form }: FieldProps) => {
         return (
           <EuiFormRow
+            fullWidth={true}
             key={props.fieldPath}
             label={props.label}
             labelAppend={
@@ -111,21 +112,14 @@ export function MapArrayField(props: MapArrayFieldProps) {
                         />
                       }
                     >
-                      <EuiFlexGroup
-                        direction="row"
-                        justifyContent="spaceBetween"
-                      >
-                        <EuiFlexItem grow={false}>
-                          <EuiPanel grow={false}>
-                            <MapField
-                              fieldPath={`${props.fieldPath}.${idx}`}
-                              keyPlaceholder={props.keyPlaceholder}
-                              valuePlaceholder={props.valuePlaceholder}
-                              onFormChange={props.onFormChange}
-                            />
-                          </EuiPanel>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
+                      <EuiPanel grow={true}>
+                        <MapField
+                          fieldPath={`${props.fieldPath}.${idx}`}
+                          keyPlaceholder={props.keyPlaceholder}
+                          valuePlaceholder={props.valuePlaceholder}
+                          onFormChange={props.onFormChange}
+                        />
+                      </EuiPanel>
                     </EuiAccordion>
                   </EuiFlexItem>
                 );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -33,6 +33,7 @@ interface MapArrayFieldProps {
   keyPlaceholder?: string;
   valuePlaceholder?: string;
   onFormChange: () => void;
+  onMapDelete?: (idxToDelete: number) => void;
 }
 
 /**
@@ -60,6 +61,9 @@ export function MapArrayField(props: MapArrayFieldProps) {
     setFieldValue(props.fieldPath, updatedMapArray);
     setFieldTouched(props.fieldPath, true);
     props.onFormChange();
+    if (props.onMapDelete) {
+      props.onMapDelete(entryIndexToDelete);
+    }
   }
 
   return (
@@ -115,8 +119,8 @@ export function MapArrayField(props: MapArrayFieldProps) {
                           <EuiPanel grow={false}>
                             <MapField
                               fieldPath={`${props.fieldPath}.${idx}`}
-                              keyPlaceholder="Model input field"
-                              valuePlaceholder="Document field"
+                              keyPlaceholder={props.keyPlaceholder}
+                              valuePlaceholder={props.valuePlaceholder}
                               onFormChange={props.onFormChange}
                             />
                           </EuiPanel>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiLink,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
+import { Field, FieldProps, getIn, useFormikContext } from 'formik';
+import {
+  IConfigField,
+  MapArrayFormValue,
+  MapEntry,
+  WorkflowFormValues,
+} from '../../../../../common';
+import { MapField } from './map_field';
+
+interface MapArrayFieldProps {
+  field: IConfigField;
+  fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
+  label?: string;
+  helpLink?: string;
+  helpText?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  onFormChange: () => void;
+}
+
+/**
+ * Input component for configuring an array of field mappings
+ */
+export function MapArrayField(props: MapArrayFieldProps) {
+  const { setFieldValue, setFieldTouched, errors, touched } = useFormikContext<
+    WorkflowFormValues
+  >();
+
+  // Adding a map to the end of the existing arr
+  function addMap(curMapArray: MapArrayFormValue): void {
+    setFieldValue(props.fieldPath, [...curMapArray, []]);
+    setFieldTouched(props.fieldPath, true);
+    props.onFormChange();
+  }
+
+  // Deleting a map
+  function deleteMap(
+    curMapArray: MapArrayFormValue,
+    entryIndexToDelete: number
+  ): void {
+    const updatedMapArray = [...curMapArray];
+    updatedMapArray.splice(entryIndexToDelete, 1);
+    setFieldValue(props.fieldPath, updatedMapArray);
+    setFieldTouched(props.fieldPath, true);
+    props.onFormChange();
+  }
+
+  return (
+    <Field name={props.fieldPath}>
+      {({ field, form }: FieldProps) => {
+        return (
+          <EuiFormRow
+            key={props.fieldPath}
+            label={props.label}
+            labelAppend={
+              props.helpLink ? (
+                <EuiText size="xs">
+                  <EuiLink href={props.helpLink} target="_blank">
+                    Learn more
+                  </EuiLink>
+                </EuiText>
+              ) : undefined
+            }
+            helpText={props.helpText || undefined}
+            isInvalid={
+              getIn(errors, field.name) !== undefined &&
+              getIn(errors, field.name).length > 0 &&
+              getIn(touched, field.name) !== undefined &&
+              getIn(touched, field.name).length > 0
+            }
+          >
+            <EuiFlexGroup direction="column">
+              {field.value?.map((mapping: MapEntry, idx: number) => {
+                return (
+                  <EuiFlexItem key={idx}>
+                    <EuiAccordion
+                      key={idx}
+                      id={`accordion${idx}`}
+                      buttonContent={`Prediction ${idx + 1}`}
+                      paddingSize="m"
+                      extraAction={
+                        <EuiButtonIcon
+                          style={{ marginTop: '8px' }}
+                          iconType={'trash'}
+                          color="danger"
+                          aria-label="Delete"
+                          onClick={() => {
+                            deleteMap(field.value, idx);
+                          }}
+                        />
+                      }
+                    >
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceBetween"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiPanel grow={false}>
+                            <MapField
+                              fieldPath={`${props.fieldPath}.${idx}`}
+                              keyPlaceholder="Model input field"
+                              valuePlaceholder="Document field"
+                              onFormChange={props.onFormChange}
+                            />
+                          </EuiPanel>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiAccordion>
+                  </EuiFlexItem>
+                );
+              })}
+              <EuiFlexItem grow={false}>
+                <div>
+                  <EuiButton
+                    size="s"
+                    onClick={() => {
+                      addMap(field.value);
+                    }}
+                  >
+                    {field.value?.length > 0 ? 'Add another map' : 'Add map'}
+                  </EuiButton>
+                </div>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFormRow>
+        );
+      }}
+    </Field>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -16,16 +16,14 @@ import {
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import {
-  IConfigField,
   MapEntry,
   MapFormValue,
   WorkflowFormValues,
 } from '../../../../../common';
 
 interface MapFieldProps {
-  field: IConfigField;
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
-  label: string;
+  label?: string;
   helpLink?: string;
   helpText?: string;
   keyPlaceholder?: string;
@@ -62,7 +60,7 @@ export function MapField(props: MapFieldProps) {
   }
 
   return (
-    <Field name={props.fieldPath}>
+    <Field name={props.fieldPath} key={props.fieldPath}>
       {({ field, form }: FieldProps) => {
         return (
           <EuiFormRow

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -64,6 +64,7 @@ export function MapField(props: MapFieldProps) {
       {({ field, form }: FieldProps) => {
         return (
           <EuiFormRow
+            fullWidth={true}
             key={props.fieldPath}
             label={props.label}
             labelAppend={
@@ -93,9 +94,10 @@ export function MapField(props: MapFieldProps) {
               {field.value?.map((mapping: MapEntry, idx: number) => {
                 return (
                   <EuiFlexItem key={idx}>
-                    <EuiFlexGroup direction="row" justifyContent="spaceBetween">
-                      <EuiFlexItem grow={false}>
+                    <EuiFlexGroup direction="row">
+                      <EuiFlexItem grow={true}>
                         <EuiFormControlLayoutDelimited
+                          fullWidth={true}
                           startControl={
                             <input
                               type="string"

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { useFormikContext, getIn } from 'formik';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import {
   EuiButton,
   EuiCodeEditor,
@@ -69,10 +69,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
   // get the current input map
-  const map = getIn(
-    values,
-    `ingest.enrich.${props.config.id}.inputMap`
-  ) as MapArrayFormValue;
+  const map = getIn(values, props.inputMapFieldPath) as MapArrayFormValue;
 
   // selected output state
   const outputOptions = map.map((_, idx) => ({
@@ -81,11 +78,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
   })) as EuiSelectOption[];
   const [selectedOutputOption, setSelectedOutputOption] = useState<
     number | undefined
-  >(
-    get(outputOptions, '0.value') !== undefined
-      ? (outputOptions[0].value as number)
-      : undefined
-  );
+  >((outputOptions[0]?.value as number) ?? undefined);
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { useFormikContext, getIn } from 'formik';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import {
   EuiButton,
   EuiCodeEditor,
@@ -16,6 +16,8 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
+  EuiSelect,
+  EuiSelectOption,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -25,6 +27,7 @@ import {
   IngestPipelineConfig,
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
+  MapArrayFormValue,
   PROCESSOR_CONTEXT,
   SimulateIngestPipelineResponse,
   WorkflowConfig,
@@ -38,7 +41,7 @@ import {
 } from '../../../../utils';
 import { simulatePipeline, useAppDispatch } from '../../../../store';
 import { getCore } from '../../../../services';
-import { MapField } from '../input_fields';
+import { MapArrayField } from '../input_fields';
 
 interface InputTransformModalProps {
   uiConfig: WorkflowConfig;
@@ -59,10 +62,26 @@ export function InputTransformModal(props: InputTransformModalProps) {
 
   // source input / transformed output state
   const [sourceInput, setSourceInput] = useState<string>('[]');
-  const [transformedOutput, setTransformedOutput] = useState<string>('[]');
+  const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
   // get the current input map
-  const map = getIn(values, `ingest.enrich.${props.config.id}.inputMap`);
+  const map = getIn(
+    values,
+    `ingest.enrich.${props.config.id}.inputMap`
+  ) as MapArrayFormValue;
+
+  // selected output state
+  const outputOptions = map.map((_, idx) => ({
+    value: idx,
+    text: `Prediction ${idx + 1}`,
+  })) as EuiSelectOption[];
+  const [selectedOutputOption, setSelectedOutputOption] = useState<
+    number | undefined
+  >(
+    get(outputOptions, '0.value') !== undefined
+      ? (outputOptions[0].value as number)
+      : undefined
+  );
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
@@ -149,35 +168,56 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
               </EuiText>
               <EuiSpacer size="s" />
-              {/**TODO update to be map array field */}
-              <MapField
+              <MapArrayField
                 field={props.inputMapField}
                 fieldPath={props.inputMapFieldPath}
-                label="Input map"
+                label="Input Map"
                 helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
                 valuePlaceholder="Document field"
                 onFormChange={props.onFormChange}
+                // If the map we are deleting is the one we last used to test, reset the state and
+                // default to the first map in the list.
+                onMapDelete={(idxToDelete) => {
+                  if (selectedOutputOption === idxToDelete) {
+                    setSelectedOutputOption(0);
+                    setTransformedOutput('{}');
+                  }
+                }}
               />
             </>
           </EuiFlexItem>
           <EuiFlexItem>
             <>
-              <EuiText>Expected output</EuiText>
+              <EuiSelect
+                prepend={<EuiText>Expected output for</EuiText>}
+                compressed={true}
+                options={outputOptions}
+                value={selectedOutputOption}
+                onChange={(e) => {
+                  setSelectedOutputOption(Number(e.target.value));
+                  setTransformedOutput('{}');
+                }}
+              />
+              <EuiSpacer size="s" />
               <EuiButton
                 style={{ width: '100px' }}
                 disabled={isEmpty(map) || isEmpty(JSON.parse(sourceInput))}
                 onClick={async () => {
                   switch (props.context) {
                     case PROCESSOR_CONTEXT.INGEST: {
-                      if (!isEmpty(map) && !isEmpty(JSON.parse(sourceInput))) {
+                      if (
+                        !isEmpty(map) &&
+                        !isEmpty(JSON.parse(sourceInput)) &&
+                        selectedOutputOption !== undefined
+                      ) {
                         let sampleSourceInput = {};
                         try {
                           sampleSourceInput = JSON.parse(sourceInput)[0];
                           const output = generateTransform(
                             sampleSourceInput,
-                            map
+                            map[selectedOutputOption]
                           );
                           setTransformedOutput(
                             JSON.stringify(output, undefined, 2)

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -53,6 +53,10 @@ interface InputTransformModalProps {
   onFormChange: () => void;
 }
 
+// TODO: InputTransformModal and OutputTransformModal are very similar, and can
+// likely be refactored and have more reusable components. Leave as-is until the
+// UI is more finalized.
+
 /**
  * A modal to configure advanced JSON-to-JSON transforms into a model's expected input
  */
@@ -177,6 +181,12 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 keyPlaceholder="Model input field"
                 valuePlaceholder="Document field"
                 onFormChange={props.onFormChange}
+                // If the map we are adding is the first one, populate the selected option to index 0
+                onMapAdd={(curArray) => {
+                  if (isEmpty(curArray)) {
+                    setSelectedOutputOption(0);
+                  }
+                }}
                 // If the map we are deleting is the one we last used to test, reset the state and
                 // default to the first map in the list.
                 onMapDelete={(idxToDelete) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -149,6 +149,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
               </EuiText>
               <EuiSpacer size="s" />
+              {/**TODO update to be map array field */}
               <MapField
                 field={props.inputMapField}
                 fieldPath={props.inputMapFieldPath}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -21,7 +21,7 @@ import {
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
 } from '../../../../../common';
-import { MapField, ModelField } from '../input_fields';
+import { MapField, MapArrayField, ModelField } from '../input_fields';
 import { isEmpty } from 'lodash';
 import { InputTransformModal } from './input_transform_modal';
 import { OutputTransformModal } from './output_transform_modal';
@@ -121,7 +121,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
           </EuiText>
           <EuiSpacer size="s" />
-          <MapField
+          <MapArrayField
             field={inputMapField}
             fieldPath={inputMapFieldPath}
             label="Input Map"
@@ -152,6 +152,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="s" />
+          {/**TODO update to be map array field */}
           <MapField
             field={outputMapField}
             fieldPath={outputMapFieldPath}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -21,7 +21,7 @@ import {
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
 } from '../../../../../common';
-import { MapField, MapArrayField, ModelField } from '../input_fields';
+import { MapArrayField, ModelField } from '../input_fields';
 import { isEmpty } from 'lodash';
 import { InputTransformModal } from './input_transform_modal';
 import { OutputTransformModal } from './output_transform_modal';
@@ -152,8 +152,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="s" />
-          {/**TODO update to be map array field */}
-          <MapField
+          <MapArrayField
             field={outputMapField}
             fieldPath={outputMapFieldPath}
             label="Output Map"

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
 import {
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -51,10 +52,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     (field) => field.id === 'inputMap'
   ) as IConfigField;
   const inputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${inputMapField.id}`;
+  const inputMapValue = getIn(values, inputMapFieldPath);
   const outputMapField = props.config.fields.find(
     (field) => field.id === 'outputMap'
   ) as IConfigField;
   const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${outputMapField.id}`;
+  const outputMapValue = getIn(values, outputMapFieldPath);
 
   // advanced transformations modal state
   const [isInputTransformModalOpen, setIsInputTransformModalOpen] = useState<
@@ -163,6 +166,16 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             onFormChange={props.onFormChange}
           />
           <EuiSpacer size="s" />
+          {inputMapValue.length !== outputMapValue.length &&
+            inputMapValue.length > 0 &&
+            outputMapValue.length > 0 && (
+              <EuiCallOut
+                size="s"
+                title="Input and output maps must have equal length if both are defined"
+                iconType={'alert'}
+                color="danger"
+              />
+            )}
         </>
       )}
     </>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -178,6 +178,12 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 keyPlaceholder="New document field"
                 valuePlaceholder="Model output field"
                 onFormChange={props.onFormChange}
+                // If the map we are adding is the first one, populate the selected option to index 0
+                onMapAdd={(curArray) => {
+                  if (isEmpty(curArray)) {
+                    setSelectedOutputOption(0);
+                  }
+                }}
                 // If the map we are deleting is the one we last used to test, reset the state and
                 // default to the first map in the list.
                 onMapDelete={(idxToDelete) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { useFormikContext, getIn } from 'formik';
-import { cloneDeep, isEmpty, set, get } from 'lodash';
+import { cloneDeep, isEmpty, set } from 'lodash';
 import {
   EuiButton,
   EuiCodeEditor,
@@ -65,10 +65,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
   // get the current output map
-  const map = getIn(
-    values,
-    `ingest.enrich.${props.config.id}.outputMap`
-  ) as MapArrayFormValue;
+  const map = getIn(values, props.outputMapFieldPath) as MapArrayFormValue;
 
   // selected output state
   const outputOptions = map.map((_, idx) => ({
@@ -77,11 +74,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   })) as EuiSelectOption[];
   const [selectedOutputOption, setSelectedOutputOption] = useState<
     number | undefined
-  >(
-    get(outputOptions, '0.value') !== undefined
-      ? (outputOptions[0].value as number)
-      : undefined
-  );
+  >((outputOptions[0]?.value as number) ?? undefined);
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -149,6 +149,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
               </EuiText>
               <EuiSpacer size="s" />
+              {/**TODO update to be map array field */}
               <MapField
                 field={props.outputMapField}
                 fieldPath={props.outputMapFieldPath}

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -15,7 +15,6 @@ import {
   ConfigFieldType,
   ConfigFieldValue,
   ModelFormValue,
-  FETCH_ALL_QUERY_BODY,
 } from '../../common';
 
 /*
@@ -122,6 +121,9 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     }
     case 'jsonArray': {
       return '[]';
+    }
+    case 'mapArray': {
+      return [];
     }
   }
 }

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -127,12 +127,30 @@ function getFieldSchema(fieldType: ConfigFieldType): Schema {
           try {
             // @ts-ignore
             return Array.isArray(JSON.parse(value));
-            return true;
           } catch (error) {
             return false;
           }
         });
 
+      break;
+    }
+    case 'mapArray': {
+      baseSchema = yup.array().of(
+        yup.array().of(
+          yup.object().shape({
+            key: yup
+              .string()
+              .min(1, 'Too short')
+              .max(70, 'Too long')
+              .required(),
+            value: yup
+              .string()
+              .min(1, 'Too short')
+              .max(70, 'Too long')
+              .required(),
+          })
+        )
+      );
       break;
     }
   }

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -25,6 +25,8 @@ import {
   SearchProcessor,
   IngestConfig,
   SearchConfig,
+  MapFormValue,
+  MapEntry,
 } from '../../common';
 import { processorConfigToFormik } from './config_to_form_utils';
 import { generateId } from './utils';
@@ -155,23 +157,15 @@ export function processorConfigsToTemplateProcessors(
           },
         } as MLInferenceProcessor;
         if (inputMap?.length > 0) {
-          processor.ml_inference.input_map = inputMap.map((mapFormValue) => {
-            let curMap = {} as { key: string; value: string };
-            mapFormValue.forEach((mapEntry) => {
-              curMap = {
-                ...curMap,
-                [mapEntry.key]: mapEntry.value,
-              };
-            });
-            return curMap;
-          });
+          processor.ml_inference.input_map = inputMap.map((mapFormValue) =>
+            mergeMapIntoSingleObj(mapFormValue)
+          );
         }
 
-        // TODO complete for output map
         if (outputMap?.length > 0) {
-          processor.ml_inference.output_map = outputMap.map((mapEntry) => ({
-            [mapEntry.key]: mapEntry.value,
-          }));
+          processor.ml_inference.output_map = outputMap.map((mapFormValue) =>
+            mergeMapIntoSingleObj(mapFormValue)
+          );
         }
 
         processorsList.push(processor);
@@ -257,4 +251,18 @@ export function reduceToTemplate(workflow: Workflow): WorkflowTemplate {
     ...workflowTemplate
   } = workflow;
   return workflowTemplate;
+}
+
+// Helper fn to merge the form map (an arr of objs) into a single obj, such that each key
+// is an obj property, and each value is a property value. Used to format into the
+// expected inputs for input_maps and output_maps of the ML inference processors.
+function mergeMapIntoSingleObj(mapFormValue: MapFormValue): {} {
+  let curMap = {} as MapEntry;
+  mapFormValue.forEach((mapEntry) => {
+    curMap = {
+      ...curMap,
+      [mapEntry.key]: mapEntry.value,
+    };
+  });
+  return curMap;
 }

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -17,7 +17,7 @@ import {
   IndexConfig,
   IProcessorConfig,
   MLInferenceProcessor,
-  MapFormValue,
+  MapArrayFormValue,
   IngestProcessor,
   Workflow,
   WorkflowTemplate,
@@ -145,8 +145,8 @@ export function processorConfigsToTemplateProcessors(
           processorConfig
         ) as {
           model: ModelFormValue;
-          inputMap: MapFormValue;
-          outputMap: MapFormValue;
+          inputMap: MapArrayFormValue;
+          outputMap: MapArrayFormValue;
         };
 
         let processor = {
@@ -155,10 +155,19 @@ export function processorConfigsToTemplateProcessors(
           },
         } as MLInferenceProcessor;
         if (inputMap?.length > 0) {
-          processor.ml_inference.input_map = inputMap.map((mapEntry) => ({
-            [mapEntry.key]: mapEntry.value,
-          }));
+          processor.ml_inference.input_map = inputMap.map((mapFormValue) => {
+            let curMap = {} as { key: string; value: string };
+            mapFormValue.forEach((mapEntry) => {
+              curMap = {
+                ...curMap,
+                [mapEntry.key]: mapEntry.value,
+              };
+            });
+            return curMap;
+          });
         }
+
+        // TODO complete for output map
         if (outputMap?.length > 0) {
           processor.ml_inference.output_map = outputMap.map((mapEntry) => ({
             [mapEntry.key]: mapEntry.value,

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -8,6 +8,7 @@ import jsonpath from 'jsonpath';
 import { get } from 'lodash';
 import {
   JSONPATH_ROOT_SELECTOR,
+  MapFormValue,
   SimulateIngestPipelineDoc,
   SimulateIngestPipelineResponse,
   WORKFLOW_RESOURCE_TYPE,
@@ -157,10 +158,7 @@ export function unwrapTransformedDocs(
 
 // ML inference processors will use standard dot notation or JSONPath depending on the input.
 // We follow the same logic here to generate consistent results.
-export function generateTransform(
-  input: {},
-  map: { key: string; value: string }[]
-): {} {
+export function generateTransform(input: {}, map: MapFormValue): {} {
   let output = {};
   map.forEach((mapEntry) => {
     const path = mapEntry.value;


### PR DESCRIPTION
### Description

This PR expands the form inputs for the input map / output map fields for ML processors, to be a _list_ of maps, instead of a single map. This is so multiple predict/inference calls can happen within a single processor's execution. At a high level, this means changing the form, schema, and components to maintain an arr of maps instead of a single one.

Additionally, In the advanced transform modals, users can now select which predict/inference call they want to test out and see test transformation results of.

More specific details:
- add new `mapArray` config field type
- add new `MapArrayField` which takes in a `Formik`'s arr field and maintains an arr of individual `MapField`s
- update the transform modals to maintain a specific map/prediction to test with. Adds in a selector for users to choose which map/prediction they want
- minor refactoring updates to the conversion fns for handling the new `mapArray` field type, used in the ML processor's `inputMap`/`outputMap` fields

Testing
- confirmed arrays of input_maps and output_maps work as expected in the simulate pipeline calls within the transform modals, as well as the actual ingest calls and checking the indexed data
- confirmed edge cases (some empty/mismatching arr sizes) for both input and output transforms work as expected

Demo video, showing configuration of multiple prediction/inference mappings configured in the input and output maps, validation of mismatching, and transformation testing within the input transform modal and output transform modals:

[screen-capture (12).webm](https://github.com/user-attachments/assets/0e00feef-c2a9-43c0-af75-6eff7c0aa98e)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
