### PR TITLE
Improve input constraints; general usability improvements

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -158,6 +158,7 @@ export const FETCH_ALL_QUERY_BODY = {
   size: 1000,
 };
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
+export const ERROR_GETTING_WORKFLOW_MSG = 'Failed to retrieve template';
 export const NO_MODIFICATIONS_FOUND_TEXT =
   'Template does not contain any modifications';
 export const JSONPATH_ROOT_SELECTOR = '$.';

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -165,6 +165,11 @@ export enum SORT_ORDER {
   ASC = 'asc',
   DESC = 'desc',
 }
+export const MAX_DOCS = 1000;
+export const MAX_STRING_LENGTH = 100;
+export const MAX_JSON_STRING_LENGTH = 10000;
+export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
+export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 
 export enum PROCESSOR_CONTEXT {
   INGEST = 'ingest',

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -24,3 +24,10 @@ export const prettifyErrorMessage = (rawErrorMessage: string) => {
     return `User ${match[2]} has no permissions to [${match[1]}].`;
   }
 };
+
+export function getCharacterLimitedString(
+  input: string,
+  limit: number
+): string {
+  return input.length > limit ? input.substring(0, limit - 3) + '...' : input;
+}

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -26,8 +26,12 @@ export const prettifyErrorMessage = (rawErrorMessage: string) => {
 };
 
 export function getCharacterLimitedString(
-  input: string,
+  input: string | undefined,
   limit: number
 ): string {
-  return input.length > limit ? input.substring(0, limit - 3) + '...' : input;
+  return input !== undefined
+    ? input.length > limit
+      ? input.substring(0, limit - 3) + '...'
+      : input
+    : '';
 }

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -4,6 +4,5 @@
  */
 
 export { MultiSelectFilter } from './multi_select_filter';
-export { DeleteWorkflowModal } from './delete_workflow_modal';
 export { ProcessorsTitle } from './processors_title';
 export { ResourceList } from './resource_list';

--- a/public/pages/workflow_detail/components/export_modal.tsx
+++ b/public/pages/workflow_detail/components/export_modal.tsx
@@ -19,7 +19,11 @@ import {
   EuiModalFooter,
   EuiSmallButtonEmpty,
 } from '@elastic/eui';
