### PR TITLE
Support `query_template` optional field for ML search request processor

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -21,6 +21,7 @@ export type ConfigFieldType =
   | 'string'
   | 'json'
   | 'jsonArray'
+  | 'jsonString'
   | 'select'
   | 'model'
   | 'map'
@@ -218,6 +219,7 @@ export type MLInferenceProcessor = IngestProcessor & {
     model_id: string;
     input_map?: {};
     output_map?: {};
+    [key: string]: any;
   };
 };
 

--- a/public/configs/search_request_processors/ml_search_request_processor.ts
+++ b/public/configs/search_request_processors/ml_search_request_processor.ts
@@ -13,5 +13,12 @@ export class MLSearchRequestProcessor extends MLProcessor {
   constructor() {
     super();
     this.id = generateId('ml_processor_search_request');
+    this.optionalFields = [
+      {
+        id: 'query_template',
+        type: 'json',
+      },
+      ...(this.optionalFields || []),
+    ];
   }
 }

--- a/public/configs/search_request_processors/ml_search_request_processor.ts
+++ b/public/configs/search_request_processors/ml_search_request_processor.ts
@@ -16,7 +16,7 @@ export class MLSearchRequestProcessor extends MLProcessor {
     this.optionalFields = [
       {
         id: 'query_template',
-        type: 'json',
+        type: 'jsonString',
       },
       ...(this.optionalFields || []),
     ];

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -10,6 +10,7 @@ import {
   SelectField,
   BooleanField,
   NumberField,
+  JsonField,
 } from './input_fields';
 import { IConfigField } from '../../../../common';
 import { camelCaseToTitleString } from '../../../utils';
@@ -90,6 +91,19 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
                   showError={true}
+                  onFormChange={props.onFormChange}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'json': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <JsonField
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
                   onFormChange={props.onFormChange}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -111,6 +111,20 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
             );
             break;
           }
+          case 'jsonString': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <JsonField
+                  validate={false}
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  onFormChange={props.onFormChange}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
         }
         return el;
       })}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -17,6 +17,7 @@ import { camelCaseToTitleString } from '../../../../utils';
 interface JsonFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onFormChange: () => void;
+  validate?: boolean;
   label?: string;
   helpLink?: string;
   helpText?: string;
@@ -29,6 +30,8 @@ interface JsonFieldProps {
  * in some custom JSON
  */
 export function JsonField(props: JsonFieldProps) {
+  const validate = props.validate !== undefined ? props.validate : true;
+
   const { errors, touched, values } = useFormikContext<WorkspaceFormValues>();
 
   // temp input state. only format when users click out of the code editor
@@ -61,8 +64,12 @@ export function JsonField(props: JsonFieldProps) {
               ) : undefined
             }
             helpText={props.helpText || undefined}
-            error={getIn(errors, field.name)}
-            isInvalid={getIn(errors, field.name) && getIn(touched, field.name)}
+            error={validate ? getIn(errors, field.name) : undefined}
+            isInvalid={
+              validate
+                ? getIn(errors, field.name) && getIn(touched, field.name)
+                : false
+            }
           >
             <EuiCodeEditor
               mode="json"
@@ -89,6 +96,7 @@ export function JsonField(props: JsonFieldProps) {
               readOnly={props.readOnly || false}
               setOptions={{
                 fontSize: '14px',
+                useWorker: validate,
               }}
               aria-label="Code Editor"
               tabSize={2}

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -139,7 +139,8 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     case 'map': {
       return [];
     }
-    case 'json': {
+    case 'json':
+    case 'jsonString': {
       return '{}';
     }
     case 'jsonArray': {

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -157,6 +157,10 @@ function getFieldSchema(
 
       break;
     }
+    case 'jsonString': {
+      baseSchema = yup.string().min(1, 'Too short');
+      break;
+    }
     case 'mapArray': {
       baseSchema = yup.array().of(
         yup.array().of(


### PR DESCRIPTION
### Description

Adds support for the `query_template` parameter for the ML inference processor in the context of search request. This param is used to rewrite a query, commonly used for creating some knn query based on vectors returned from an embedding model. 

Also cleans up the `ConfigFieldList` to support `json` fields and `jsonString` fields to fully support all optional field types. The latter `jsonString` does not have the JSON validation, as it could be invalid JSON with variable placeholders in the context of a JSON template. Currently, only the added `query_template` field uses this field type.

And lastly, finishes processing of ML processor optional inputs and ensure they are included in the final generated template configuration.

Demo video, showing a semantic search use case. Indexes some sample text data with an ML processor to vectorize it. Next, on the search side, take some input query, vectorize the text input, use `query_template` to create some `knn` query, using the ML embedding response as the vector to search on. knn results are then returned.

[screen-capture (22).webm](https://github.com/user-attachments/assets/02af288e-c900-4007-a61a-6b27f518a3c0)

### Issues Resolved
Makes progresson #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
