### PR TITLE
Add basic preset queries; onboard hybrid/multimodal search use cases

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WORKFLOW_STATE } from './interfaces';
+import { QueryPreset, WORKFLOW_STATE } from './interfaces';
+import { customStringify } from './utils';
 
 export const PLUGIN_ID = 'flow-framework';
 export const SEARCH_STUDIO = 'Search Studio';
@@ -59,6 +60,8 @@ export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
 // frontend-specific workflow types, derived from the available preset templates
 export enum WORKFLOW_TYPE {
   SEMANTIC_SEARCH = 'Semantic search',
+  MULTIMODAL_SEARCH = 'Multimodal search',
+  HYBRID_SEARCH = 'Hybrid search',
   CUSTOM = 'Custom',
   UNKNOWN = 'Unknown',
 }
@@ -143,6 +146,91 @@ export const DELIMITER_OPTIONAL_FIELDS = ['delimiter'];
 export const SHARED_OPTIONAL_FIELDS = ['max_chunk_limit', 'description', 'tag'];
 
 /**
+ * QUERIES
+ */
+export const FETCH_ALL_QUERY = {
+  query: {
+    match_all: {},
+  },
+  size: 1000,
+};
+export const SEMANTIC_SEARCH_QUERY = {
+  _source: {
+    excludes: [`{{vector_field}}`],
+  },
+  query: {
+    neural: {
+      [`{{vector_field}}`]: {
+        query_text: `{{query_text}}`,
+        model_id: `{{model_id}}`,
+        k: 100,
+      },
+    },
+  },
+};
+export const MULTIMODAL_SEARCH_QUERY = {
+  _source: {
+    excludes: [`{{vector_field}}`],
+  },
+  query: {
+    neural: {
+      [`{{vector_field}}`]: {
+        query_text: `{{query_text}}`,
+        query_image: `{{query_image}}`,
+        model_id: `{{model_id}}`,
+        k: 100,
+      },
+    },
+  },
+};
+export const HYBRID_SEARCH_QUERY = {
+  _source: {
+    excludes: [`{{vector_field}}`],
+  },
+  query: {
+    hybrid: {
+      queries: [
+        {
+          match: {
+            [`{{text_field}}`]: {
+              query: `{{query_text}}`,
+            },
+          },
+        },
+        {
+          neural: {
+            [`{{vector_field}}`]: {
+              query_text: `{{query_text}}`,
+              model_id: `{{model_id}}`,
+              k: 5,
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export const QUERY_PRESETS = [
+  {
+    name: 'Fetch all',
+    query: customStringify(FETCH_ALL_QUERY),
+  },
+  {
+    name: WORKFLOW_TYPE.SEMANTIC_SEARCH,
+    query: customStringify(SEMANTIC_SEARCH_QUERY),
+  },
+  {
+    name: WORKFLOW_TYPE.MULTIMODAL_SEARCH,
+    query: customStringify(MULTIMODAL_SEARCH_QUERY),
+  },
+  {
+    name: WORKFLOW_TYPE.HYBRID_SEARCH,
+    query: customStringify(HYBRID_SEARCH_QUERY),
+  },
+] as QueryPreset[];
+
+/**
  * MISCELLANEOUS
  */
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
@@ -152,12 +240,6 @@ export const DEFAULT_NEW_WORKFLOW_STATE = WORKFLOW_STATE.NOT_STARTED;
 export const DEFAULT_NEW_WORKFLOW_STATE_TYPE = ('NOT_STARTED' as any) as typeof WORKFLOW_STATE;
 export const DATE_FORMAT_PATTERN = 'MM/DD/YY hh:mm A';
 export const EMPTY_FIELD_STRING = '--';
-export const FETCH_ALL_QUERY_BODY = {
-  query: {
-    match_all: {},
-  },
-  size: 1000,
-};
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
 export const ERROR_GETTING_WORKFLOW_MSG = 'Failed to retrieve template';
 export const NO_MODIFICATIONS_FOUND_TEXT =

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -456,6 +456,11 @@ export type WorkflowDict = {
   [workflowId: string]: Workflow;
 };
 
+export type QueryPreset = {
+  name: string;
+  query: string;
+};
+
 /**
  ********** OPENSEARCH TYPES/INTERFACES ************
  */

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -16,7 +16,7 @@ import {
   EuiPage,
   EuiPageBody,
 } from '@elastic/eui';
-import { APP_PATH, BREADCRUMBS, SHOW_ACTIONS_IN_HEADER} from '../../utils';
+import { APP_PATH, BREADCRUMBS, SHOW_ACTIONS_IN_HEADER } from '../../utils';
 import { getCore } from '../../services';
 import { WorkflowDetailHeader } from './components';
 import {
@@ -28,7 +28,7 @@ import {
 import { ResizableWorkspace } from './resizable_workspace';
 import {
   ERROR_GETTING_WORKFLOW_MSG,
-  FETCH_ALL_QUERY_BODY,
+  FETCH_ALL_QUERY,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
   getCharacterLimitedString,
 } from '../../../common';
@@ -102,7 +102,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   // - fetch available models as their IDs may be used when building flows
   useEffect(() => {
     dispatch(getWorkflow({ workflowId, dataSourceId }));
-    dispatch(searchModels({ apiBody: FETCH_ALL_QUERY_BODY, dataSourceId }));
+    dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
   }, []);
 
   return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ? (

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -83,7 +83,12 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
 
   return (
     <>
-      {isEditModalOpen && <EditQueryModal setModalOpen={setIsEditModalOpen} />}
+      {isEditModalOpen && (
+        <EditQueryModal
+          setModalOpen={setIsEditModalOpen}
+          queryFieldPath="search.request"
+        />
+      )}
       <EuiFlexGroup direction="column">
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -12,11 +12,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
   EuiSuperSelect,
   EuiSuperSelectOption,
   EuiText,
@@ -31,6 +26,7 @@ import {
   useAppDispatch,
 } from '../../../../store';
 import { getDataSourceId } from '../../../../utils/utils';
+import { EditQueryModal } from './edit_query_modal';
 
 interface ConfigureSearchRequestProps {
   setQuery: (query: string) => void;
@@ -87,35 +83,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
 
   return (
     <>
-      {isEditModalOpen && (
-        <EuiModal
-          onClose={() => setIsEditModalOpen(false)}
-          style={{ width: '70vw' }}
-        >
-          <EuiModalHeader>
-            <EuiModalHeaderTitle>
-              <p>{`Edit query`}</p>
-            </EuiModalHeaderTitle>
-          </EuiModalHeader>
-          <EuiModalBody>
-            <JsonField
-              label="Query"
-              fieldPath={'search.request'}
-              editorHeight="25vh"
-              readOnly={false}
-            />
-          </EuiModalBody>
-          <EuiModalFooter>
-            <EuiButton
-              onClick={() => setIsEditModalOpen(false)}
-              fill={false}
-              color="primary"
-            >
-              Close
-            </EuiButton>
-          </EuiModalFooter>
-        </EuiModal>
-      )}
+      {isEditModalOpen && <EditQueryModal setModalOpen={setIsEditModalOpen} />}
       <EuiFlexGroup direction="column">
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -25,15 +25,13 @@ import {
 } from '../../../../../common';
 
 interface EditQueryModalProps {
+  queryFieldPath: string;
   setModalOpen(isOpen: boolean): void;
 }
 
 /**
- * Specialized component to render the text chunking ingest processor. The list of optional
- * params we display is dependent on the source algorithm that is chosen. Internally, we persist
- * all of the params, but only choose the relevant ones when constructing the final ingest processor
- * template. This is to minimize the amount of ui config / form / schema updates we would need
- * to do if we only persisted the subset of optional params specific to the currently-chosen algorithm.
+ * Basic modal for configuring a query. Provides a dropdown to select from
+ * a set of pre-defined queries targeted for different use cases.
  */
 export function EditQueryModal(props: EditQueryModalProps) {
   // Form state
@@ -48,7 +46,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
   useEffect(() => {
     setQueryPreset(
       QUERY_PRESETS.find(
-        (preset) => preset.query === getIn(values, 'search.request')
+        (preset) => preset.query === getIn(values, props.queryFieldPath)
       )?.name
     );
   }, []);
@@ -86,7 +84,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
           onChange={(option: string) => {
             setQueryPreset(option);
             setFieldValue(
-              'search.request',
+              props.queryFieldPath,
               QUERY_PRESETS.find((preset) => preset.name === option)?.query
             );
           }}
@@ -95,7 +93,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
         <EuiSpacer size="s" />
         <JsonField
           label="Query"
-          fieldPath={'search.request'}
+          fieldPath={props.queryFieldPath}
           editorHeight="25vh"
           readOnly={false}
         />

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { useFormikContext } from 'formik';
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiSuperSelect,
+  EuiSuperSelectOption,
+  EuiText,
+} from '@elastic/eui';
+import { JsonField } from '../input_fields';
+import { WorkflowFormValues, customStringify } from '../../../../../common';
+
+interface EditQueryModalProps {
+  setModalOpen(isOpen: boolean): void;
+}
+
+type QueryPreset = {
+  name: string;
+  query: string;
+};
+
+const QUERY_PRESETS = [
+  {
+    name: 'Semantic search',
+    query: customStringify({
+      _source: {
+        excludes: [`{{vector_field}}`],
+      },
+      query: {
+        neural: {
+          [`{{vector_field}}`]: {
+            query_text: `{{query_text}}`,
+            model_id: `{{model_id}}`,
+            k: 100,
+          },
+        },
+      },
+    }),
+  },
+] as QueryPreset[];
+
+/**
+ * Specialized component to render the text chunking ingest processor. The list of optional
+ * params we display is dependent on the source algorithm that is chosen. Internally, we persist
+ * all of the params, but only choose the relevant ones when constructing the final ingest processor
+ * template. This is to minimize the amount of ui config / form / schema updates we would need
+ * to do if we only persisted the subset of optional params specific to the currently-chosen algorithm.
+ */
+export function EditQueryModal(props: EditQueryModalProps) {
+  // Form state
+  const { setFieldValue } = useFormikContext<WorkflowFormValues>();
+
+  // selected preset state
+  const [queryPreset, setQueryPreset] = useState<string | undefined>(undefined);
+
+  return (
+    <EuiModal
+      onClose={() => props.setModalOpen(false)}
+      style={{ width: '70vw' }}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Edit query`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText color="subdued">
+          Start with a preset or enter manually.
+        </EuiText>{' '}
+        <EuiSpacer size="s" />
+        <EuiSuperSelect
+          options={QUERY_PRESETS.map(
+            (preset: QueryPreset) =>
+              ({
+                value: preset.name,
+                inputDisplay: (
+                  <>
+                    <EuiText size="s">{preset.name}</EuiText>
+                  </>
+                ),
+                dropdownDisplay: <EuiText size="s">{preset.name}</EuiText>,
+                disabled: false,
+              } as EuiSuperSelectOption<string>)
+          )}
+          valueOfSelected={queryPreset || ''}
+          onChange={(option: string) => {
+            setQueryPreset(option);
+            setFieldValue(
+              'search.request',
+              QUERY_PRESETS.find((preset) => preset.name === option)?.query
+            );
+          }}
+          isInvalid={false}
+        />
+        <EuiSpacer size="s" />
+        <JsonField
+          label="Query"
+          fieldPath={'search.request'}
+          editorHeight="25vh"
+          readOnly={false}
+        />
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton
+          onClick={() => props.setModalOpen(false)}
+          fill={false}
+          color="primary"
+        >
+          Close
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { getIn, useFormikContext } from 'formik';
 import { debounce, isEmpty, isEqual } from 'lodash';
 import {
@@ -814,7 +813,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       <EuiFlexItem grow={false}>
                         <EuiButton
                           disabled={
-                            isRunningSearch || isProposingNoSearchResources
+                            isRunningSearch ||
+                            (isProposingNoSearchResources &&
+                              hasProvisionedSearchResources(props.workflow))
                           }
                           isLoading={isRunningSearch}
                           fill={false}

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -30,7 +30,7 @@ import {
   searchWorkflows,
   useAppDispatch,
 } from '../../../store';
-import { FETCH_ALL_QUERY_BODY, Workflow } from '../../../../common';
+import { FETCH_ALL_QUERY, Workflow } from '../../../../common';
 import { WORKFLOWS_TAB } from '../workflows';
 import { getDataSourceId } from '../../../utils/utils';
 
@@ -151,7 +151,7 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
                 const { workflow } = result;
                 dispatch(
                   searchWorkflows({
-                    apiBody: FETCH_ALL_QUERY_BODY,
+                    apiBody: FETCH_ALL_QUERY,
                     dataSourceId,
                   })
                 );

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -118,8 +118,6 @@ function fetchEmptyMetadata(): UIState {
 }
 
 function fetchSemanticSearchMetadata(): UIState {
-  // We can reuse the base state. Only need to override a few things,
-  // such as preset ingest processors.
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.SEMANTIC_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
@@ -134,8 +132,6 @@ function fetchSemanticSearchMetadata(): UIState {
 }
 
 function fetchMultimodalSearchMetadata(): UIState {
-  // We can reuse the base state. Only need to override a few things,
-  // such as preset ingest processors.
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.MULTIMODAL_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
@@ -150,8 +146,6 @@ function fetchMultimodalSearchMetadata(): UIState {
 }
 
 function fetchHybridSearchMetadata(): UIState {
-  // We can reuse the base state. Only need to override a few things,
-  // such as preset ingest processors.
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.HYBRID_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -11,8 +11,11 @@ import {
   DEFAULT_NEW_WORKFLOW_NAME,
   UIState,
   WORKFLOW_TYPE,
-  FETCH_ALL_QUERY_BODY,
+  FETCH_ALL_QUERY,
   customStringify,
+  SEMANTIC_SEARCH_QUERY,
+  MULTIMODAL_SEARCH_QUERY,
+  HYBRID_SEARCH_QUERY,
 } from '../../../../common';
 import { generateId } from '../../../utils';
 
@@ -26,7 +29,14 @@ export function enrichPresetWorkflowWithUiMetadata(
       uiMetadata = fetchSemanticSearchMetadata();
       break;
     }
-    // TODO: add more presets
+    case WORKFLOW_TYPE.MULTIMODAL_SEARCH: {
+      uiMetadata = fetchMultimodalSearchMetadata();
+      break;
+    }
+    case WORKFLOW_TYPE.HYBRID_SEARCH: {
+      uiMetadata = fetchHybridSearchMetadata();
+      break;
+    }
     default: {
       uiMetadata = fetchEmptyMetadata();
       break;
@@ -83,7 +93,7 @@ function fetchEmptyMetadata(): UIState {
         request: {
           id: 'request',
           type: 'json',
-          value: customStringify(FETCH_ALL_QUERY_BODY),
+          value: customStringify(FETCH_ALL_QUERY),
         },
         pipelineName: {
           id: 'pipelineName',
@@ -117,6 +127,39 @@ function fetchSemanticSearchMetadata(): UIState {
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });
+  baseState.config.search.request.value = customStringify(
+    SEMANTIC_SEARCH_QUERY
+  );
+  return baseState;
+}
+
+function fetchMultimodalSearchMetadata(): UIState {
+  // We can reuse the base state. Only need to override a few things,
+  // such as preset ingest processors.
+  let baseState = fetchEmptyMetadata();
+  baseState.type = WORKFLOW_TYPE.MULTIMODAL_SEARCH;
+  baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
+  baseState.config.ingest.index.name.value = 'my-knn-index';
+  baseState.config.ingest.index.settings.value = customStringify({
+    [`index.knn`]: true,
+  });
+  baseState.config.search.request.value = customStringify(
+    MULTIMODAL_SEARCH_QUERY
+  );
+  return baseState;
+}
+
+function fetchHybridSearchMetadata(): UIState {
+  // We can reuse the base state. Only need to override a few things,
+  // such as preset ingest processors.
+  let baseState = fetchEmptyMetadata();
+  baseState.type = WORKFLOW_TYPE.HYBRID_SEARCH;
+  baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
+  baseState.config.ingest.index.name.value = 'my-knn-index';
+  baseState.config.ingest.index.settings.value = customStringify({
+    [`index.knn`]: true,
+  });
+  baseState.config.search.request.value = customStringify(HYBRID_SEARCH_QUERY);
   return baseState;
 }
 

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -52,6 +52,16 @@ const filterOptions = [
   } as EuiFilterSelectItem,
   // @ts-ignore
   {
+    name: WORKFLOW_TYPE.MULTIMODAL_SEARCH,
+    checked: 'on',
+  } as EuiFilterSelectItem,
+  // @ts-ignore
+  {
+    name: WORKFLOW_TYPE.HYBRID_SEARCH,
+    checked: 'on',
+  } as EuiFilterSelectItem,
+  // @ts-ignore
+  {
     name: WORKFLOW_TYPE.CUSTOM,
     checked: 'on',
   } as EuiFilterSelectItem,

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -25,7 +25,7 @@ import { WorkflowList } from './workflow_list';
 import { NewWorkflow } from './new_workflow';
 import { AppState, searchWorkflows, useAppDispatch } from '../../store';
 import { EmptyListMessage } from './empty_list_message';
-import { FETCH_ALL_QUERY_BODY, SEARCH_STUDIO } from '../../../common';
+import { FETCH_ALL_QUERY, SEARCH_STUDIO } from '../../../common';
 import { ImportWorkflowModal } from './import_workflow';
 import { MountPoint } from '../../../../../src/core/public';
 import { DataSourceSelectableConfig } from '../../../../../src/plugins/data_source_management/public';
@@ -119,7 +119,7 @@ export function Workflows(props: WorkflowsProps) {
     if (selectedTabId === WORKFLOWS_TAB.MANAGE) {
       dispatch(
         searchWorkflows({
-          apiBody: FETCH_ALL_QUERY_BODY,
+          apiBody: FETCH_ALL_QUERY,
           dataSourceId: dataSourceId,
         })
       );
@@ -141,7 +141,7 @@ export function Workflows(props: WorkflowsProps) {
   useEffect(() => {
     dispatch(
       searchWorkflows({
-        apiBody: FETCH_ALL_QUERY_BODY,
+        apiBody: FETCH_ALL_QUERY,
         dataSourceId: dataSourceId,
       })
     );
@@ -161,7 +161,7 @@ export function Workflows(props: WorkflowsProps) {
     }
     dispatch(
       searchWorkflows({
-        apiBody: FETCH_ALL_QUERY_BODY,
+        apiBody: FETCH_ALL_QUERY,
         dataSourceId: dataSourceId,
       })
     );

--- a/server/resources/templates/hybrid_search.json
+++ b/server/resources/templates/hybrid_search.json
@@ -1,0 +1,14 @@
+{
+    "name": "Hybrid Search",
+    "description": "A basic workflow containing the ingest pipeline and index configurations for performing hybrid search",
+    "version": {
+        "template": "1.0.0",
+        "compatibility": [
+            "2.17.0",
+            "3.0.0"
+        ]
+    },
+    "ui_metadata": {
+        "type": "Hybrid search"
+    }
+}

--- a/server/resources/templates/multimodal_search.json
+++ b/server/resources/templates/multimodal_search.json
@@ -1,0 +1,14 @@
+{
+    "name": "Multimodal Search",
+    "description": "A basic workflow containing the ingest pipeline and index configurations for performing multimodal search",
+    "version": {
+        "template": "1.0.0",
+        "compatibility": [
+            "2.17.0",
+            "3.0.0"
+        ]
+    },
+    "ui_metadata": {
+        "type": "Multimodal search"
+    }
+}


### PR DESCRIPTION
### Description

This PR is a start to improve the user experience for existing, basic neural-search-variation use cases:
1. Onboards hybrid and multimodal use cases as options
2. Provides preset, sample queries for users to use. Currently just basic ones for each use case.

More details:
- sets up and defines constants for some basic queries using the `neural` clause based on different use cases
- refactors the query editing modal into a standalone `EditQueryModal` component to separately handle state
- minor tune to the `Run query` button to allow it to run, even if no search processors are defined
- basic preset UI config logic in `new_workflow/utils` for the new use cases, including setting the default query
- adds filters for the new use case types in the workflow list page

Notes:
- the hybrid query use case should have a normalization processor set by default. This is a complex processor not yet onboarded as an option yet, will be done in a separate PR
- depending on final UX, may have some more automated logic around populating some of the placeholders in the preset queries and/or expanding the number of preset queries per use case. This may also mean some dynamic form inputs for users to fill in placeholders, and let the frontend handle generation of the final query.

Demo video, showing the different use cases, and the added dropdown in the "Edit query" modal to select from some presets. For preset use cases, they are set by default.

[screen-capture (1).webm](https://github.com/user-attachments/assets/a34dfe4d-fd3f-449b-9055-029e99b5560c)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