-import { CREATE_WORKFLOW_LINK, Workflow } from '../../../../common';
+import {
+  CREATE_WORKFLOW_LINK,
+  Workflow,
+  getCharacterLimitedString,
+} from '../../../../common';
 import { reduceToTemplate } from '../../../utils';
 
 interface ExportModalProps {
@@ -69,7 +73,10 @@ export function ExportModal(props: ExportModalProps) {
     <EuiModal onClose={() => props.setIsExportModalOpen(false)}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Export ${props.workflow?.name}`}</p>
+          <p>{`Export ${getCharacterLimitedString(
+            props.workflow?.name || '',
+            25
+          )}`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -15,8 +15,10 @@ import {
 } from '@elastic/eui';
 import {
   DEFAULT_NEW_WORKFLOW_STATE,
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
   WORKFLOW_STATE,
   Workflow,
+  getCharacterLimitedString,
   toFormattedDate,
 } from '../../../../common';
 import { APP_PATH } from '../../../utils';
@@ -38,7 +40,12 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
 
   useEffect(() => {
     if (props.workflow) {
-      setWorkflowName(props.workflow.name);
+      setWorkflowName(
+        getCharacterLimitedString(
+          props.workflow.name,
+          MAX_WORKFLOW_NAME_TO_DISPLAY
+        )
+      );
       setWorkflowState(props.workflow.state || DEFAULT_NEW_WORKFLOW_STATE);
       try {
         const formattedDate = toFormattedDate(

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -19,8 +19,9 @@ import {
 } from '../../store';
 import { ResizableWorkspace } from './resizable_workspace';
 import {
-  DEFAULT_NEW_WORKFLOW_NAME,
   FETCH_ALL_QUERY_BODY,
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
+  getCharacterLimitedString,
 } from '../../../common';
 import { MountPoint } from '../../../../../src/core/public';
 
@@ -62,7 +63,10 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   // selected workflow state
   const workflowId = props.match?.params?.workflowId;
   const workflow = workflows[workflowId];
-  const workflowName = workflow ? workflow.name : DEFAULT_NEW_WORKFLOW_NAME;
+  const workflowName = getCharacterLimitedString(
+    workflow?.name || '',
+    MAX_WORKFLOW_NAME_TO_DISPLAY
+  );
 
   useEffect(() => {
     if (dataSourceEnabled) {
@@ -78,7 +82,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
         { text: workflowName },
       ]);
     }
-  }, []);
+  }, [workflowName]);
 
   // On initial load:
   // - fetch workflow

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -7,8 +7,16 @@ import React, { useEffect, ReactElement } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { ReactFlowProvider } from 'reactflow';
-import { EuiPage, EuiPageBody } from '@elastic/eui';
-import { BREADCRUMBS } from '../../utils';
+import { escape } from 'lodash';
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPage,
+  EuiPageBody,
+} from '@elastic/eui';
+import { APP_PATH, BREADCRUMBS } from '../../utils';
 import { getCore } from '../../services';
 import { WorkflowDetailHeader } from './components';
 import {
@@ -19,6 +27,7 @@ import {
 } from '../../store';
 import { ResizableWorkspace } from './resizable_workspace';
 import {
+  ERROR_GETTING_WORKFLOW_MSG,
   FETCH_ALL_QUERY_BODY,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
   getCharacterLimitedString,
@@ -29,7 +38,10 @@ import { MountPoint } from '../../../../../src/core/public';
 import './workflow-detail-styles.scss';
 import '../../global-styles.scss';
 
-import { getDataSourceId } from '../../utils/utils';
+import {
+  constructHrefWithDataSourceId,
+  getDataSourceId,
+} from '../../utils/utils';
 
 import {
   getDataSourceManagementPlugin,
@@ -58,10 +70,12 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   const dispatch = useAppDispatch();
   const dataSourceEnabled = getDataSourceEnabled().enabled;
   const dataSourceId = getDataSourceId();
-  const { workflows } = useSelector((state: AppState) => state.workflows);
+  const { workflows, errorMessage } = useSelector(
+    (state: AppState) => state.workflows
+  );
 
   // selected workflow state
-  const workflowId = props.match?.params?.workflowId;
+  const workflowId = escape(props.match?.params?.workflowId);
   const workflow = workflows[workflowId];
   const workflowName = getCharacterLimitedString(
     workflow?.name || '',
@@ -111,7 +125,26 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     );
   }
 
-  return (
+  return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ? (
+    <EuiFlexGroup direction="column" alignItems="center">
+      <EuiFlexItem grow={3}>
+        <EuiEmptyPrompt
+          iconType={'cross'}
+          title={<h2>Oops! We couldn't find that workflow</h2>}
+          titleSize="s"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={7}>
+        <EuiButton
+          style={{ width: '200px' }}
+          fill={false}
+          href={constructHrefWithDataSourceId(APP_PATH.WORKFLOWS, dataSourceId)}
+        >
+          Return to home
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  ) : (
     <ReactFlowProvider>
       {dataSourceEnabled && renderDataSourceComponent}
       <EuiPage>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -84,6 +84,7 @@ export function SourceData(props: SourceDataProps) {
               />
               <EuiSpacer size="s" />
               <JsonField
+                label="Documents"
                 fieldPath={'ingest.docs'}
                 helpText="Documents should be formatted as a valid JSON array."
                 // when ingest doc values change, don't update the form
@@ -123,6 +124,7 @@ export function SourceData(props: SourceDataProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <JsonField
+            label="Documents"
             fieldPath={'ingest.docs'}
             helpText="Documents should be formatted as a valid JSON array."
             // when ingest doc values change, don't update the form

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -52,6 +52,7 @@ export function JsonField(props: JsonFieldProps) {
       {({ field, form }: FieldProps) => {
         return (
           <EuiCompressedFormRow
+            fullWidth={true}
             key={props.fieldPath}
             label={props.label || camelCaseToTitleString(field.name)}
             labelAppend={
@@ -97,6 +98,9 @@ export function JsonField(props: JsonFieldProps) {
               setOptions={{
                 fontSize: '14px',
                 useWorker: validate,
+                highlightActiveLine: !props.readOnly,
+                highlightSelectedWord: !props.readOnly,
+                highlightGutterLine: !props.readOnly,
               }}
               aria-label="Code Editor"
               tabSize={2}

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -28,6 +28,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import {
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
   SearchHit,
   TemplateNode,
   WORKFLOW_STEP_TYPE,
@@ -35,6 +36,7 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
   WorkflowTemplate,
+  getCharacterLimitedString,
 } from '../../../../common';
 import { IngestInputs } from './ingest_inputs';
 import { SearchInputs } from './search_inputs';
@@ -596,7 +598,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               <EuiModal onClose={() => setIsModalOpen(false)}>
                 <EuiModalHeader>
                   <EuiModalHeaderTitle>
-                    <p>{`Delete resources for workflow ${props.workflow?.name}?`}</p>
+                    <p>{`Delete resources for workflow ${getCharacterLimitedString(
+                      props.workflow?.name || '',
+                      MAX_WORKFLOW_NAME_TO_DISPLAY
+                    )}?`}</p>
                   </EuiModalHeaderTitle>
                 </EuiModalHeader>
                 <EuiModalBody>

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -32,7 +32,7 @@ import {
 } from '../../../store';
 import { FETCH_ALL_QUERY_BODY, Workflow } from '../../../../common';
 import { WORKFLOWS_TAB } from '../workflows';
-import {  getDataSourceId } from '../../../utils/utils';
+import { getDataSourceId } from '../../../utils/utils';
 
 interface ImportWorkflowModalProps {
   isImportModalOpen: boolean;
@@ -50,6 +50,9 @@ interface ImportWorkflowModalProps {
 export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+
+  // transient importing state for button state
+  const [isImporting, setIsImporting] = useState<boolean>(false);
 
   // file contents & file obj state
   const [fileContents, setFileContents] = useState<string | undefined>(
@@ -133,8 +136,10 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
       <EuiModalFooter>
         <EuiButtonEmpty onClick={() => onModalClose()}>Cancel</EuiButtonEmpty>
         <EuiButton
-          disabled={!isValidWorkflow(fileObj)}
+          disabled={!isValidWorkflow(fileObj) || isImporting}
+          isLoading={isImporting}
           onClick={() => {
+            setIsImporting(true);
             dispatch(
               createWorkflow({
                 apiBody: fileObj as Workflow,
@@ -159,6 +164,7 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
                 getCore().notifications.toasts.addDanger(error);
               })
               .finally(() => {
+                setIsImporting(false);
                 onModalClose();
               });
           }}

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -22,7 +22,7 @@ import {
   EuiCompressedFieldText,
   EuiCompressedFormRow,
 } from '@elastic/eui';
-import { Workflow } from '../../../../common';
+import { WORKFLOW_NAME_REGEXP, Workflow } from '../../../../common';
 import { APP_PATH } from '../../../utils';
 import { processWorkflowName } from './utils';
 import { createWorkflow, useAppDispatch } from '../../../store';
@@ -45,6 +45,15 @@ export function UseCase(props: UseCaseProps) {
     processWorkflowName(props.workflow.name)
   );
 
+  // custom sanitization on workflow name
+  function isInvalid(name: string): boolean {
+    return (
+      name === '' ||
+      name.length > 100 ||
+      WORKFLOW_NAME_REGEXP.test(name) === false
+    );
+  }
+
   return (
     <>
       {isNameModalOpen && (
@@ -57,8 +66,8 @@ export function UseCase(props: UseCaseProps) {
           <EuiModalBody>
             <EuiCompressedFormRow
               label={'Name'}
-              error={'Name cannot be empty'}
-              isInvalid={workflowName === ''}
+              error={'Invalid name'}
+              isInvalid={isInvalid(workflowName)}
             >
               <EuiCompressedFieldText
                 placeholder={processWorkflowName(props.workflow.name)}
@@ -74,7 +83,7 @@ export function UseCase(props: UseCaseProps) {
               Cancel
             </EuiSmallButtonEmpty>
             <EuiSmallButton
-              disabled={workflowName === ''}
+              disabled={isInvalid(workflowName)}
               onClick={() => {
                 const workflowToCreate = {
                   ...props.workflow,

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { snakeCase } from 'lodash';
 import { MLIngestProcessor } from '../../../configs';
 import {
   WorkflowTemplate,
@@ -117,13 +118,5 @@ function fetchSemanticSearchMetadata(): UIState {
 export function processWorkflowName(workflowName: string): string {
   return workflowName === START_FROM_SCRATCH_WORKFLOW_NAME
     ? DEFAULT_NEW_WORKFLOW_NAME
-    : toSnakeCase(workflowName);
-}
-
-function toSnakeCase(text: string): string {
-  return text
-    .replace(/\W+/g, ' ')
-    .split(/ |\B(?=[A-Z])/)
-    .map((word) => word.toLowerCase())
-    .join('_');
+    : snakeCase(workflowName);
 }

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -7,7 +7,9 @@ import React from 'react';
 import { EuiLink } from '@elastic/eui';
 import {
   EMPTY_FIELD_STRING,
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
   Workflow,
+  getCharacterLimitedString,
   toFormattedDate,
 } from '../../../../common';
 import {
@@ -31,7 +33,7 @@ export const columns = (actions: any[]) => {
             dataSourceId
           )}
         >
-          {name}
+          {getCharacterLimitedString(name, MAX_WORKFLOW_NAME_TO_DISPLAY)}
         </EuiLink>
       ),
     },

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -24,7 +24,7 @@ export const columns = (actions: any[]) => {
     {
       field: 'name',
       name: 'Name',
-      width: '33%',
+      width: '35%',
       sortable: true,
       render: (name: string, workflow: Workflow) => (
         <EuiLink
@@ -40,13 +40,13 @@ export const columns = (actions: any[]) => {
     {
       field: 'ui_metadata.type',
       name: 'Type',
-      width: '33%',
+      width: '20%',
       sortable: true,
     },
     {
       field: 'lastUpdated',
       name: 'Last saved',
-      width: '33%',
+      width: '35%',
       sortable: true,
       render: (lastUpdated: number) =>
         lastUpdated !== undefined
@@ -55,6 +55,7 @@ export const columns = (actions: any[]) => {
     },
     {
       name: 'Actions',
+      width: '10%',
       actions,
     },
   ];

--- a/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
+++ b/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -13,38 +13,124 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCheckbox,
 } from '@elastic/eui';
 import { Workflow } from '../../../../common';
+import {
+  deleteWorkflow,
+  deprovisionWorkflow,
+  useAppDispatch,
+} from '../../../store';
+import { getDataSourceId, getResourcesToBeForceDeleted } from '../../../utils';
+import { getCore } from '../../../services';
 
 interface DeleteWorkflowModalProps {
   workflow: Workflow;
-  onClose: () => void;
-  onConfirm: () => void;
+  clearDeleteState(): void;
 }
 
 /**
- * A general delete workflow modal.
+ * A modal to delete workflow. Optionally deprovision/delete associated resources.
  */
 export function DeleteWorkflowModal(props: DeleteWorkflowModalProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+
+  // isDeleting state used for button states
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+
+  // deprovision state
+  const [deprovision, setDeprovision] = useState<boolean>(true);
+
+  // reusable delete workflow fn
+  async function handleDelete() {
+    await dispatch(
+      deleteWorkflow({
+        workflowId: props.workflow.id as string,
+        dataSourceId,
+      })
+    )
+      .unwrap()
+      .then((result) => {
+        getCore().notifications.toasts.addSuccess(
+          `Successfully deleted ${props.workflow.name}`
+        );
+      })
+      .catch((err: any) => {
+        getCore().notifications.toasts.addDanger(
+          `Failed to delete ${props.workflow.name}`
+        );
+        console.error(`Failed to delete ${props.workflow.name}: ${err}`);
+      });
+  }
+
   return (
-    <EuiModal onClose={props.onClose}>
+    <EuiModal onClose={() => props.clearDeleteState()}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <p>{`Delete ${props.workflow.name}?`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        <EuiText>
-          The workflow will be permanently deleted. This action cannot be
-          undone. Resources created by this workflow will be retained.
-        </EuiText>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <EuiText>The workflow will be permanently deleted.</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCheckbox
+              id="deprovision"
+              onChange={(e) => {
+                setDeprovision(e.target.checked);
+              }}
+              checked={deprovision}
+              label="Delete associated resources"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiSmallButtonEmpty onClick={props.onClose}>
+        <EuiSmallButtonEmpty onClick={() => props.clearDeleteState()}>
           {' '}
           Cancel
         </EuiSmallButtonEmpty>
-        <EuiSmallButton onClick={props.onConfirm} fill={true} color="danger">
+        <EuiSmallButton
+          isDisabled={isDeleting}
+          isLoading={isDeleting}
+          onClick={async () => {
+            setIsDeleting(true);
+            if (deprovision) {
+              await dispatch(
+                deprovisionWorkflow({
+                  apiBody: {
+                    workflowId: props.workflow.id as string,
+                    resourceIds: getResourcesToBeForceDeleted(props.workflow),
+                  },
+                  dataSourceId,
+                })
+              )
+                .unwrap()
+                .then(async (result) => {
+                  handleDelete();
+                })
+                .catch((err: any) => {
+                  getCore().notifications.toasts.addDanger(
+                    `Failed to delete resources for ${props.workflow.name}`
+                  );
+                  console.error(
+                    `Failed to delete resources for ${props.workflow.name}: ${err}`
+                  );
+                });
+            } else {
+              handleDelete();
+            }
+            setIsDeleting(false);
+            props.clearDeleteState();
+          }}
+          fill={true}
+          color="danger"
+        >
           Delete
         </EuiSmallButton>
       </EuiModalFooter>

--- a/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
+++ b/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiText,
 } from '@elastic/eui';
-import { Workflow } from '../../common';
+import { Workflow } from '../../../../common';
 
 interface DeleteWorkflowModalProps {
   workflow: Workflow;
@@ -40,7 +40,10 @@ export function DeleteWorkflowModal(props: DeleteWorkflowModalProps) {
         </EuiText>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiSmallButtonEmpty onClick={props.onClose}> Cancel</EuiSmallButtonEmpty>
+        <EuiSmallButtonEmpty onClick={props.onClose}>
+          {' '}
+          Cancel
+        </EuiSmallButtonEmpty>
         <EuiSmallButton onClick={props.onConfirm} fill={true} color="danger">
           Delete
         </EuiSmallButton>

--- a/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
+++ b/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
@@ -17,7 +17,11 @@ import {
   EuiFlexItem,
   EuiCheckbox,
 } from '@elastic/eui';
-import { Workflow } from '../../../../common';
+import {
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
+  Workflow,
+  getCharacterLimitedString,
+} from '../../../../common';
 import {
   deleteWorkflow,
   deprovisionWorkflow,
@@ -70,7 +74,10 @@ export function DeleteWorkflowModal(props: DeleteWorkflowModalProps) {
     <EuiModal onClose={() => props.clearDeleteState()}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Delete ${props.workflow.name}?`}</p>
+          <p>{`Delete ${getCharacterLimitedString(
+            props.workflow.name,
+            MAX_WORKFLOW_NAME_TO_DISPLAY
+          )}?`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -21,7 +21,13 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { AppState } from '../../../store';
-import { UIState, WORKFLOW_TYPE, Workflow } from '../../../../common';
+import {
+  MAX_WORKFLOW_NAME_TO_DISPLAY,
+  UIState,
+  WORKFLOW_TYPE,
+  Workflow,
+  getCharacterLimitedString,
+} from '../../../../common';
 import { columns } from './columns';
 import { MultiSelectFilter, ResourceList } from '../../../general_components';
 import { WORKFLOWS_TAB } from '../workflows';
@@ -144,7 +150,10 @@ export function WorkflowList(props: WorkflowListProps) {
         >
           <EuiFlyoutHeader hasBorder={true}>
             <EuiTitle size="m">
-              <h2>{`Active resources with ${selectedWorkflow.name}`}</h2>
+              <h2>{`Active resources with ${getCharacterLimitedString(
+                selectedWorkflow.name,
+                MAX_WORKFLOW_NAME_TO_DISPLAY
+              )}`}</h2>
             </EuiTitle>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -20,13 +20,11 @@ import {
   EuiFlyoutBody,
   EuiText,
 } from '@elastic/eui';
-import { AppState, deleteWorkflow, useAppDispatch } from '../../../store';
+import { AppState } from '../../../store';
 import { UIState, WORKFLOW_TYPE, Workflow } from '../../../../common';
 import { columns } from './columns';
 import { MultiSelectFilter, ResourceList } from '../../../general_components';
 import { WORKFLOWS_TAB } from '../workflows';
-import { getCore } from '../../../services';
-import { getDataSourceId } from '../../../utils/utils';
 import { DeleteWorkflowModal } from './delete_workflow_modal';
 
 interface WorkflowListProps {
@@ -62,8 +60,6 @@ const filterOptions = [
  * The searchable list of created workflows.
  */
 export function WorkflowList(props: WorkflowListProps) {
-  const dispatch = useAppDispatch();
-  const dataSourceId = getDataSourceId();
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
@@ -138,32 +134,7 @@ export function WorkflowList(props: WorkflowListProps) {
       {isDeleteModalOpen && selectedWorkflow?.id !== undefined && (
         <DeleteWorkflowModal
           workflow={selectedWorkflow}
-          onClose={() => {
-            clearDeleteState();
-          }}
-          onConfirm={async () => {
-            clearDeleteState();
-            await dispatch(
-              deleteWorkflow({
-                workflowId: selectedWorkflow.id as string,
-                dataSourceId,
-              })
-            )
-              .unwrap()
-              .then((result) => {
-                getCore().notifications.toasts.addSuccess(
-                  `Successfully deleted ${selectedWorkflow.name}`
-                );
-              })
-              .catch((err: any) => {
-                getCore().notifications.toasts.addDanger(
-                  `Failed to delete ${selectedWorkflow.name}`
-                );
-                console.error(
-                  `Failed to delete ${selectedWorkflow.name}: ${err}`
-                );
-              });
-          }}
+          clearDeleteState={clearDeleteState}
         />
       )}
       {isResourcesFlyoutOpen && selectedWorkflow && (

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -23,14 +23,11 @@ import {
 import { AppState, deleteWorkflow, useAppDispatch } from '../../../store';
 import { UIState, WORKFLOW_TYPE, Workflow } from '../../../../common';
 import { columns } from './columns';
-import {
-  DeleteWorkflowModal,
-  MultiSelectFilter,
-  ResourceList,
-} from '../../../general_components';
+import { MultiSelectFilter, ResourceList } from '../../../general_components';
 import { WORKFLOWS_TAB } from '../workflows';
 import { getCore } from '../../../services';
 import { getDataSourceId } from '../../../utils/utils';
+import { DeleteWorkflowModal } from './delete_workflow_modal';
 
 interface WorkflowListProps {
   setSelectedTabId: (tabId: WORKFLOWS_TAB) => void;

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -5,6 +5,7 @@
 
 import React, { useEffect, useState, useMemo } from 'react';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
+import { escape } from 'lodash';
 import {
   EuiPageHeader,
   EuiTitle,
@@ -91,7 +92,9 @@ export function Workflows(props: WorkflowsProps) {
   const tabFromUrl = queryString.parse(useLocation().search)[
     ACTIVE_TAB_PARAM
   ] as WORKFLOWS_TAB;
-  const [selectedTabId, setSelectedTabId] = useState<WORKFLOWS_TAB>(tabFromUrl);
+  const [selectedTabId, setSelectedTabId] = useState<WORKFLOWS_TAB>(
+    escape(tabFromUrl) as WORKFLOWS_TAB
+  );
 
   // If there is no selected tab or invalid tab, default to manage tab
   useEffect(() => {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -5,7 +5,7 @@
 
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
-import { get } from 'lodash';
+import { escape, get } from 'lodash';
 import {
   JSONPATH_ROOT_SELECTOR,
   MapFormValue,
@@ -238,7 +238,8 @@ export const getDataSourceFromURL = (location: {
   const queryParams = queryString.parse(location.search);
   const dataSourceId = queryParams.dataSourceId;
   return {
-    dataSourceId: typeof dataSourceId === 'string' ? dataSourceId : undefined,
+    dataSourceId:
+      typeof dataSourceId === 'string' ? escape(dataSourceId) : undefined,
   };
 };
 


### PR DESCRIPTION
### Description

This PR covers a bunch of general usability improvements:
- refactors the delete workflow modal into the workflow list module
- updates the delete workflow modal by adding deprovisioning as an option (and setting it as the default) when deleting workflows from the list page
- adds a 'failed to find workflow' dedicated page due to invalid id in url, for example
- adds more loading state and visibility when deleting
- adds input limits - max 1000 documents, max 100 chars for string, max 10000 chars for json string
- adds regexp matching and character limit handling when defining workflow name from the new workflows page
- adds `getCharacterLimitedString()` util fn to dynamically truncate strings if beyond the specified limit and adds an ellipses. Audited the entire plugin to ensure the workflow name, for example, is displayed properly, if the name is very long.
- adds xss checks by sanitizing all scenarios when parsing url params
- adds loading state to importing
- makes JSON editor full-width

Demo video, showing the updated delete modal, invalid url page, and some general input handling checks.

[screen-capture (26).webm](https://github.com/user-attachments/assets/b8229984-780e-4273-bf2e-f3021e3db07e)

### Issues Resolved

Makes progress on #23 
Makes progress on #295 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
