### PR TITLE
Support optional params for all processors; onboard text_chunking processor

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -68,6 +68,7 @@ export enum PROCESSOR_TYPE {
   ML = 'ml_inference',
   SPLIT = 'split',
   SORT = 'sort',
+  TEXT_CHUNKING = 'text_chunking',
 }
 
 export enum MODEL_TYPE {
@@ -120,6 +121,24 @@ export const ML_INFERENCE_DOCS_LINK =
   'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters';
 export const ML_CHOOSE_MODEL_LINK =
   'https://opensearch.org/docs/latest/ml-commons-plugin/integrating-ml-models/#choosing-a-model';
+export const TEXT_CHUNKING_PROCESSOR_LINK =
+  'https://opensearch.org/docs/latest/ingest-pipelines/processors/text-chunking/';
+
+/**
+ * Text chunking algorithm constants
+ */
+export enum TEXT_CHUNKING_ALGORITHM {
+  FIXED_TOKEN_LENGTH = 'fixed_token_length',
+  DELIMITER = 'delimiter',
+}
+export const FIXED_TOKEN_LENGTH_OPTIONAL_FIELDS = [
+  'token_limit',
+  'tokenizer',
+  'overlap_rate',
+];
+export const DELIMITER_OPTIONAL_FIELDS = ['delimiter'];
+export const SHARED_OPTIONAL_FIELDS = ['max_chunk_limit', 'description', 'tag'];
+
 /**
  * MISCELLANEOUS
  */

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -62,10 +62,12 @@ export enum WORKFLOW_TYPE {
   UNKNOWN = 'Unknown',
 }
 
+// the names should be consistent with the underlying implementation. used when generating the
+// final ingest/search pipeline configurations.
 export enum PROCESSOR_TYPE {
-  ML = 'ml_processor',
-  SPLIT = 'split_processor',
-  SORT = 'sort_processor',
+  ML = 'ml_inference',
+  SPLIT = 'split',
+  SORT = 'sort',
 }
 
 export enum MODEL_TYPE {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -25,7 +25,8 @@ export type ConfigFieldType =
   | 'model'
   | 'map'
   | 'mapArray'
-  | 'boolean';
+  | 'boolean'
+  | 'number';
 
 export type ConfigFieldValue = string | {};
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -31,8 +31,6 @@ export type ConfigFieldValue = string | {};
 export interface IConfigField {
   type: ConfigFieldType;
   id: string;
-  optional?: boolean;
-  label?: string;
   value?: ConfigFieldValue;
   selectOptions?: ConfigFieldValue[];
 }
@@ -41,6 +39,7 @@ export interface IConfig {
   id: string;
   name: string;
   fields: IConfigField[];
+  optionalFields?: IConfigField[];
 }
 
 export interface IProcessorConfig extends IConfig {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -24,7 +24,8 @@ export type ConfigFieldType =
   | 'select'
   | 'model'
   | 'map'
-  | 'mapArray';
+  | 'mapArray'
+  | 'boolean';
 
 export type ConfigFieldValue = string | {};
 

--- a/public/configs/base_config.ts
+++ b/public/configs/base_config.ts
@@ -12,14 +12,14 @@ export abstract class BaseConfig implements IConfig {
   id: string;
   name: string;
   fields: IConfigField[];
-  // TODO: have a dedicated optional fields list to display more fields & have more
-  // flexibility for the users to customize
+  optionalFields?: IConfigField[];
 
   // No-op constructor. If there are general / defaults for field values, add in here.
   constructor() {
     this.id = '';
     this.name = '';
     this.fields = [];
+    this.optionalFields = [];
   }
 
   // Persist a standard toObj() fn that all component classes can use. This is necessary
@@ -29,6 +29,7 @@ export abstract class BaseConfig implements IConfig {
       id: this.id,
       name: this.name,
       fields: this.fields,
+      optionalFields: this.optionalFields,
     } as IConfig;
   }
 }

--- a/public/configs/ingest_processors/index.ts
+++ b/public/configs/ingest_processors/index.ts
@@ -6,3 +6,4 @@
 export * from './ml_ingest_processor';
 export * from './split_ingest_processor';
 export * from './sort_ingest_processor';
+export * from './text_chunking_ingest_processor';

--- a/public/configs/ingest_processors/text_chunking_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_chunking_ingest_processor.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PROCESSOR_TYPE, TEXT_CHUNKING_ALGORITHM } from '../../../common';
+import { generateId } from '../../utils';
+import { Processor } from '../processor';
+
+/**
+ * The text chunking ingest processor
+ */
+export class TextChunkingIngestProcessor extends Processor {
+  constructor() {
+    super();
+    this.name = 'Text Chunking Processor';
+    this.type = PROCESSOR_TYPE.TEXT_CHUNKING;
+    this.id = generateId('text_chunking_processor_ingest');
+    this.fields = [
+      {
+        id: 'field_map',
+        type: 'map',
+      },
+      {
+        id: 'algorithm',
+        type: 'select',
+        selectOptions: [
+          TEXT_CHUNKING_ALGORITHM.FIXED_TOKEN_LENGTH,
+          TEXT_CHUNKING_ALGORITHM.DELIMITER,
+        ],
+      },
+    ];
+    // optional params include all of those possible from both text chunking algorithms.
+    // for more details, see https://opensearch.org/docs/latest/ingest-pipelines/processors/text-chunking/
+    // the list of optional params per algorithm and shared across algorithms is persisted in
+    // common/constants.ts
+    this.optionalFields = [
+      // fixed_token_length optional params
+      {
+        id: 'token_limit',
+        type: 'number',
+        value: 384,
+      },
+      {
+        id: 'tokenizer',
+        type: 'string',
+        value: 'standard',
+      },
+      {
+        id: 'overlap_rate',
+        type: 'number',
+        value: 0,
+      },
+      // delimiter optional params
+      {
+        id: 'delimiter',
+        type: 'string',
+      },
+      // shared optional params (independent of algorithm)
+      {
+        id: 'max_chunk_limit',
+        type: 'number',
+        value: 100,
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+    ];
+  }
+}

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -21,11 +21,11 @@ export abstract class MLProcessor extends Processor {
         type: 'model',
       },
       {
-        id: 'inputMap',
+        id: 'input_map',
         type: 'mapArray',
       },
       {
-        id: 'outputMap',
+        id: 'output_map',
         type: 'mapArray',
       },
     ];

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -29,5 +29,39 @@ export abstract class MLProcessor extends Processor {
         type: 'mapArray',
       },
     ];
