### PR TITLE
Support fine-grained provisioning; handle more edge cases on search flow

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -58,15 +58,25 @@ export type IndexConfig = {
   settings: IConfigField;
 };
 
+// TODO: may expand to just IndexConfig (including mappings/settings info)
+// if we want to persist this for users using some existing index,
+// and want to pass that index config around.
+export type SearchIndexConfig = {
+  name: IConfigField;
+};
+
 export type IngestConfig = {
   enabled: boolean;
   source: {};
+  pipelineName: string;
   enrich: ProcessorsConfig;
   index: IndexConfig;
 };
 
 export type SearchConfig = {
   request: IConfigField;
+  index: SearchIndexConfig;
+  pipelineName: string;
   enrichRequest: ProcessorsConfig;
   enrichResponse: ProcessorsConfig;
 };

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -66,9 +66,9 @@ export type SearchIndexConfig = {
 };
 
 export type IngestConfig = {
-  enabled: boolean;
+  enabled: IConfigField;
   source: {};
-  pipelineName: string;
+  pipelineName: IConfigField;
   enrich: ProcessorsConfig;
   index: IndexConfig;
 };
@@ -76,7 +76,7 @@ export type IngestConfig = {
 export type SearchConfig = {
   request: IConfigField;
   index: SearchIndexConfig;
-  pipelineName: string;
+  pipelineName: IConfigField;
   enrichRequest: ProcessorsConfig;
   enrichResponse: ProcessorsConfig;
 };

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -234,7 +234,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
-                valuePlaceholder="Document field"
+                valuePlaceholder={
+                  props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                    ? 'Query field'
+                    : 'Document field'
+                }
                 keyOptions={props.inputFields}
                 onFormChange={props.onFormChange}
                 // If the map we are adding is the first one, populate the selected option to index 0

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -229,7 +229,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
             helpLink={ML_INFERENCE_DOCS_LINK}
             keyPlaceholder="Model input field"
-            valuePlaceholder="Document field"
+            valuePlaceholder={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Query field'
+                : 'Document field'
+            }
             onFormChange={props.onFormChange}
             keyOptions={inputFields}
           />
@@ -273,7 +277,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             label="Output Map"
             helpText={`An array specifying how to map the model’s output to new document fields.`}
             helpLink={ML_INFERENCE_DOCS_LINK}
-            keyPlaceholder="New document field"
+            keyPlaceholder={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Query field'
+                : 'Document field'
+            }
             valuePlaceholder="Model output field"
             onFormChange={props.onFormChange}
             valueOptions={outputFields}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -226,7 +226,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 label="Output Map"
                 helpText={`An array specifying how to map the model’s output to new fields.`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
-                keyPlaceholder="New document field"
+                keyPlaceholder="Document field"
                 valuePlaceholder="Model output field"
                 valueOptions={props.outputFields}
                 onFormChange={props.onFormChange}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -108,7 +108,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                       const valuesWithoutOutputMapConfig = cloneDeep(values);
                       set(
                         valuesWithoutOutputMapConfig,
-                        `ingest.enrich.${props.config.id}.outputMap`,
+                        `ingest.enrich.${props.config.id}.output_map`,
                         []
                       );
                       const curIngestPipeline = formikToPartialPipeline(
@@ -146,7 +146,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                       const valuesWithoutOutputMapConfig = cloneDeep(values);
                       set(
                         valuesWithoutOutputMapConfig,
-                        `search.enrichResponse.${props.config.id}.outputMap`,
+                        `search.enrichResponse.${props.config.id}.output_map`,
                         []
                       );
                       const curSearchPipeline = formikToPartialPipeline(

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -177,7 +177,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
               // see https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/#disabling-the-default-pipeline-for-a-request
               dispatch(
                 searchIndex({
-                  index: selectedIndex as string,
+                  index: values.search.index.name,
                   body: values.search.request,
                   searchPipeline: '_none',
                 })

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -218,9 +218,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           // amount of time and may be long and expensive; we add this single
           // auto-fetching to cover the majority of provisioning updates which
           // are inexpensive and will finish within milliseconds.
-          new Promise((f) => setTimeout(f, 1000)).then(async () => {
+          setTimeout(async () => {
             dispatch(getWorkflow(updatedWorkflow.id as string));
-          });
+          }, 1000);
         })
         .catch((error: any) => {
           console.error('Error reprovisioning workflow: ', error);
@@ -254,9 +254,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                   // amount of time and may be long and expensive; we add this single
                   // auto-fetching to cover the majority of provisioning updates which
                   // are inexpensive and will finish within milliseconds.
-                  new Promise((f) => setTimeout(f, 1000)).then(async () => {
+                  setTimeout(async () => {
                     dispatch(getWorkflow(updatedWorkflow.id as string));
-                  });
+                  }, 1000);
                 })
                 .catch((error: any) => {
                   console.error('Error provisioning updated workflow: ', error);
@@ -289,13 +289,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     submitForm();
     await validateForm()
       .then(async (validationResults: { ingest?: {}; search?: {} }) => {
-        let relevantValidationResults = {} as { ingest?: {}; search?: {} };
-        if (includeIngest && validationResults.ingest !== undefined) {
-          relevantValidationResults.ingest = validationResults.ingest;
-        }
-        if (includeSearch && validationResults.search !== undefined) {
-          relevantValidationResults.search = validationResults.search;
-        }
+        const { ingest, search } = validationResults;
+        const relevantValidationResults = {
+          ...(includeIngest && ingest !== undefined ? { ingest } : {}),
+          ...(includeSearch && search !== undefined ? { search } : {}),
+        };
         if (Object.keys(relevantValidationResults).length > 0) {
           // TODO: may want to persist more fine-grained form validation (ingest vs. search)
           // For example, running an ingest should be possible, even with some

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useFormikContext } from 'formik';
+import { getIn, useFormikContext } from 'formik';
 import { debounce, isEmpty } from 'lodash';
 import {
   EuiButton,
@@ -124,6 +124,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const onIngestAndProvisioned = onIngest && ingestProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
   const onIngestAndDisabled = onIngest && !ingestEnabled;
+  const isProposingNoSearchResources =
+    isEmpty(getIn(values, 'search.enrichRequest')) &&
+    isEmpty(getIn(values, 'search.enrichResponse'));
 
   // Auto-save the UI metadata when users update form values.
   // Only update the underlying workflow template (deprovision/provision) when
@@ -657,7 +660,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiButton
-                          disabled={searchProvisioned && !isDirty}
+                          disabled={
+                            (searchProvisioned && !isDirty) ||
+                            isProposingNoSearchResources
+                          }
                           fill={false}
                           onClick={() => {
                             validateAndRunQuery();

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -160,6 +160,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             workflowId: props.workflow?.id as string,
             workflowTemplate: updatedTemplate,
             updateFields: true,
+            reprovision: false,
           })
         )
           .unwrap()
@@ -188,64 +189,95 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     setSearchProvisioned(hasProvisionedSearchResources(props.workflow));
   }, [props.workflow]);
 
-  // Utility fn to update the workflow, including any updated/new resources
-  // Eventually, should be able to use fine-grained provisioning to do a single API call
-  // instead of the currently-implemented deprovision -> update -> provision.
-  // To simplify and minimize errors, we set various sleep calls in between the actions
-  // to allow time for full deprovisioning / provisioning to occur, such as index deletion
-  // & index re-creation.
-  // TODO: update to fine-grained provisioning when available.
+  // Utility fn to update the workflow, including any updated/new resources.
+  // The reprovision param is used to determine whether we are doing full
+  // deprovision/update/provision, vs. update w/ reprovision (fine-grained provisioning).
+  // Details on the reprovision API is here: https://github.com/opensearch-project/flow-framework/pull/804
   async function updateWorkflowAndResources(
-    updatedWorkflow: Workflow
+    updatedWorkflow: Workflow,
+    reprovision: boolean
   ): Promise<boolean> {
     let success = false;
-    await dispatch(
-      deprovisionWorkflow({
-        workflowId: updatedWorkflow.id as string,
-        resourceIds: getResourcesToBeForceDeleted(props.workflow),
-      })
-    )
-      .unwrap()
-      .then(async (result) => {
-        await dispatch(
-          updateWorkflow({
-            workflowId: updatedWorkflow.id as string,
-            workflowTemplate: reduceToTemplate(updatedWorkflow),
-          })
-        )
-          .unwrap()
-          .then(async (result) => {
-            await sleep(1000);
-            await dispatch(provisionWorkflow(updatedWorkflow.id as string))
-              .unwrap()
-              .then(async (result) => {
-                await sleep(1000);
-                success = true;
-                // Kicking off an async task to re-fetch the workflow details
-                // after some amount of time. Provisioning will finish in an indeterminate
-                // amount of time and may be long and expensive; we add this single
-                // auto-fetching to cover the majority of provisioning updates which
-                // are inexpensive and will finish within milliseconds.
-                new Promise((f) => setTimeout(f, 1000)).then(async () => {
-                  dispatch(getWorkflow(updatedWorkflow.id as string));
-                });
-              })
-              .catch((error: any) => {
-                console.error('Error provisioning updated workflow: ', error);
-              });
-          })
-          .catch((error: any) => {
-            console.error('Error updating workflow: ', error);
+    if (reprovision) {
+      await dispatch(
+        updateWorkflow({
+          workflowId: updatedWorkflow.id as string,
+          workflowTemplate: reduceToTemplate(updatedWorkflow),
+          reprovision: true,
+        })
+      )
+        .unwrap()
+        .then(async (result) => {
+          await sleep(1000);
+          success = true;
+          // Kicking off an async task to re-fetch the workflow details
+          // after some amount of time. Provisioning will finish in an indeterminate
+          // amount of time and may be long and expensive; we add this single
+          // auto-fetching to cover the majority of provisioning updates which
+          // are inexpensive and will finish within milliseconds.
+          new Promise((f) => setTimeout(f, 1000)).then(async () => {
+            dispatch(getWorkflow(updatedWorkflow.id as string));
           });
-      })
-      .catch((error: any) => {
-        console.error('Error deprovisioning workflow: ', error);
-      });
+        })
+        .catch((error: any) => {
+          console.error('Error reprovisioning workflow: ', error);
+        });
+    } else {
+      await dispatch(
+        deprovisionWorkflow({
+          workflowId: updatedWorkflow.id as string,
+          resourceIds: getResourcesToBeForceDeleted(props.workflow),
+        })
+      )
+        .unwrap()
+        .then(async (result) => {
+          await dispatch(
+            updateWorkflow({
+              workflowId: updatedWorkflow.id as string,
+              workflowTemplate: reduceToTemplate(updatedWorkflow),
+              reprovision: false,
+            })
+          )
+            .unwrap()
+            .then(async (result) => {
+              await sleep(1000);
+              await dispatch(provisionWorkflow(updatedWorkflow.id as string))
+                .unwrap()
+                .then(async (result) => {
+                  await sleep(1000);
+                  success = true;
+                  // Kicking off an async task to re-fetch the workflow details
+                  // after some amount of time. Provisioning will finish in an indeterminate
+                  // amount of time and may be long and expensive; we add this single
+                  // auto-fetching to cover the majority of provisioning updates which
+                  // are inexpensive and will finish within milliseconds.
+                  new Promise((f) => setTimeout(f, 1000)).then(async () => {
+                    dispatch(getWorkflow(updatedWorkflow.id as string));
+                  });
+                })
+                .catch((error: any) => {
+                  console.error('Error provisioning updated workflow: ', error);
+                });
+            })
+            .catch((error: any) => {
+              console.error('Error updating workflow: ', error);
+            });
+        })
+        .catch((error: any) => {
+          console.error('Error deprovisioning workflow: ', error);
+        });
+    }
     return success;
   }
 
   // Utility fn to validate the form and update the workflow if valid
-  async function validateAndUpdateWorkflow(): Promise<boolean> {
+  // Support fine-grained validation if we only need to validate a subset
+  // of the entire form.
+  async function validateAndUpdateWorkflow(
+    reprovision: boolean,
+    includeIngest: boolean = true,
+    includeSearch: boolean = true
+  ): Promise<boolean> {
     let success = false;
     // Submit the form to bubble up any errors.
     // Ideally we handle Promise accept/rejects with submitForm(), but there is
@@ -253,8 +285,15 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     // The workaround is to additionally execute validateForm() which will return any errors found.
     submitForm();
     await validateForm()
-      .then(async (validationResults: {}) => {
-        if (Object.keys(validationResults).length > 0) {
+      .then(async (validationResults: { ingest?: {}; search?: {} }) => {
+        let relevantValidationResults = {} as { ingest?: {}; search?: {} };
+        if (includeIngest && validationResults.ingest !== undefined) {
+          relevantValidationResults.ingest = validationResults.ingest;
+        }
+        if (includeSearch && validationResults.search !== undefined) {
+          relevantValidationResults.search = validationResults.search;
+        }
+        if (Object.keys(relevantValidationResults).length > 0) {
           // TODO: may want to persist more fine-grained form validation (ingest vs. search)
           // For example, running an ingest should be possible, even with some
           // invalid query or search processor config. And vice versa.
@@ -272,7 +311,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             },
             workflows: configToTemplateFlows(updatedConfig),
           } as Workflow;
-          success = await updateWorkflowAndResources(updatedWorkflow);
+          success = await updateWorkflowAndResources(
+            updatedWorkflow,
+            reprovision
+          );
         }
       })
       .catch((error) => {
@@ -282,6 +324,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     return success;
   }
 
+  // Updating ingest. In this case, do full deprovision/update/provision, since we want
+  // to clean up any created resources and not have leftover / stale data in some index.
+  // This is propagated by passing `reprovision=false` to validateAndUpdateWorkflow()
   async function validateAndRunIngestion(): Promise<boolean> {
     let success = false;
     try {
@@ -290,7 +335,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         ingestDocsObjs = JSON.parse(props.ingestDocs);
       } catch (e) {}
       if (ingestDocsObjs.length > 0 && !isEmpty(ingestDocsObjs[0])) {
-        success = await validateAndUpdateWorkflow();
+        success = await validateAndUpdateWorkflow(false, true, false);
         if (success) {
           const bulkBody = prepareBulkBody(
             values.ingest.index.name,
@@ -318,6 +363,13 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     return success;
   }
 
+  // Updating search. If existing ingest resources, run fine-grained provisioning to persist that
+  // created index and any indexed data, and only update/re-create the search
+  // pipeline, as well as adding that pipeline as the default pipeline for the existing index.
+  // If no ingest resources (using user's existing index), run full
+  // deprovision/update/provision, since we're just re-creating the search pipeline.
+  // This logic is propagated by passing `reprovision=true/false` in the
+  // validateAndUpdateWorkflow() fn calls below.
   async function validateAndRunQuery(): Promise<boolean> {
     let success = false;
     try {
@@ -326,13 +378,14 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         queryObj = JSON.parse(props.query);
       } catch (e) {}
       if (!isEmpty(queryObj)) {
-        // TODO: currently this will execute deprovision in child fns.
-        // In the future, we must omit deprovisioning the index, as it contains
-        // the data we are executing the query against. Tracking issue:
-        // https://github.com/opensearch-project/flow-framework/issues/717
-        success = await validateAndUpdateWorkflow();
+        if (hasProvisionedIngestResources(props.workflow)) {
+          success = await validateAndUpdateWorkflow(true, false, true);
+        } else {
+          success = await validateAndUpdateWorkflow(false, false, true);
+        }
+
         if (success) {
-          const indexName = values.ingest.index.name;
+          const indexName = values.search.index.name;
           dispatch(searchIndex({ index: indexName, body: props.query }))
             .unwrap()
             .then(async (resp) => {

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -12,6 +12,7 @@ import {
   WORKFLOW_TYPE,
   FETCH_ALL_QUERY_BODY,
 } from '../../../../common';
+import { generateId } from '../../../utils';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
 export function enrichPresetWorkflowWithUiMetadata(
@@ -46,6 +47,7 @@ function fetchEmptyMetadata(): UIState {
       ingest: {
         enabled: true,
         source: {},
+        pipelineName: generateId('ingest_pipeline'),
         enrich: {
           processors: [],
         },
@@ -69,6 +71,13 @@ function fetchEmptyMetadata(): UIState {
           id: 'request',
           type: 'json',
           value: JSON.stringify(FETCH_ALL_QUERY_BODY, undefined, 2),
+        },
+        pipelineName: generateId('search_pipeline'),
+        index: {
+          name: {
+            id: 'indexName',
+            type: 'string',
+          },
         },
         enrichRequest: {
           processors: [],

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -45,9 +45,17 @@ function fetchEmptyMetadata(): UIState {
     type: WORKFLOW_TYPE.CUSTOM,
     config: {
       ingest: {
-        enabled: true,
+        enabled: {
+          id: 'enabled',
+          type: 'boolean',
+          value: true,
+        },
         source: {},
-        pipelineName: generateId('ingest_pipeline'),
+        pipelineName: {
+          id: 'pipelineName',
+          type: 'string',
+          value: generateId('ingest_pipeline'),
+        },
         enrich: {
           processors: [],
         },
@@ -72,7 +80,11 @@ function fetchEmptyMetadata(): UIState {
           type: 'json',
           value: JSON.stringify(FETCH_ALL_QUERY_BODY, undefined, 2),
         },
-        pipelineName: generateId('search_pipeline'),
+        pipelineName: {
+          id: 'pipelineName',
+          type: 'string',
+          value: generateId('search_pipeline'),
+        },
         index: {
           name: {
             id: 'indexName',

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -40,7 +40,8 @@ export interface RouteService {
   updateWorkflow: (
     workflowId: string,
     workflowTemplate: WorkflowTemplate,
-    updateFields: boolean
+    updateFields: boolean,
+    reprovision: boolean
   ) => Promise<any | HttpFetchError>;
   provisionWorkflow: (workflowId: string) => Promise<any | HttpFetchError>;
   deprovisionWorkflow: (
@@ -115,11 +116,12 @@ export function configureRoutes(core: CoreStart): RouteService {
     updateWorkflow: async (
       workflowId: string,
       workflowTemplate: WorkflowTemplate,
-      updateFields: boolean
+      updateFields: boolean,
+      reprovision: boolean
     ) => {
       try {
         const response = await core.http.put<{ respString: string }>(
-          `${UPDATE_WORKFLOW_NODE_API_PATH}/${workflowId}/${updateFields}`,
+          `${UPDATE_WORKFLOW_NODE_API_PATH}/${workflowId}/${updateFields}/${reprovision}`,
           {
             body: JSON.stringify(workflowTemplate),
           }

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -95,16 +95,23 @@ export const updateWorkflow = createAsyncThunk(
       workflowId: string;
       workflowTemplate: WorkflowTemplate;
       updateFields?: boolean;
+      reprovision?: boolean;
     },
     { rejectWithValue }
   ) => {
-    const { workflowId, workflowTemplate, updateFields } = workflowInfo;
+    const {
+      workflowId,
+      workflowTemplate,
+      updateFields,
+      reprovision,
+    } = workflowInfo;
     const response:
       | any
       | HttpFetchError = await getRouteService().updateWorkflow(
       workflowId,
       workflowTemplate,
-      updateFields || false
+      updateFields || false,
+      reprovision || false
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue(

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -41,8 +41,11 @@ function ingestConfigToFormik(
 ): FormikValues {
   let ingestFormikValues = {} as FormikValues;
   if (ingestConfig) {
-    ingestFormikValues['enabled'] = ingestConfig.enabled;
-    ingestFormikValues['pipelineName'] = ingestConfig.pipelineName;
+    ingestFormikValues['enabled'] =
+      ingestConfig.enabled.value || getInitialValue(ingestConfig.enabled.type);
+    ingestFormikValues['pipelineName'] =
+      ingestConfig.pipelineName.value ||
+      getInitialValue(ingestConfig.pipelineName.type);
     ingestFormikValues['docs'] = ingestDocs || getInitialValue('jsonArray');
     ingestFormikValues['enrich'] = processorsConfigToFormik(
       ingestConfig.enrich
@@ -95,7 +98,8 @@ function searchConfigToFormik(
     searchFormikValues['request'] =
       searchConfig.request.value || getInitialValue('json');
     searchFormikValues['pipelineName'] =
-      searchConfig.pipelineName || getInitialValue('string');
+      searchConfig.pipelineName.value ||
+      getInitialValue(searchConfig.pipelineName.type);
     searchFormikValues['index'] = searchIndexConfigToFormik(searchConfig.index);
     searchFormikValues['enrichRequest'] = processorsConfigToFormik(
       searchConfig.enrichRequest

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -15,6 +15,7 @@ import {
   ConfigFieldType,
   ConfigFieldValue,
   ModelFormValue,
+  SearchIndexConfig,
 } from '../../common';
 
 /*
@@ -41,6 +42,7 @@ function ingestConfigToFormik(
   let ingestFormikValues = {} as FormikValues;
   if (ingestConfig) {
     ingestFormikValues['enabled'] = ingestConfig.enabled;
+    ingestFormikValues['pipelineName'] = ingestConfig.pipelineName;
     ingestFormikValues['docs'] = ingestDocs || getInitialValue('jsonArray');
     ingestFormikValues['enrich'] = processorsConfigToFormik(
       ingestConfig.enrich
@@ -92,6 +94,9 @@ function searchConfigToFormik(
   if (searchConfig) {
     searchFormikValues['request'] =
       searchConfig.request.value || getInitialValue('json');
+    searchFormikValues['pipelineName'] =
+      searchConfig.pipelineName || getInitialValue('string');
+    searchFormikValues['index'] = searchIndexConfigToFormik(searchConfig.index);
     searchFormikValues['enrichRequest'] = processorsConfigToFormik(
       searchConfig.enrichRequest
     );
@@ -100,6 +105,16 @@ function searchConfigToFormik(
     );
   }
   return searchFormikValues;
+}
+
+function searchIndexConfigToFormik(
+  searchIndexConfig: SearchIndexConfig
+): FormikValues {
+  let formValues = {} as FormikValues;
+  formValues['name'] =
+    searchIndexConfig.name.value ||
+    getInitialValue(searchIndexConfig.name.type);
+  return formValues;
 }
 
 // Helper fn to get an initial value based on the field type

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -36,9 +36,7 @@ function ingestConfigToSchema(
     ingestSchemaObj['docs'] = getFieldSchema({
       type: 'jsonArray',
     } as IConfigField);
-    ingestSchemaObj['pipelineName'] = getFieldSchema({
-      type: 'string',
-    } as IConfigField);
+    ingestSchemaObj['pipelineName'] = getFieldSchema(ingestConfig.pipelineName);
     ingestSchemaObj['enrich'] = processorsConfigToSchema(ingestConfig.enrich);
     ingestSchemaObj['index'] = indexConfigToSchema(ingestConfig.index);
   }
@@ -61,9 +59,7 @@ function searchConfigToSchema(
     searchSchemaObj['request'] = getFieldSchema({
       type: 'json',
     } as IConfigField);
-    searchSchemaObj['pipelineName'] = getFieldSchema({
-      type: 'string',
-    } as IConfigField);
+    searchSchemaObj['pipelineName'] = getFieldSchema(searchConfig.pipelineName);
     searchSchemaObj['index'] = searchIndexToSchema(searchConfig.index);
     searchSchemaObj['enrichRequest'] = processorsConfigToSchema(
       searchConfig.enrichRequest

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -14,6 +14,7 @@ import {
   WorkflowSchemaObj,
   IndexConfig,
   IConfigField,
+  SearchIndexConfig,
 } from '../../common';
 
 /*
@@ -31,9 +32,12 @@ function ingestConfigToSchema(
   ingestConfig: IngestConfig | undefined
 ): ObjectSchema<any> {
   const ingestSchemaObj = {} as { [key: string]: Schema };
-  if (ingestConfig) {
+  if (ingestConfig?.enabled) {
     ingestSchemaObj['docs'] = getFieldSchema({
       type: 'jsonArray',
+    } as IConfigField);
+    ingestSchemaObj['pipelineName'] = getFieldSchema({
+      type: 'string',
     } as IConfigField);
     ingestSchemaObj['enrich'] = processorsConfigToSchema(ingestConfig.enrich);
     ingestSchemaObj['index'] = indexConfigToSchema(ingestConfig.index);
@@ -57,6 +61,10 @@ function searchConfigToSchema(
     searchSchemaObj['request'] = getFieldSchema({
       type: 'json',
     } as IConfigField);
+    searchSchemaObj['pipelineName'] = getFieldSchema({
+      type: 'string',
+    } as IConfigField);
+    searchSchemaObj['index'] = searchIndexToSchema(searchConfig.index);
     searchSchemaObj['enrichRequest'] = processorsConfigToSchema(
       searchConfig.enrichRequest
     );
@@ -65,6 +73,12 @@ function searchConfigToSchema(
     );
   }
   return yup.object(searchSchemaObj);
+}
+
+function searchIndexToSchema(searchIndexConfig: SearchIndexConfig): Schema {
+  const searchIndexSchemaObj = {} as { [key: string]: Schema };
+  searchIndexSchemaObj['name'] = getFieldSchema(searchIndexConfig.name);
+  return yup.object(searchIndexSchemaObj);
 }
 
 function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -35,7 +35,6 @@ import {
   DELIMITER_OPTIONAL_FIELDS,
 } from '../../common';
 import { processorConfigToFormik } from './config_to_form_utils';
-import { generateId } from './utils';
 
 /*
  **************** Config -> template utils **********************
@@ -84,7 +83,7 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
 function ingestConfigToTemplateNodes(
   ingestConfig: IngestConfig
 ): TemplateNode[] {
-  const ingestPipelineName = generateId('ingest_pipeline');
+  const ingestPipelineName = ingestConfig.pipelineName;
   const ingestProcessors = processorConfigsToTemplateProcessors(
     ingestConfig.enrich.processors
   );
@@ -110,7 +109,7 @@ function ingestConfigToTemplateNodes(
 function searchConfigToTemplateNodes(
   searchConfig: SearchConfig
 ): TemplateNode[] {
-  const searchPipelineName = generateId('search_pipeline');
+  const searchPipelineName = searchConfig.pipelineName;
   const searchRequestProcessors = processorConfigsToTemplateProcessors(
     searchConfig.enrichRequest.processors
   );
@@ -295,7 +294,7 @@ function indexConfigToTemplateNode(
   updateFinalInputsAndSettings(searchPipelineNode);
 
   return {
-    id: 'create_index',
+    id: indexConfig.name.value as string,
     type: WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE,
     previous_node_inputs: finalPreviousNodeInputs,
     user_inputs: {

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -64,7 +64,7 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
   ) as CreateSearchPipelineNode;
 
-  if (config.ingest.enabled) {
+  if (config.ingest.enabled.value) {
     nodes.push(
       indexConfigToTemplateNode(
         config.ingest.index,
@@ -83,13 +83,14 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
 function ingestConfigToTemplateNodes(
   ingestConfig: IngestConfig
 ): TemplateNode[] {
-  const ingestPipelineName = ingestConfig.pipelineName;
+  const ingestPipelineName = ingestConfig.pipelineName.value;
+  const ingestEnabled = ingestConfig.enabled.value;
   const ingestProcessors = processorConfigsToTemplateProcessors(
     ingestConfig.enrich.processors
   );
   const hasProcessors = ingestProcessors.length > 0;
 
-  return hasProcessors && ingestConfig.enabled
+  return hasProcessors && ingestEnabled
     ? [
         {
           id: ingestPipelineName,
@@ -109,7 +110,7 @@ function ingestConfigToTemplateNodes(
 function searchConfigToTemplateNodes(
   searchConfig: SearchConfig
 ): TemplateNode[] {
-  const searchPipelineName = searchConfig.pipelineName;
+  const searchPipelineName = searchConfig.pipelineName.value;
   const searchRequestProcessors = processorConfigsToTemplateProcessors(
     searchConfig.enrichRequest.processors
   );

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -88,7 +88,7 @@ function ingestConfigToWorkspaceFlow(
 
   // Parent ingest node
   const parentNode = {
-    id: ingestConfig.pipelineName,
+    id: ingestConfig.pipelineName.value,
     position: { x: 400, y: 400 },
     type: NODE_CATEGORY.INGEST_GROUP,
     data: { label: COMPONENT_CATEGORY.INGEST },
@@ -186,7 +186,7 @@ function searchConfigToWorkspaceFlow(
 
   // Parent search node
   const parentNode = {
-    id: searchConfig.pipelineName,
+    id: searchConfig.pipelineName.value,
     position: { x: 400, y: 800 },
     type: NODE_CATEGORY.SEARCH_GROUP,
     data: { label: COMPONENT_CATEGORY.SEARCH },

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -88,7 +88,7 @@ function ingestConfigToWorkspaceFlow(
 
   // Parent ingest node
   const parentNode = {
-    id: generateId(COMPONENT_CATEGORY.INGEST),
+    id: ingestConfig.pipelineName,
     position: { x: 400, y: 400 },
     type: NODE_CATEGORY.INGEST_GROUP,
     data: { label: COMPONENT_CATEGORY.INGEST },
@@ -186,7 +186,7 @@ function searchConfigToWorkspaceFlow(
 
   // Parent search node
   const parentNode = {
-    id: generateId(COMPONENT_CATEGORY.SEARCH),
+    id: searchConfig.pipelineName,
     position: { x: 400, y: 800 },
     type: NODE_CATEGORY.SEARCH_GROUP,
     data: { label: COMPONENT_CATEGORY.SEARCH },

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -46,8 +46,14 @@ function formikToIngestUiConfig(
 ): IngestConfig {
   return {
     ...existingConfig,
-    enabled: ingestFormValues['enabled'],
-    pipelineName: ingestFormValues['pipelineName'],
+    enabled: {
+      ...existingConfig.enabled,
+      value: ingestFormValues['enabled'],
+    },
+    pipelineName: {
+      ...existingConfig.pipelineName,
+      value: ingestFormValues['pipelineName'],
+    },
     enrich: formikToProcessorsUiConfig(
       ingestFormValues['enrich'],
       existingConfig.enrich
@@ -79,7 +85,10 @@ function formikToSearchUiConfig(
       ...existingConfig.request,
       value: searchFormValues['request'],
     },
-    pipelineName: searchFormValues['pipelineName'],
+    pipelineName: {
+      ...existingConfig.pipelineName,
+      value: searchFormValues['pipelineName'],
+    },
     index: formikToSearchIndexUiConfig(
       searchFormValues['index'],
       existingConfig.index

--- a/public/utils/form_to_config_utils.ts
+++ b/public/utils/form_to_config_utils.ts
@@ -12,6 +12,7 @@ import {
   SearchConfig,
   ProcessorsConfig,
   IndexConfig,
+  SearchIndexConfig,
 } from '../../common';
 import { getInitialValue } from './config_to_form_utils';
 
@@ -46,6 +47,7 @@ function formikToIngestUiConfig(
   return {
     ...existingConfig,
     enabled: ingestFormValues['enabled'],
+    pipelineName: ingestFormValues['pipelineName'],
     enrich: formikToProcessorsUiConfig(
       ingestFormValues['enrich'],
       existingConfig.enrich
@@ -77,6 +79,11 @@ function formikToSearchUiConfig(
       ...existingConfig.request,
       value: searchFormValues['request'],
     },
+    pipelineName: searchFormValues['pipelineName'],
+    index: formikToSearchIndexUiConfig(
+      searchFormValues['index'],
+      existingConfig.index
+    ),
     enrichRequest: formikToProcessorsUiConfig(
       searchFormValues['enrichRequest'],
       existingConfig.enrichRequest
@@ -86,6 +93,14 @@ function formikToSearchUiConfig(
       existingConfig.enrichResponse
     ),
   };
+}
+
+function formikToSearchIndexUiConfig(
+  searchIndexFormValues: FormikValues,
+  existingConfig: SearchIndexConfig
+): SearchIndexConfig {
+  existingConfig['name'].value = searchIndexFormValues['name'];
+  return existingConfig;
 }
 
 function formikToProcessorsUiConfig(

--- a/server/cluster/flow_framework_plugin.ts
+++ b/server/cluster/flow_framework_plugin.ts
@@ -75,13 +75,17 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
 
   flowFramework.updateWorkflow = ca({
     url: {
-      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>`,
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>&reprovision=<%=reprovision%>`,
       req: {
         workflow_id: {
           type: 'string',
           required: true,
         },
         update_fields: {
+          type: 'boolean',
+          required: true,
+        },
+        reprovision: {
           type: 'boolean',
           required: true,
         },

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -93,11 +93,12 @@ export function registerFlowFrameworkRoutes(
 
   router.put(
     {
-      path: `${UPDATE_WORKFLOW_NODE_API_PATH}/{workflow_id}/{update_fields}`,
+      path: `${UPDATE_WORKFLOW_NODE_API_PATH}/{workflow_id}/{update_fields}/{reprovision}`,
       validate: {
         params: schema.object({
           workflow_id: schema.string(),
           update_fields: schema.boolean(),
+          reprovision: schema.boolean(),
         }),
         body: schema.any(),
       },
@@ -294,9 +295,10 @@ export class FlowFrameworkRoutesService {
     req: OpenSearchDashboardsRequest,
     res: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
-    const { workflow_id, update_fields } = req.params as {
+    const { workflow_id, update_fields, reprovision } = req.params as {
       workflow_id: string;
       update_fields: boolean;
+      reprovision: boolean;
     };
     const workflowTemplate = req.body as WorkflowTemplate;
     try {
@@ -306,6 +308,7 @@ export class FlowFrameworkRoutesService {
           workflow_id,
           // default update_fields to false if not explicitly set otherwise
           update_fields: update_fields,
+          reprovision: reprovision,
           body: workflowTemplate,
         });
 


### PR DESCRIPTION
### Description

This PR improves the search flow by allowing fine-grained provisioning (creating a search pipeline and attaching to an existing index) instead of the limitation from before, forcing full index deletion and re-creation. Now data is persisted and can be searched on in the search flow end-to-end. Additionally, cleans up some edge cases and improves the search flow experience overall, making it fully functional end-to-end now.

More details:
- adds `reprovision` parameter on the update workflow API call to support fine-grained provisioning (ref: https://github.com/opensearch-project/flow-framework/pull/804)
- persists several other fields in the UI config, including 1/ ingest pipeline name, 2/ search pipeline name, and 3/ search index name. The pipeline names are created initially & persisted so we have consistent template node IDs during subsequent updates (before, we were re-generating every time, in which case node IDs did not match, which caused fine-grained provisioning to fail, as it perceived this as node deletions, since the node IDs from the existing template were no longer present). The search index name is a way to persist a user-chosen index (if they skip ingest) and persist it in the UI. This may be expanded upon in the future if we want to pull existing UI configs into an augmented template for users as an option.
- blocks 'Run query' if there is no search pipeline config (the request and response processor configs are empty). This prevents several different edge cases and confusing user experiences otherwise
- adds fine-grained validation: only validate the relevant form fields depending on users being in the context of ingest or search.
- removed bunch of TODO comments :)

Testing:
Tested following scenarios:
- create ingest resources, add on search resources
- skip ingest resources, add on search resources
- skip ingest resources, add on search resources, add ingest resources, update search resources

Demo video, showing fine-grained provisioning happening on the search side. We provision an ingest pipeline & index, then on search, configure and provision a search pipeline separately, but keeping the existing ingest resources. Notice the search call made after running, and how data is still present. Lastly, shows that selecting different indices (if ingest is disabled) is persisted in the UI.

[screen-capture (21).webm](https://github.com/user-attachments/assets/28f72822-0090-4d0f-b116-9a368192dce1)

### Issues Resolved

Makes progress on #23 
Resolves #267

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
