### PR TITLE
Onboard search req / search resp ML processors

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -51,12 +51,6 @@ export type ProcessorsConfig = {
   processors: IProcessorConfig[];
 };
 
-export type IngestPipelineConfig = ProcessorsConfig & {
-  description?: string;
-};
-
-export type SearchPipelineConfig = ProcessorsConfig;
-
 export type IndexConfig = {
   name: IConfigField;
   mappings: IConfigField;
@@ -196,6 +190,18 @@ export type SearchRequestProcessor = SearchProcessor & {};
 export type SearchResponseProcessor = SearchProcessor & {};
 export type SearchPhaseResultsProcessor = SearchProcessor & {};
 
+export type IngestPipelineConfig = {
+  description?: string;
+  processors: IngestProcessor[];
+};
+
+export type SearchPipelineConfig = {
+  description?: string;
+  request_processors?: SearchRequestProcessor[];
+  response_processors?: SearchResponseProcessor[];
+  phase_results_processors?: SearchPhaseResultsProcessor[];
+};
+
 export type MLInferenceProcessor = IngestProcessor & {
   ml_inference: {
     model_id: string;
@@ -238,22 +244,14 @@ export type CreateIngestPipelineNode = TemplateNode & {
     model_id?: string;
     input_field?: string;
     output_field?: string;
-    configurations: {
-      description?: string;
-      processors: IngestProcessor[];
-    };
+    configurations: IngestPipelineConfig;
   };
 };
 
 export type CreateSearchPipelineNode = TemplateNode & {
   user_inputs: {
     pipeline_id: string;
-    configurations: {
-      description?: string;
-      request_processors?: SearchRequestProcessor[];
-      response_processors?: SearchResponseProcessor[];
-      phase_results_processors?: SearchPhaseResultsProcessor[];
-    };
+    configurations: SearchPipelineConfig;
   };
 };
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -451,7 +451,7 @@ export type WorkflowDict = {
 export type SimulateIngestPipelineDoc = {
   _index: string;
   _id: string;
-  _source: {};
+  _source: any;
 };
 
 // from https://opensearch.org/docs/latest/ingest-pipelines/simulate-ingest/#example-specify-a-pipeline-in-the-path
@@ -470,3 +470,5 @@ export type SimulateIngestPipelineDocResponse = {
 export type SimulateIngestPipelineResponse = {
   docs: SimulateIngestPipelineDocResponse[];
 };
+
+export type SearchHit = SimulateIngestPipelineDoc;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -34,7 +34,7 @@ import {
   WorkflowFormValues,
 } from '../../../../../common';
 import {
-  formikToIngestPipeline,
+  formikToPipeline,
   generateTransform,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
@@ -99,11 +99,12 @@ export function InputTransformModal(props: InputTransformModalProps) {
                   switch (props.context) {
                     case PROCESSOR_CONTEXT.INGEST: {
                       // get the current ingest pipeline up to, but not including, this processor
-                      const curIngestPipeline = formikToIngestPipeline(
+                      const curIngestPipeline = formikToPipeline(
                         values,
                         props.uiConfig,
                         props.config.id,
-                        false
+                        false,
+                        PROCESSOR_CONTEXT.INGEST
                       );
                       // if there are preceding processors, we need to generate the ingest pipeline
                       // up to this point and simulate, in order to get the latest transformed

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -187,7 +187,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <EuiText
                 size="m"
                 style={{ marginTop: '4px' }}
-              >{`Configure input transformations (optional)`}</EuiText>
+              >{`Configure input transformations (${
+                props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                  ? 'Required'
+                  : 'Optional'
+              })`}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip
@@ -233,7 +237,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <EuiText
                 size="m"
                 style={{ marginTop: '4px' }}
-              >{`Configure output transformations (optional)`}</EuiText>
+              >{`Configure output transformations (${
+                props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                  ? 'Required'
+                  : 'Optional'
+              })`}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip
@@ -275,6 +283,15 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <EuiCallOut
                 size="s"
                 title="Input and output maps must have equal length if both are defined"
+                iconType={'alert'}
+                color="danger"
+              />
+            )}
+          {props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST &&
+            (inputMapValue.length === 0 || outputMapValue.length === 0) && (
+              <EuiCallOut
+                size="s"
+                title="Input and output maps are required for ML inference search request processors"
                 iconType={'alert'}
                 color="danger"
               />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -34,7 +34,7 @@ import {
   WorkflowFormValues,
 } from '../../../../../common';
 import {
-  formikToIngestPipeline,
+  formikToPipeline,
   generateTransform,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
@@ -103,11 +103,12 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         `ingest.enrich.${props.config.id}.outputMap`,
                         []
                       );
-                      const curIngestPipeline = formikToIngestPipeline(
+                      const curIngestPipeline = formikToPipeline(
                         valuesWithoutOutputMapConfig,
                         props.uiConfig,
                         props.config.id,
-                        true
+                        true,
+                        PROCESSOR_CONTEXT.INGEST
                       ) as IngestPipelineConfig;
                       const curDocs = prepareDocsForSimulate(
                         values.ingest.docs,

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -34,7 +34,7 @@ import {
   WorkflowFormValues,
 } from '../../../../../common';
 import {
-  formikToPipeline,
+  formikToPartialPipeline,
   generateTransform,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
@@ -103,7 +103,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         `ingest.enrich.${props.config.id}.outputMap`,
                         []
                       );
-                      const curIngestPipeline = formikToPipeline(
+                      const curIngestPipeline = formikToPartialPipeline(
                         valuesWithoutOutputMapConfig,
                         props.uiConfig,
                         props.config.id,

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -29,6 +29,8 @@ import {
   ML_INFERENCE_DOCS_LINK,
   MapArrayFormValue,
   PROCESSOR_CONTEXT,
+  SearchHit,
+  SearchPipelineConfig,
   SimulateIngestPipelineResponse,
   WorkflowConfig,
   WorkflowFormValues,
@@ -39,7 +41,11 @@ import {
   prepareDocsForSimulate,
   unwrapTransformedDocs,
 } from '../../../../utils';
-import { simulatePipeline, useAppDispatch } from '../../../../store';
+import {
+  searchIndex,
+  simulatePipeline,
+  useAppDispatch,
+} from '../../../../store';
 import { getCore } from '../../../../services';
 import { MapArrayField } from '../input_fields';
 
@@ -93,6 +99,8 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 style={{ width: '100px' }}
                 onClick={async () => {
                   switch (props.context) {
+                    // note we skip search request processor context. that is because empty output maps are not supported.
+                    // for more details, see comment in ml_processor_inputs.tsx
                     case PROCESSOR_CONTEXT.INGEST: {
                       // get the current ingest pipeline up to, and including this processor.
                       // remove any currently-configured output map since we only want the transformation
@@ -131,7 +139,55 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         });
                       break;
                     }
-                    // TODO: complete for search request / search response contexts
+                    case PROCESSOR_CONTEXT.SEARCH_RESPONSE: {
+                      // get the current search pipeline up to, and including this processor.
+                      // remove any currently-configured output map since we only want the transformation
+                      // up to, and including, the input map transformations
+                      const valuesWithoutOutputMapConfig = cloneDeep(values);
+                      set(
+                        valuesWithoutOutputMapConfig,
+                        `search.enrichResponse.${props.config.id}.outputMap`,
+                        []
+                      );
+                      const curSearchPipeline = formikToPartialPipeline(
+                        valuesWithoutOutputMapConfig,
+                        props.uiConfig,
+                        props.config.id,
+                        true,
+                        PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                      ) as SearchPipelineConfig;
+
+                      // Execute search. Augment the existing query with
+                      // the partial search pipeline (inline) to get the latest transformed
+                      // version of the request.
+                      dispatch(
+                        searchIndex({
+                          index: values.ingest.index.name,
+                          body: JSON.stringify({
+                            ...JSON.parse(values.search.request as string),
+                            search_pipeline: curSearchPipeline,
+                          }),
+                        })
+                      )
+                        .unwrap()
+                        .then(async (resp) => {
+                          setSourceInput(
+                            JSON.stringify(
+                              resp.hits.hits.map(
+                                (hit: SearchHit) => hit._source
+                              ),
+                              undefined,
+                              2
+                            )
+                          );
+                        })
+                        .catch((error: any) => {
+                          getCore().notifications.toasts.addDanger(
+                            `Failed to fetch input data`
+                          );
+                        });
+                      break;
+                    }
                   }
                 }}
               >
@@ -208,28 +264,28 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 style={{ width: '100px' }}
                 disabled={isEmpty(map) || isEmpty(JSON.parse(sourceInput))}
                 onClick={async () => {
-                  switch (props.context) {
-                    case PROCESSOR_CONTEXT.INGEST: {
-                      if (
-                        !isEmpty(map) &&
-                        !isEmpty(JSON.parse(sourceInput)) &&
-                        selectedOutputOption !== undefined
-                      ) {
-                        let sampleSourceInput = {};
-                        try {
-                          sampleSourceInput = JSON.parse(sourceInput)[0];
-                          const output = generateTransform(
-                            sampleSourceInput,
-                            map[selectedOutputOption]
-                          );
-                          setTransformedOutput(
-                            JSON.stringify(output, undefined, 2)
-                          );
-                        } catch {}
-                      }
-                      break;
-                    }
-                    // TODO: complete for search request / search response contexts
+                  if (
+                    !isEmpty(map) &&
+                    !isEmpty(JSON.parse(sourceInput)) &&
+                    selectedOutputOption !== undefined
+                  ) {
+                    let sampleSourceInput = {};
+                    try {
+                      // In the context of ingest or search resp, this input will be an array (list of docs)
+                      // In the context of request, it will be a single JSON
+                      sampleSourceInput =
+                        props.context === PROCESSOR_CONTEXT.INGEST ||
+                        props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                          ? JSON.parse(sourceInput)[0]
+                          : JSON.parse(sourceInput);
+                      const output = generateTransform(
+                        sampleSourceInput,
+                        map[selectedOutputOption]
+                      );
+                      setTransformedOutput(
+                        JSON.stringify(output, undefined, 2)
+                      );
+                    } catch {}
                   }
                 }}
               >

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -26,6 +26,8 @@ import {
 import { formikToUiConfig } from '../../../utils';
 import {
   MLIngestProcessor,
+  MLSearchRequestProcessor,
+  MLSearchResponseProcessor,
   SortIngestProcessor,
   SortSearchResponseProcessor,
   SplitIngestProcessor,
@@ -224,11 +226,28 @@ export function ProcessorsList(props: ProcessorsListProps) {
                             },
                           },
                         ]
-                      : // TODO: populate more search req / search resp processors.
-                      // Ref: https://github.com/opensearch-project/dashboards-flow-framework/issues/219
-                      props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                      ? []
+                      : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                      ? [
+                          {
+                            name: 'ML Inference Processor',
+                            onClick: () => {
+                              closePopover();
+                              addProcessor(
+                                new MLSearchRequestProcessor().toObj()
+                              );
+                            },
+                          },
+                        ]
                       : [
+                          {
+                            name: 'ML Inference Processor',
+                            onClick: () => {
+                              closePopover();
+                              addProcessor(
+                                new MLSearchResponseProcessor().toObj()
+                              );
+                            },
+                          },
                           {
                             name: 'Split Processor',
                             onClick: () => {

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -22,7 +22,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { WorkspaceFormValues } from '../../../../../common';
+import { SearchHit, WorkspaceFormValues } from '../../../../../common';
 import { JsonField } from '../input_fields';
 import {
   AppState,
@@ -172,8 +172,13 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
               )
                 .unwrap()
                 .then(async (resp) => {
-                  const hits = resp.hits.hits;
-                  props.setQueryResponse(JSON.stringify(hits, undefined, 2));
+                  props.setQueryResponse(
+                    JSON.stringify(
+                      resp.hits.hits.map((hit: SearchHit) => hit._source),
+                      undefined,
+                      2
+                    )
+                  );
                 })
                 .catch((error: any) => {
                   props.setQueryResponse('');

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -28,6 +28,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import {
+  SearchHit,
   Workflow,
   WorkflowConfig,
   WorkflowFormValues,
@@ -335,8 +336,13 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           dispatch(searchIndex({ index: indexName, body: props.query }))
             .unwrap()
             .then(async (resp) => {
-              const hits = resp.hits.hits;
-              props.setQueryResponse(JSON.stringify(hits, undefined, 2));
+              props.setQueryResponse(
+                JSON.stringify(
+                  resp.hits.hits.map((hit: SearchHit) => hit._source),
+                  undefined,
+                  2
+                )
+              );
               dispatch(removeDirty());
             })
             .catch((error: any) => {

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { FormikValues } from 'formik';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 import {
   WorkflowConfig,
   WorkflowFormValues,
@@ -13,6 +13,7 @@ import {
   ProcessorsConfig,
   IndexConfig,
 } from '../../common';
+import { getInitialValue } from './config_to_form_utils';
 
 /*
  **************** Formik -> config utils **********************
@@ -94,7 +95,11 @@ function formikToProcessorsUiConfig(
   existingConfig.processors.forEach((processorConfig) => {
     const processorFormValues = formValues[processorConfig.id];
     processorConfig.fields.forEach((processorField) => {
-      processorField.value = processorFormValues[processorField.id];
+      processorField.value = get(
+        processorFormValues,
+        processorField.id,
+        getInitialValue(processorField.type)
+      );
     });
   });
   return existingConfig;

--- a/public/utils/form_to_pipeline_utils.ts
+++ b/public/utils/form_to_pipeline_utils.ts
@@ -7,6 +7,7 @@ import { isEmpty } from 'lodash';
 import {
   IProcessorConfig,
   IngestPipelineConfig,
+  PROCESSOR_CONTEXT,
   SearchPipelineConfig,
   WorkflowConfig,
   WorkflowFormValues,
@@ -22,15 +23,22 @@ import { processorConfigsToTemplateProcessors } from './config_to_template_utils
    the input schema at a certain stage of a pipeline.
    */
 
-export function formikToIngestPipeline(
+export function formikToPipeline(
   values: WorkflowFormValues,
   existingConfig: WorkflowConfig,
   curProcessorId: string,
-  includeCurProcessor: boolean
-): IngestPipelineConfig | SearchPipelineConfig | undefined {
+  includeCurProcessor: boolean,
+  context: PROCESSOR_CONTEXT
+): IngestPipelineConfig | undefined {
   const uiConfig = formikToUiConfig(values, existingConfig);
+  const processors =
+    context === PROCESSOR_CONTEXT.INGEST
+      ? uiConfig.ingest.enrich.processors
+      : context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+      ? uiConfig.search.enrichRequest.processors
+      : uiConfig.search.enrichResponse.processors;
   const precedingProcessors = getPrecedingProcessors(
-    uiConfig.ingest.enrich.processors,
+    processors,
     curProcessorId,
     includeCurProcessor
   );

--- a/public/utils/form_to_pipeline_utils.ts
+++ b/public/utils/form_to_pipeline_utils.ts
@@ -23,31 +23,69 @@ import { processorConfigsToTemplateProcessors } from './config_to_template_utils
    the input schema at a certain stage of a pipeline.
    */
 
-export function formikToPipeline(
+export function formikToPartialPipeline(
   values: WorkflowFormValues,
   existingConfig: WorkflowConfig,
   curProcessorId: string,
   includeCurProcessor: boolean,
   context: PROCESSOR_CONTEXT
-): IngestPipelineConfig | undefined {
+): IngestPipelineConfig | SearchPipelineConfig | undefined {
   const uiConfig = formikToUiConfig(values, existingConfig);
-  const processors =
-    context === PROCESSOR_CONTEXT.INGEST
-      ? uiConfig.ingest.enrich.processors
-      : context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-      ? uiConfig.search.enrichRequest.processors
-      : uiConfig.search.enrichResponse.processors;
-  const precedingProcessors = getPrecedingProcessors(
-    processors,
-    curProcessorId,
-    includeCurProcessor
-  );
-  if (!isEmpty(precedingProcessors)) {
-    return {
-      processors: processorConfigsToTemplateProcessors(precedingProcessors),
-    } as IngestPipelineConfig | SearchPipelineConfig;
+  switch (context) {
+    // Generating ingest pipeline: just fetch existing ingest processors and
+    // check if there are preceding ones
+    case PROCESSOR_CONTEXT.INGEST: {
+      const precedingProcessors = getPrecedingProcessors(
+        uiConfig.ingest.enrich.processors,
+        curProcessorId,
+        includeCurProcessor
+      );
+      return !isEmpty(precedingProcessors)
+        ? ({
+            processors: processorConfigsToTemplateProcessors(
+              precedingProcessors
+            ),
+          } as IngestPipelineConfig)
+        : undefined;
+    }
+    // Generating search pipeline (request): just fetch existing search request
+    // processors and check if there are preceding ones
+    case PROCESSOR_CONTEXT.SEARCH_REQUEST: {
+      const precedingProcessors = getPrecedingProcessors(
+        uiConfig.search.enrichRequest.processors,
+        curProcessorId,
+        includeCurProcessor
+      );
+      return !isEmpty(precedingProcessors)
+        ? ({
+            request_processors: processorConfigsToTemplateProcessors(
+              precedingProcessors
+            ),
+          } as SearchPipelineConfig)
+        : undefined;
+    }
+    // Generating search pipeline (response): fetch existing search response
+    // processors and check if there are preceding ones. Also add on any
+    // existing search request processors
+    case PROCESSOR_CONTEXT.SEARCH_RESPONSE: {
+      const requestProcessors = uiConfig.search.enrichRequest.processors;
+      const precedingProcessors = getPrecedingProcessors(
+        uiConfig.search.enrichResponse.processors,
+        curProcessorId,
+        includeCurProcessor
+      );
+      return !isEmpty(precedingProcessors) || !isEmpty(requestProcessors)
+        ? ({
+            request_processors: processorConfigsToTemplateProcessors(
+              requestProcessors
+            ),
+            response_processors: processorConfigsToTemplateProcessors(
+              precedingProcessors
+            ),
+          } as SearchPipelineConfig)
+        : undefined;
+    }
   }
-  return undefined;
 }
 
 function getPrecedingProcessors(

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -22,6 +22,7 @@ import {
   GET_WORKFLOW_STATE_NODE_API_PATH,
   PROVISION_WORKFLOW_NODE_API_PATH,
   SEARCH_WORKFLOWS_NODE_API_PATH,
+  SearchHit,
   UPDATE_WORKFLOW_NODE_API_PATH,
   WORKFLOW_STATE,
   Workflow,
@@ -218,12 +219,12 @@ export class FlowFrameworkRoutesService {
       const workflowsResponse = await this.client
         .asScoped(req)
         .callAsCurrentUser('flowFramework.searchWorkflows', { body });
-      const workflowHits = workflowsResponse.hits.hits as any[];
+      const workflowHits = workflowsResponse.hits.hits as SearchHit[];
 
       const workflowStatesResponse = await this.client
         .asScoped(req)
         .callAsCurrentUser('flowFramework.searchWorkflowState', { body });
-      const workflowStateHits = workflowStatesResponse.hits.hits as any[];
+      const workflowStateHits = workflowStatesResponse.hits.hits as SearchHit[];
 
       const workflowDict = getWorkflowsFromResponses(
         workflowHits,

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -11,6 +11,7 @@ import {
   Model,
   ModelDict,
   ModelInterface,
+  SearchHit,
   WORKFLOW_RESOURCE_TYPE,
   WORKFLOW_STATE,
   Workflow,
@@ -57,11 +58,11 @@ export function toWorkflowObj(hitSource: any, id: string): Workflow {
 // Current implementation combines 2 search responses to create a single set of workflows with
 // static information + state information
 export function getWorkflowsFromResponses(
-  workflowHits: any[],
-  workflowStateHits: any[]
+  workflowHits: SearchHit[],
+  workflowStateHits: SearchHit[]
 ): WorkflowDict {
   const workflowDict = {} as WorkflowDict;
-  workflowHits.forEach((workflowHit: any) => {
+  workflowHits.forEach((workflowHit: SearchHit) => {
     const hitSource = workflowHit._source;
     workflowDict[workflowHit._id] = toWorkflowObj(hitSource, workflowHit._id);
     const workflowStateHit = workflowStateHits.find(
@@ -85,9 +86,9 @@ export function getWorkflowsFromResponses(
   return workflowDict;
 }
 
-export function getModelsFromResponses(modelHits: any[]): ModelDict {
+export function getModelsFromResponses(modelHits: SearchHit[]): ModelDict {
   const modelDict = {} as ModelDict;
-  modelHits.forEach((modelHit: any) => {
+  modelHits.forEach((modelHit: SearchHit) => {
     // search model API returns hits for each deployed model chunk. ignore these hits
     if (modelHit._source.chunk_number === undefined) {
       const modelId = modelHit._id;

--- a/server/routes/ml_routes_service.ts
+++ b/server/routes/ml_routes_service.ts
@@ -11,7 +11,7 @@ import {
   OpenSearchDashboardsRequest,
   OpenSearchDashboardsResponseFactory,
 } from '../../../../src/core/server';
-import { SEARCH_MODELS_NODE_API_PATH } from '../../common';
+import { SEARCH_MODELS_NODE_API_PATH, SearchHit } from '../../common';
 import { generateCustomError, getModelsFromResponses } from './helpers';
 
 /**
@@ -50,7 +50,7 @@ export class MLRoutesService {
       const modelsResponse = await this.client
         .asScoped(req)
         .callAsCurrentUser('mlClient.searchModels', { body });
-      const modelHits = modelsResponse.hits.hits as any[];
+      const modelHits = modelsResponse.hits.hits as SearchHit[];
       const modelDict = getModelsFromResponses(modelHits);
 
       return res.ok({ body: { models: modelDict } });


### PR DESCRIPTION
### Description

This PR adds ML processor as options in the context of search request and search response. Additionally, it finishes all of the logic in the input transform / output transform modals to dynamically fetch input / generate output. There are a few places where this preview / advanced transform view is gated:
1. Chaining multiple search request processors - in this case, since we don't have per-processor logging available, we cannot generate the interim transformed request. This is already tracked here: https://github.com/opensearch-project/OpenSearch/issues/14745
2. Advanced output transform for search request processors - we cannot do partial simulation of the search request processor in the context of output transformations, since there is no way to configure a working, simulate-able search request processor with an empty output_map - it is always required, as both input_map and output_map are optional in the context of ingest and search response. We need an empty output_map in order to isolate the response up to the point of configuring it.

More implementation details:
- finishes handling the different contexts in `InputTransformModal` and the logic needed to fetch inputs
- finishes handling the different contexts in `OutputTransformModal` and the logic needed to fetch inputs
- refactors `formikToIngestPipeline` -> `formikToPartialPipeline` to be generic and handle for all contexts
- adds gating in `MLProcessorInputs` to enable/disable the `Preview` button based on the different scenarios mentioned above ^
- extra limitations on search request processor contexts: the input maps and output maps are required: warning modal added when these are empty
- minor change in formatting of search responses to just show the nested `_source` document info. This is also to keep consistent with how the ML inference processors handle this input JSON, so we can replicate it correctly & consistently in the transform modals.

Testing:
- Both added ML processors compile and work as expected, and generate valid search template resources
- Preview works for both
- Preview is disabled based on 2 scenarios above
- Existing ingest processor & preview works as expected

Demo video, showing the 2 new processors, and preview functionality for both.

[screen-capture (17).webm](https://github.com/user-attachments/assets/ca21910e-6b14-4680-9df7-ef3c5adbaa41)

### Issues Resolved
Resolves #217 
Makes progress on #23 
Makes progress on #219 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