+    this.optionalFields = [
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'model_config',
+        type: 'json',
+      },
+      {
+        id: 'full_response_path',
+        type: 'boolean',
+        value: false,
+      },
+      {
+        id: 'ignore_missing',
+        type: 'boolean',
+        value: false,
+      },
+      {
+        id: 'ignore_failure',
+        type: 'boolean',
+        value: false,
+      },
+      {
+        id: 'max_prediction_tasks',
+        type: 'number',
+        value: 10,
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+    ];
   }
 }

--- a/public/configs/sort_processor.ts
+++ b/public/configs/sort_processor.ts
@@ -19,15 +19,26 @@ export abstract class SortProcessor extends Processor {
       {
         id: 'field',
         type: 'string',
-        label: 'Field',
       },
+    ];
+    this.optionalFields = [
       {
         id: 'order',
         type: 'select',
-        label: 'Order',
-        optional: true,
         selectOptions: [SORT_ORDER.ASC, SORT_ORDER.DESC],
         value: SORT_ORDER.ASC,
+      },
+      {
+        id: 'targetField',
+        type: 'string',
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'tag',
+        type: 'string',
       },
     ];
   }

--- a/public/configs/sort_processor.ts
+++ b/public/configs/sort_processor.ts
@@ -29,7 +29,7 @@ export abstract class SortProcessor extends Processor {
         value: SORT_ORDER.ASC,
       },
       {
-        id: 'targetField',
+        id: 'target_field',
         type: 'string',
       },
       {

--- a/public/configs/split_processor.ts
+++ b/public/configs/split_processor.ts
@@ -19,12 +19,10 @@ export abstract class SplitProcessor extends Processor {
       {
         id: 'field',
         type: 'string',
-        label: 'Field',
       },
       {
         id: 'separator',
         type: 'string',
-        label: 'Separator',
       },
     ];
   }

--- a/public/configs/split_processor.ts
+++ b/public/configs/split_processor.ts
@@ -25,5 +25,26 @@ export abstract class SplitProcessor extends Processor {
         type: 'string',
       },
     ];
