### PR TITLE
Improve loading state; prevent duplicate refresh

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -49,7 +49,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
   >();
-  const ingestEnabled = values?.ingest?.enabled || true;
+  const ingestEnabled = values?.ingest?.enabled;
   const searchIndexNameFormPath = 'search.index.name';
 
   // All indices state

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -92,7 +92,6 @@ export function UseCase(props: UseCaseProps) {
                     history.replace(
                       `${APP_PATH.WORKFLOWS}/${workflow.id}?dataSourceId=${dataSourceId}`
                     );
-                    history.go(0);
                   })
                   .catch((err: any) => {
                     console.error(err);


### PR DESCRIPTION
### Description

Another usability PR to clean up 2 things:
1. improve button enablement/disablement based on redux loading states (representing APIs in-progress), and state vars when a user-specified ingest, search, or delete action occurs
2. Removes unnecessary page reload on workflow creation


Demo video showing simplified creation flow and more fine-grained button states:

[screen-capture (25).webm](https://github.com/user-attachments/assets/661264f8-f479-4255-b8b2-f88a942aa366)


### Issues Resolved

Resolves #287 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