+    this.optionalFields = [
+      // TODO: although listed in docs, this field doesn't seem to exist. Fails
+      // at regular API level.
+      // {
+      //   id: 'preserve_field',
+      //   type: 'boolean',
+      //   value: false,
+      // },
+      {
+        id: 'target_field',
+        type: 'string',
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+    ];
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -5,8 +5,9 @@
 
 import React from 'react';
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { TextField, ModelField, SelectField } from './input_fields';
-import { IConfig } from '../../../../common';
+import { TextField, SelectField } from './input_fields';
+import { IConfigField } from '../../../../common';
+import { camelCaseToTitleString } from '../../../utils';
 
 /**
  * A helper component to format all of the input fields for a component. Dynamically
@@ -14,7 +15,8 @@ import { IConfig } from '../../../../common';
  */
 
 interface ConfigFieldListProps {
-  config: IConfig;
+  configId: string;
+  configFields: IConfigField[];
   baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
   onFormChange: () => void;
 }
@@ -22,20 +24,17 @@ interface ConfigFieldListProps {
 const CONFIG_FIELD_SPACER_SIZE = 'm';
 
 export function ConfigFieldList(props: ConfigFieldListProps) {
-  const configFields = props.config.fields || [];
-  const configId = props.config.id;
   return (
     <EuiFlexItem grow={false}>
-      {configFields.map((field, idx) => {
+      {props.configFields.map((field, idx) => {
         let el;
         switch (field.type) {
           case 'string': {
             el = (
               <EuiFlexItem key={idx}>
                 <TextField
-                  // Default to ID if no optional formatted / prettified label provided
-                  label={field.label || field.id}
-                  fieldPath={`${props.baseConfigPath}.${configId}.${field.id}`}
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
                   showError={true}
                   onFormChange={props.onFormChange}
                 />
@@ -49,7 +48,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <SelectField
                   field={field}
-                  fieldPath={`${props.baseConfigPath}.${configId}.${field.id}`}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
                   onFormChange={props.onFormChange}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { TextField, SelectField } from './input_fields';
+import { TextField, SelectField, BooleanField } from './input_fields';
 import { IConfigField } from '../../../../common';
 import { camelCaseToTitleString } from '../../../utils';
 
@@ -50,6 +50,28 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   field={field}
                   fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
                   onFormChange={props.onFormChange}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'boolean': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <BooleanField
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  onFormChange={props.onFormChange}
+                  enabledOption={{
+                    id: 'true',
+                    label: 'True',
+                  }}
+                  disabledOption={{
+                    id: 'false',
+                    label: 'False',
+                  }}
+                  showLabel={true}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -5,7 +5,12 @@
 
 import React from 'react';
 import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { TextField, SelectField, BooleanField } from './input_fields';
+import {
+  TextField,
+  SelectField,
+  BooleanField,
+  NumberField,
+} from './input_fields';
 import { IConfigField } from '../../../../common';
 import { camelCaseToTitleString } from '../../../utils';
 
@@ -72,6 +77,20 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                     label: 'False',
                   }}
                   showLabel={true}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'number': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <NumberField
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  showError={true}
+                  onFormChange={props.onFormChange}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -5,13 +5,24 @@
 
 import React from 'react';
 import { Field, FieldProps } from 'formik';
-import { EuiCompressedRadioGroup, EuiRadioGroupOption } from '@elastic/eui';
+import {
+  EuiCompressedFormRow,
+  EuiCompressedRadioGroup,
+  EuiLink,
+  EuiRadioGroupOption,
+  EuiText,
+} from '@elastic/eui';
+import { camelCaseToTitleString } from '../../../../utils';
 
 interface BooleanFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onFormChange: () => void;
   enabledOption: EuiRadioGroupOption;
   disabledOption: EuiRadioGroupOption;
+  label?: string;
+  helpLink?: string;
+  helpText?: string;
+  showLabel?: boolean;
 }
 
 /**
@@ -22,18 +33,37 @@ export function BooleanField(props: BooleanFieldProps) {
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
         return (
-          <EuiCompressedRadioGroup
-            options={[props.enabledOption, props.disabledOption]}
-            idSelected={
-              field.value === undefined || field.value === true
-                ? props.enabledOption.id
-                : props.disabledOption.id
+          <EuiCompressedFormRow
+            key={props.fieldPath}
+            label={
+              props.showLabel &&
+              (props.label || camelCaseToTitleString(field.name))
             }
-            onChange={(id) => {
-              form.setFieldValue(field.name, !field.value);
-              props.onFormChange();
-            }}
-          />
+            labelAppend={
+              props.helpLink ? (
+                <EuiText size="xs">
+                  <EuiLink href={props.helpLink} target="_blank">
+                    Learn more
+                  </EuiLink>
+                </EuiText>
+              ) : undefined
+            }
+            helpText={props.helpText || undefined}
+            isInvalid={false}
+          >
+            <EuiCompressedRadioGroup
+              options={[props.enabledOption, props.disabledOption]}
+              idSelected={
+                field.value === undefined || field.value === true
+                  ? props.enabledOption.id
+                  : props.disabledOption.id
+              }
+              onChange={(id) => {
+                form.setFieldValue(field.name, !field.value);
+                props.onFormChange();
+              }}
+            />
+          </EuiCompressedFormRow>
         );
       }}
     </Field>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
@@ -10,3 +10,4 @@ export { MapField } from './map_field';
 export { MapArrayField } from './map_array_field';
 export { BooleanField } from './boolean_field';
 export { SelectField } from './select_field';
+export { NumberField } from './number_field';

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -5,8 +5,14 @@
 
 import React, { useEffect, useState } from 'react';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
-import { EuiCodeEditor, EuiCompressedFormRow, EuiLink, EuiText } from '@elastic/eui';
+import {
+  EuiCodeEditor,
+  EuiCompressedFormRow,
+  EuiLink,
+  EuiText,
+} from '@elastic/eui';
 import { WorkspaceFormValues } from '../../../../../common';
+import { camelCaseToTitleString } from '../../../../utils';
 
 interface JsonFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
@@ -44,7 +50,7 @@ export function JsonField(props: JsonFieldProps) {
         return (
           <EuiCompressedFormRow
             key={props.fieldPath}
-            label={props.label}
+            label={props.label || camelCaseToTitleString(field.name)}
             labelAppend={
               props.helpLink ? (
                 <EuiText size="xs">

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/number_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/number_field.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Field, FieldProps, getIn, useFormikContext } from 'formik';
+import {
+  EuiCompressedFormRow,
+  EuiLink,
+  EuiText,
+  EuiFieldNumber,
+} from '@elastic/eui';
+import { WorkspaceFormValues } from '../../../../../common';
+import { camelCaseToTitleString, getInitialValue } from '../../../../utils';
+
+interface NumberFieldProps {
+  fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
+  onFormChange: () => void;
+  label?: string;
+  helpLink?: string;
+  helpText?: string;
+  placeholder?: string;
+  showError?: boolean;
+}
+
+/**
+ * An input field for a component where users input numbers
+ */
+export function NumberField(props: NumberFieldProps) {
+  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+
+  return (
+    <Field name={props.fieldPath}>
+      {({ field, form }: FieldProps) => {
+        return (
+          <EuiCompressedFormRow
+            key={props.fieldPath}
+            label={props.label || camelCaseToTitleString(field.name)}
+            labelAppend={
+              props.helpLink ? (
+                <EuiText size="xs">
+                  <EuiLink href={props.helpLink} target="_blank">
+                    Learn more
+                  </EuiLink>
+                </EuiText>
+              ) : undefined
+            }
+            helpText={props.helpText || undefined}
+            error={props.showError && getIn(errors, field.name)}
+            isInvalid={getIn(errors, field.name) && getIn(touched, field.name)}
+          >
+            <EuiFieldNumber
+              {...field}
+              placeholder={props.placeholder || ''}
+              compressed={false}
+              value={field.value || getInitialValue('number')}
+              onChange={(e) => {
+                form.setFieldValue(props.fieldPath, e.target.value);
+                props.onFormChange();
+              }}
+            />
+          </EuiCompressedFormRow>
+        );
+      }}
+    </Field>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -12,6 +12,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { WorkspaceFormValues, IConfigField } from '../../../../../common';
+import { camelCaseToTitleString } from '../../../../utils';
 
 interface SelectFieldProps {
   field: IConfigField;
@@ -29,7 +30,7 @@ export function SelectField(props: SelectFieldProps) {
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
         return (
-          <EuiFormRow label={props.field.label}>
+          <EuiFormRow label={camelCaseToTitleString(props.field.id)}>
             <EuiSuperSelect
               options={
                 props.field.selectOptions

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -18,6 +18,7 @@ interface SelectFieldProps {
   field: IConfigField;
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onFormChange: () => void;
+  onSelectChange?: (option: string) => void;
 }
 
 /**
@@ -54,6 +55,9 @@ export function SelectField(props: SelectFieldProps) {
                 form.setFieldTouched(props.fieldPath, true);
                 form.setFieldValue(props.fieldPath, option);
                 props.onFormChange();
+                if (props.onSelectChange) {
+                  props.onSelectChange(option);
+                }
               }}
               isInvalid={
                 getIn(errors, field.name) && getIn(touched, field.name)

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -12,7 +12,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { WorkspaceFormValues } from '../../../../../common';
-import { camelCaseToTitleString, getInitialValue } from '../../../../utils';
+import { getInitialValue } from '../../../../utils';
 
 interface TextFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
@@ -36,7 +36,7 @@ export function TextField(props: TextFieldProps) {
         return (
           <EuiCompressedFormRow
             key={props.fieldPath}
-            label={props.label || camelCaseToTitleString(field.name)}
+            label={props.label}
             labelAppend={
               props.helpLink ? (
                 <EuiText size="xs">

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -5,9 +5,14 @@
 
 import React from 'react';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
-import { EuiFieldText, EuiCompressedFormRow, EuiLink, EuiText } from '@elastic/eui';
+import {
+  EuiFieldText,
+  EuiCompressedFormRow,
+  EuiLink,
+  EuiText,
+} from '@elastic/eui';
 import { WorkspaceFormValues } from '../../../../../common';
-import { getInitialValue } from '../../../../utils';
+import { camelCaseToTitleString, getInitialValue } from '../../../../utils';
 
 interface TextFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
@@ -31,7 +36,7 @@ export function TextField(props: TextFieldProps) {
         return (
           <EuiCompressedFormRow
             key={props.fieldPath}
-            label={props.label}
+            label={props.label || camelCaseToTitleString(field.name)}
             labelAppend={
               props.helpLink ? (
                 <EuiText size="xs">

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -64,12 +64,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   ) as IConfigField;
   const modelFieldPath = `${props.baseConfigPath}.${props.config.id}.${modelField.id}`;
   const inputMapField = props.config.fields.find(
-    (field) => field.id === 'inputMap'
+    (field) => field.id === 'input_map'
   ) as IConfigField;
   const inputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${inputMapField.id}`;
   const inputMapValue = getIn(values, inputMapFieldPath);
   const outputMapField = props.config.fields.find(
-    (field) => field.id === 'outputMap'
+    (field) => field.id === 'output_map'
   ) as IConfigField;
   const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${outputMapField.id}`;
   const outputMapValue = getIn(values, outputMapFieldPath);
@@ -113,7 +113,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
 
   // Hook to listen when the selected model has changed. We do a few checks here:
   // 1: update model interface states
-  // 2. clear out any persisted inputMap/outputMap form values, as those would now be invalid
+  // 2. clear out any persisted input_map/output_map form values, as those would now be invalid
   function onModelChange(modelId: string) {
     updateModelInterfaceStates(modelId);
     setFieldValue(inputMapFieldPath, []);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect } from 'react';
 import { getIn, useFormikContext } from 'formik';
 import { useSelector } from 'react-redux';
 import {
+  EuiAccordion,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
@@ -36,6 +37,7 @@ import {
   parseModelInputs,
   parseModelOutputs,
 } from '../../../../utils';
+import { ConfigFieldList } from '../config_field_list';
 
 interface MLProcessorInputsProps {
   uiConfig: WorkflowConfig;
@@ -296,6 +298,20 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 color="danger"
               />
             )}
+          <EuiSpacer size="s" />
+          <EuiAccordion
+            id={`advancedSettings${props.config.id}`}
+            buttonContent="Advanced settings"
+            paddingSize="none"
+          >
+            <EuiSpacer size="s" />
+            <ConfigFieldList
+              configId={props.config.id}
+              configFields={props.config.optionalFields || []}
+              baseConfigPath={props.baseConfigPath}
+              onFormChange={props.onFormChange}
+            />
+          </EuiAccordion>
         </>
       )}
     </>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../../../common';
 import { MLProcessorInputs } from './ml_processor_inputs';
 import { ConfigFieldList } from '../config_field_list';
+import { TextChunkingProcessorInputs } from './text_chunking_processor_inputs';
 
 /**
  * Base component for rendering processor form inputs based on the processor type
@@ -29,6 +30,10 @@ interface ProcessorInputsProps {
 
 const PROCESSOR_INPUTS_SPACER_SIZE = 'm';
 
+// Component to dynamically render the processor inputs based on the processor types.
+// For most processors, we can use the standard/default ConfigFieldList components
+// for rendering the required and optional fields. For more complex processors, we have
+// standalone, specialized components.
 export function ProcessorInputs(props: ProcessorInputsProps) {
   const configType = props.config.type;
 
@@ -41,6 +46,21 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
             el = (
               <EuiFlexItem>
                 <MLProcessorInputs
+                  uiConfig={props.uiConfig}
+                  config={props.config}
+                  baseConfigPath={props.baseConfigPath}
+                  onFormChange={props.onFormChange}
+                  context={props.context}
+                />
+                <EuiSpacer size={PROCESSOR_INPUTS_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case PROCESSOR_TYPE.TEXT_CHUNKING: {
+            el = (
+              <EuiFlexItem>
+                <TextChunkingProcessorInputs
                   uiConfig={props.uiConfig}
                   config={props.config}
                   baseConfigPath={props.baseConfigPath}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiAccordion, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { isEmpty } from 'lodash';
 import {
   IProcessorConfig,
   PROCESSOR_CONTEXT,
@@ -30,6 +31,7 @@ const PROCESSOR_INPUTS_SPACER_SIZE = 'm';
 
 export function ProcessorInputs(props: ProcessorInputsProps) {
   const configType = props.config.type;
+
   return (
     <EuiFlexItem grow={false}>
       {(() => {
@@ -53,11 +55,29 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
           default: {
             el = (
               <EuiFlexItem>
-                <ConfigFieldList
-                  config={props.config}
-                  baseConfigPath={props.baseConfigPath}
-                  onFormChange={props.onFormChange}
-                />
+                <>
+                  <ConfigFieldList
+                    configId={props.config.id}
+                    configFields={props.config.fields}
+                    baseConfigPath={props.baseConfigPath}
+                    onFormChange={props.onFormChange}
+                  />
+                  {!isEmpty(props.config.optionalFields) && (
+                    <EuiAccordion
+                      id={`advancedSettings${props.config.id}`}
+                      buttonContent="Advanced settings"
+                      paddingSize="none"
+                    >
+                      <EuiSpacer size="s" />
+                      <ConfigFieldList
+                        configId={props.config.id}
+                        configFields={props.config.optionalFields || []}
+                        baseConfigPath={props.baseConfigPath}
+                        onFormChange={props.onFormChange}
+                      />
+                    </EuiAccordion>
+                  )}
+                </>
               </EuiFlexItem>
             );
             break;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { getIn, useFormikContext } from 'formik';
+import { EuiAccordion, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import {
+  IProcessorConfig,
+  IConfigField,
+  PROCESSOR_CONTEXT,
+  WorkflowConfig,
+  TEXT_CHUNKING_ALGORITHM,
+  FIXED_TOKEN_LENGTH_OPTIONAL_FIELDS,
+  DELIMITER_OPTIONAL_FIELDS,
+  SHARED_OPTIONAL_FIELDS,
+  WorkflowFormValues,
+  MapFormValue,
+  TEXT_CHUNKING_PROCESSOR_LINK,
+} from '../../../../../common';
+import { MapField, SelectField } from '../input_fields';
+import { ConfigFieldList } from '../config_field_list';
+
+interface TextChunkingProcessorInputsProps {
+  uiConfig: WorkflowConfig;
+  config: IProcessorConfig;
+  baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
+  onFormChange: () => void;
+  context: PROCESSOR_CONTEXT;
+}
+
+/**
+ * Specialized component to render the text chunking ingest processor. The list of optional
+ * params we display is dependent on the source algorithm that is chosen. Internally, we persist
+ * all of the params, but only choose the relevant ones when constructing the final ingest processor
+ * template. This is to minimize the amount of ui config / form / schema updates we would need
+ * to do if we only persisted the subset of optional params specific to the currently-chosen algorithm.
+ */
+export function TextChunkingProcessorInputs(
+  props: TextChunkingProcessorInputsProps
+) {
+  const { values } = useFormikContext<WorkflowFormValues>();
+
+  // extracting field info from the text chunking processor config
+  // TODO: have a better mechanism for guaranteeing the expected fields/config instead of hardcoding them here
+  const algorithmFieldPath = `${props.baseConfigPath}.${props.config.id}.algorithm`;
+  const algorithmField = props.config.fields.find(
+    (field) => field.id === 'algorithm'
+  ) as IConfigField;
+  const fieldMapFieldPath = `${props.baseConfigPath}.${props.config.id}.field_map`;
+  const fieldMapValue = getIn(values, fieldMapFieldPath) as MapFormValue;
+
+  // algorithm optional fields state
+  const [algorithmOptionalFields, setAlgorithmOptionalFields] = useState<
+    string[]
+  >(
+    algorithmField !== undefined && algorithmField.value !== undefined
+      ? algorithmField.value === TEXT_CHUNKING_ALGORITHM.FIXED_TOKEN_LENGTH
+        ? FIXED_TOKEN_LENGTH_OPTIONAL_FIELDS
+        : DELIMITER_OPTIONAL_FIELDS
+      : FIXED_TOKEN_LENGTH_OPTIONAL_FIELDS
+  );
+
+  // Update the optional fields to display when the algorithm is changed
+  function onAlgorithmChange(algorithm: string) {
+    setAlgorithmOptionalFields(
+      algorithm === TEXT_CHUNKING_ALGORITHM.FIXED_TOKEN_LENGTH
+        ? FIXED_TOKEN_LENGTH_OPTIONAL_FIELDS
+        : DELIMITER_OPTIONAL_FIELDS
+    );
+  }
+
+  return (
+    <>
+      <SelectField
+        field={algorithmField}
+        fieldPath={algorithmFieldPath}
+        onFormChange={props.onFormChange}
+        onSelectChange={onAlgorithmChange}
+      />
+      <MapField
+        label="Field map"
+        helpLink={TEXT_CHUNKING_PROCESSOR_LINK}
+        fieldPath={fieldMapFieldPath}
+        keyPlaceholder={'Input field'}
+        valuePlaceholder={'Output field'}
+        onFormChange={props.onFormChange}
+      />
+      <EuiSpacer size="s" />
+      {fieldMapValue.length === 0 && (
+        <>
+          <EuiCallOut
+            size="s"
+            title="Field map cannot be empty"
+            iconType={'alert'}
+            color="danger"
+          />
+          <EuiSpacer size="s" />
+        </>
+      )}
+
+      <EuiAccordion
+        id={`advancedSettings${props.config.id}`}
+        buttonContent="Advanced settings"
+        paddingSize="none"
+      >
+        <EuiSpacer size="s" />
+        <ConfigFieldList
+          configId={props.config.id}
+          // construct the final set of optional fields by combining the current
+          // algorithm's set of optional fields, with the commonly shared fields
+          configFields={[
+            ...(props.config.optionalFields?.filter((optionalField) =>
+              algorithmOptionalFields.includes(optionalField.id)
+            ) || []),
+            ...(props.config.optionalFields?.filter((optionalField) =>
+              SHARED_OPTIONAL_FIELDS.includes(optionalField.id)
+            ) || []),
+          ]}
+          baseConfigPath={props.baseConfigPath}
+          onFormChange={props.onFormChange}
+        />
+      </EuiAccordion>
+    </>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
@@ -88,7 +88,7 @@ export function TextChunkingProcessorInputs(
         onFormChange={props.onFormChange}
       />
       <EuiSpacer size="s" />
-      {fieldMapValue.length === 0 && (
+      {fieldMapValue?.length === 0 && (
         <>
           <EuiCallOut
             size="s"

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -32,6 +32,7 @@ import {
   SortSearchResponseProcessor,
   SplitIngestProcessor,
   SplitSearchResponseProcessor,
+  TextChunkingIngestProcessor,
 } from '../../../configs';
 import { ProcessorInputs } from './processor_inputs';
 
@@ -223,6 +224,15 @@ export function ProcessorsList(props: ProcessorsListProps) {
                             onClick: () => {
                               closePopover();
                               addProcessor(new SortIngestProcessor().toObj());
+                            },
+                          },
+                          {
+                            name: 'Text Chunking Processor',
+                            onClick: () => {
+                              closePopover();
+                              addProcessor(
+                                new TextChunkingIngestProcessor().toObj()
+                              );
                             },
                           },
                         ]

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -482,6 +482,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       </EuiFlexGroup>
                     ),
                   }}
+                  showLabel={false}
                 />
               </>
             )}

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -129,5 +129,8 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     case 'mapArray': {
       return [];
     }
+    case 'boolean': {
+      return false;
+    }
   }
 }

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -67,6 +67,10 @@ export function processorConfigToFormik(
   processorConfig.fields.forEach((field) => {
     fieldValues[field.id] = field.value || getInitialValue(field.type);
   });
+  processorConfig.optionalFields?.forEach((optionalField) => {
+    fieldValues[optionalField.id] =
+      optionalField.value || getInitialValue(optionalField.type);
+  });
   return fieldValues;
 }
 

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -132,5 +132,8 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     case 'boolean': {
       return false;
     }
+    case 'number': {
+      return 0;
+    }
   }
 }

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -170,6 +170,9 @@ function getFieldSchema(
       baseSchema = yup.boolean();
       break;
     }
+    case 'number': {
+      baseSchema = yup.number();
+    }
   }
 
   return optional ? baseSchema.optional() : baseSchema.required('Required');

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -166,6 +166,10 @@ function getFieldSchema(
       );
       break;
     }
+    case 'boolean': {
+      baseSchema = yup.boolean();
+      break;
+    }
   }
 
   return optional ? baseSchema.optional() : baseSchema.required('Required');

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -74,6 +74,12 @@ function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {
     processorConfig.fields.forEach((field) => {
       processorSchemaObj[field.id] = getFieldSchema(field);
     });
+    processorConfig.optionalFields?.forEach((optionalField) => {
+      processorSchemaObj[optionalField.id] = getFieldSchema(
+        optionalField,
+        true
+      );
+    });
     processorsSchemaObj[processorConfig.id] = yup.object(processorSchemaObj);
   });
 
@@ -84,7 +90,10 @@ function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {
  **************** Yup (validation) utils **********************
  */
 
-function getFieldSchema(field: IConfigField): Schema {
+function getFieldSchema(
+  field: IConfigField,
+  optional: boolean = false
+): Schema {
   let baseSchema: Schema;
   switch (field.type) {
     case 'string':
@@ -159,7 +168,5 @@ function getFieldSchema(field: IConfigField): Schema {
     }
   }
 
-  return field.optional
-    ? baseSchema.optional()
-    : baseSchema.required('Required');
+  return optional ? baseSchema.optional() : baseSchema.required('Required');
 }

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -315,6 +315,13 @@ function processorsConfigToWorkspaceFlow(
         transformerNodeId = generateId(COMPONENT_CLASS.TRANSFORMER);
         break;
       }
+      case PROCESSOR_TYPE.TEXT_CHUNKING: {
+        transformer = new BaseTransformer(
+          processorConfig.name,
+          'A processor to split long documents into shorter passages'
+        );
+        transformerNodeId = generateId(COMPONENT_CLASS.TRANSFORMER);
+      }
       default: {
         transformer = new BaseTransformer(processorConfig.name, '');
         transformerNodeId = generateId(COMPONENT_CLASS.TRANSFORMER);

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -101,6 +101,13 @@ function formikToProcessorsUiConfig(
         getInitialValue(processorField.type)
       );
     });
+    processorConfig.optionalFields?.forEach((processorField) => {
+      processorField.value = get(
+        processorFormValues,
+        processorField.id,
+        undefined
+      );
+    });
   });
   return existingConfig;
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -228,3 +228,10 @@ export function parseModelOutputs(
       } as ModelOutputFormField)
   );
 }
+
+// converts camelCase to a space-delimited string with the first word capitalized.
+// useful for converting config IDs (in camelcase) to a formatted form title
+export function camelCaseToTitleString(camelCaseString: string): string {
+  const result = camelCaseString.replace(/([A-Z])/g, ' $1');
+  return result.charAt(0).toUpperCase() + result.slice(1);
+}

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -230,8 +230,11 @@ export function parseModelOutputs(
 }
 
 // converts camelCase to a space-delimited string with the first word capitalized.
-// useful for converting config IDs (in camelcase) to a formatted form title
-export function camelCaseToTitleString(camelCaseString: string): string {
-  const result = camelCaseString.replace(/([A-Z])/g, ' $1');
-  return result.charAt(0).toUpperCase() + result.slice(1);
+// useful for converting config IDs (in snake_case) to a formatted form title
+export function camelCaseToTitleString(snakeCaseString: string): string {
+  return snakeCaseString
+    .split('_')
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 }


### PR DESCRIPTION
### Description

This PR enables a pre-configured set of optional parameters for each processor type, all under an `Advanced settings` accordion. It also adds the [text chunking processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/text-chunking) as an available option for ingest.

More details:
- refactors existing optional params and adds a dedicated `optionalFields` field for each processor config
- adds a new text chunking processor (ingest context only). Renders using the specialized `TextChunkingProcessorInputs` due to its complexity; we display a different set of optional fields based on the selected text chunking algorithm. Also adds special logic in `config_to_template_utils` to only add any configured optional fields relevant to the currently selected algorithm.
- adds `boolean` and `number` fields as optional config field types
- adds `camelCaseToTitleString()` helper fn and removes the `label` field in the config to help minimize what we persist on-cluster. We can now just generate the field title based on its ID.

Demo video (existing processors with optional fields):

[screen-capture (19).webm](https://github.com/user-attachments/assets/fbe534d1-bf16-4133-81b2-b4ea9301e1ca)

Demo video (new text chunking ingest processor):

[screen-capture (20).webm](https://github.com/user-attachments/assets/7aaf83b9-66d4-4e96-b798-3dc8904dfc86)

### Issues Resolved
Makes progress on #23 
Makes progress on #219 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
