### PR TITLE
General form improvements

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QueryPreset, WORKFLOW_STATE } from './interfaces';
+import { MapEntry, QueryPreset, WORKFLOW_STATE } from './interfaces';
 import { customStringify } from './utils';
 
 export const PLUGIN_ID = 'flow-framework';
@@ -254,6 +254,7 @@ export const MAX_STRING_LENGTH = 100;
 export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
+export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
 
 export enum PROCESSOR_CONTEXT {
   INGEST = 'ingest',

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -6,13 +6,14 @@
 import React from 'react';
 import {
   EuiAccordion,
-  EuiButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
   EuiLink,
   EuiPanel,
+  EuiSmallButton,
+  EuiSmallButtonEmpty,
   EuiText,
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
@@ -48,7 +49,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
 
   // Adding a map to the end of the existing arr
   function addMap(curMapArray: MapArrayFormValue): void {
-    setFieldValue(props.fieldPath, [...curMapArray, []]);
+    setFieldValue(props.fieldPath, [...curMapArray, [{ key: '', value: '' }]]);
     setFieldTouched(props.fieldPath, true);
     if (props.onMapAdd) {
       props.onMapAdd(curMapArray);
@@ -94,7 +95,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
               getIn(touched, field.name).length > 0
             }
           >
-            <EuiFlexGroup direction="column">
+            <EuiFlexGroup direction="column" gutterSize="none">
               {field.value?.map((mapping: MapEntry, idx: number) => {
                 return (
                   <EuiFlexItem key={idx}>
@@ -114,6 +115,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
                           }}
                         />
                       }
+                      initialIsOpen={true}
                     >
                       <EuiPanel grow={true}>
                         <MapField
@@ -130,14 +132,24 @@ export function MapArrayField(props: MapArrayFieldProps) {
               })}
               <EuiFlexItem grow={false}>
                 <div>
-                  <EuiButton
-                    size="s"
-                    onClick={() => {
-                      addMap(field.value);
-                    }}
-                  >
-                    {field.value?.length > 0 ? 'Add another map' : 'Add map'}
-                  </EuiButton>
+                  <>
+                    {field.value?.length === 0 ? (
+                      <EuiSmallButton
+                        onClick={() => {
+                          addMap(field.value);
+                        }}
+                      >
+                        {'Configure'}
+                      </EuiSmallButton>
+                    ) : (
+                      <EuiSmallButtonEmpty
+                        style={{ marginLeft: '-8px', marginTop: '-4px' }}
+                        onClick={() => {
+                          addMap(field.value);
+                        }}
+                      >{`(Advanced) Configure multiple`}</EuiSmallButtonEmpty>
+                    )}
+                  </>
                 </div>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import {
-  EuiButton,
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -13,6 +12,7 @@ import {
   EuiIcon,
   EuiLink,
   EuiText,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
@@ -164,16 +164,13 @@ export function MapField(props: MapFieldProps) {
               })}
               <EuiFlexItem grow={false}>
                 <div>
-                  <EuiButton
-                    size="s"
+                  <EuiSmallButton
                     onClick={() => {
                       addMapEntry(field.value);
                     }}
                   >
-                    {field.value?.length > 0
-                      ? 'Add another field mapping'
-                      : 'Add field mapping'}
-                  </EuiButton>
+                    {field.value?.length > 0 ? 'Add more' : 'Add field mapping'}
+                  </EuiSmallButton>
                 </div>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -7,7 +7,6 @@ import React, { useState } from 'react';
 import { useFormikContext, getIn } from 'formik';
 import { isEmpty } from 'lodash';
 import {
-  EuiButton,
   EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,6 +17,7 @@ import {
   EuiModalHeaderTitle,
   EuiSelect,
   EuiSelectOption,
+  EuiSmallButton,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -100,7 +100,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
           <EuiFlexItem>
             <>
               <EuiText>Expected input</EuiText>
-              <EuiButton
+              <EuiSmallButton
                 style={{ width: '100px' }}
                 onClick={async () => {
                   switch (props.context) {
@@ -207,7 +207,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 }}
               >
                 Fetch
-              </EuiButton>
+              </EuiSmallButton>
               <EuiSpacer size="s" />
               <EuiCodeEditor
                 mode="json"
@@ -230,16 +230,13 @@ export function InputTransformModal(props: InputTransformModalProps) {
           <EuiFlexItem>
             <>
               <EuiText>Define transform</EuiText>
-              <EuiText size="s" color="subdued">
-                {`Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
-                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-              </EuiText>
               <EuiSpacer size="s" />
               <MapArrayField
                 field={props.inputMapField}
                 fieldPath={props.inputMapFieldPath}
                 label="Input Map"
-                helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
+                helpText={`An array specifying how to map fields from the ingested document to the model’s input. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
+                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
                 valuePlaceholder={
@@ -278,7 +275,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 }}
               />
               <EuiSpacer size="s" />
-              <EuiButton
+              <EuiSmallButton
                 style={{ width: '100px' }}
                 disabled={isEmpty(map) || isEmpty(JSON.parse(sourceInput))}
                 onClick={async () => {
@@ -306,7 +303,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 }}
               >
                 Generate
-              </EuiButton>
+              </EuiSmallButton>
               <EuiSpacer size="s" />
               <EuiCodeEditor
                 mode="json"
@@ -329,9 +326,9 @@ export function InputTransformModal(props: InputTransformModalProps) {
         </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiButton onClick={props.onClose} fill={false} color="primary">
+        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -213,16 +213,13 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="s" />
-          <EuiText size="s" color="subdued">
-            {`Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
-                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-          </EuiText>
           <EuiSpacer size="s" />
           <MapArrayField
             field={inputMapField}
             fieldPath={inputMapFieldPath}
             label="Input Map"
-            helpText={`An array specifying how to map fields from the ingested document to the model’s input.`}
+            helpText={`An array specifying how to map fields from the ingested document to the model’s input. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
+            root object selector "${JSONPATH_ROOT_SELECTOR}"`}
             helpLink={ML_INFERENCE_DOCS_LINK}
             keyPlaceholder="Model input field"
             valuePlaceholder={
@@ -270,7 +267,8 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             field={outputMapField}
             fieldPath={outputMapFieldPath}
             label="Output Map"
-            helpText={`An array specifying how to map the model’s output to new document fields.`}
+            helpText={`An array specifying how to map the model’s output to new document fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
+            root object selector "${JSONPATH_ROOT_SELECTOR}"`}
             helpLink={ML_INFERENCE_DOCS_LINK}
             keyPlaceholder={
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -7,7 +7,6 @@ import React, { useState } from 'react';
 import { useFormikContext, getIn } from 'formik';
 import { cloneDeep, isEmpty, set } from 'lodash';
 import {
-  EuiButton,
   EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,6 +17,7 @@ import {
   EuiModalHeaderTitle,
   EuiSelect,
   EuiSelectOption,
+  EuiSmallButton,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -97,7 +97,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
           <EuiFlexItem>
             <>
               <EuiText>Expected input</EuiText>
-              <EuiButton
+              <EuiSmallButton
                 style={{ width: '100px' }}
                 onClick={async () => {
                   switch (props.context) {
@@ -200,7 +200,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 }}
               >
                 Fetch
-              </EuiButton>
+              </EuiSmallButton>
               <EuiSpacer size="s" />
               <EuiCodeEditor
                 mode="json"
@@ -223,16 +223,13 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
           <EuiFlexItem>
             <>
               <EuiText>Define transform</EuiText>
-              <EuiText size="s" color="subdued">
-                {`Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
-                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-              </EuiText>
               <EuiSpacer size="s" />
               <MapArrayField
                 field={props.outputMapField}
                 fieldPath={props.outputMapFieldPath}
                 label="Output Map"
-                helpText={`An array specifying how to map the model’s output to new fields.`}
+                helpText={`An array specifying how to map the model’s output to new fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
+                root object selector "${JSONPATH_ROOT_SELECTOR}"`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Document field"
                 valuePlaceholder="Model output field"
@@ -267,7 +264,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 }}
               />
               <EuiSpacer size="s" />
-              <EuiButton
+              <EuiSmallButton
                 style={{ width: '100px' }}
                 disabled={isEmpty(map) || isEmpty(JSON.parse(sourceInput))}
                 onClick={async () => {
@@ -295,7 +292,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 }}
               >
                 Generate
-              </EuiButton>
+              </EuiSmallButton>
               <EuiSpacer size="s" />
               <EuiCodeEditor
                 mode="json"
@@ -318,9 +315,9 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
         </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiButton onClick={props.onClose} fill={false} color="primary">
+        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -3,19 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
-import { getIn, useFormikContext } from 'formik';
+import React, { useState } from 'react';
+import { useFormikContext } from 'formik';
 import {
+  EuiSmallButton,
   EuiButton,
+  EuiContextMenu,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
+  EuiPopover,
   EuiSpacer,
-  EuiSuperSelect,
-  EuiSuperSelectOption,
-  EuiText,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -35,21 +35,10 @@ interface EditQueryModalProps {
  */
 export function EditQueryModal(props: EditQueryModalProps) {
   // Form state
-  const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
+  const { setFieldValue } = useFormikContext<WorkflowFormValues>();
 
-  // selected preset state
-  const [queryPreset, setQueryPreset] = useState<string | undefined>(undefined);
-
-  // if the current query matches some preset, display the preset name as the selected
-  // option in the dropdown. only execute when first rendering so it isn't triggered
-  // when users are updating the underlying value in the JSON editor.
-  useEffect(() => {
-    setQueryPreset(
-      QUERY_PRESETS.find(
-        (preset) => preset.query === getIn(values, props.queryFieldPath)
-      )?.name
-    );
-  }, []);
+  // popover state
+  const [popoverOpen, setPopoverOpen] = useState<boolean>(false);
 
   return (
     <EuiModal
@@ -62,34 +51,33 @@ export function EditQueryModal(props: EditQueryModalProps) {
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        <EuiText color="subdued">
-          Start with a preset or enter manually.
-        </EuiText>{' '}
-        <EuiSpacer size="s" />
-        <EuiSuperSelect
-          options={QUERY_PRESETS.map(
-            (preset: QueryPreset) =>
-              ({
-                value: preset.name,
-                inputDisplay: (
-                  <>
-                    <EuiText size="s">{preset.name}</EuiText>
-                  </>
-                ),
-                dropdownDisplay: <EuiText size="s">{preset.name}</EuiText>,
-                disabled: false,
-              } as EuiSuperSelectOption<string>)
-          )}
-          valueOfSelected={queryPreset || ''}
-          onChange={(option: string) => {
-            setQueryPreset(option);
-            setFieldValue(
-              props.queryFieldPath,
-              QUERY_PRESETS.find((preset) => preset.name === option)?.query
-            );
-          }}
-          isInvalid={false}
-        />
+        <EuiPopover
+          button={
+            <EuiSmallButton onClick={() => setPopoverOpen(!popoverOpen)}>
+              Choose from a preset
+            </EuiSmallButton>
+          }
+          isOpen={popoverOpen}
+          closePopover={() => setPopoverOpen(false)}
+          anchorPosition="downLeft"
+        >
+          <EuiContextMenu
+            initialPanelId={0}
+            panels={[
+              {
+                id: 0,
+                items: QUERY_PRESETS.map((preset: QueryPreset) => ({
+                  name: preset.name,
+                  onClick: () => {
+                    setFieldValue(props.queryFieldPath, preset.query);
+                    setPopoverOpen(false);
+                  },
+                  size: 's',
+                })),
+              },
+            ]}
+          />
+        </EuiPopover>
         <EuiSpacer size="s" />
         <JsonField
           label="Query"


### PR DESCRIPTION
### Description

This PR improves the form inputs in 2 places:
1. Hides the multi-prediction feature unless the user explicitly wants to. In general, a single prediction configuration in the ML processors are sufficient.
2. Changes the preset query selector from a super select, to a popover button. This is so we don't persist state after users begin editing/updating the query. For example, a user could select "semantic search" preset, edit it, and before, the dropdown would still show "semantic search", even if the query had been changed entirely to something else. The new flow is a stateless button to select from a starting preset, and nothing more

More details:
- adds states in `MapArrayField` to dynamically render based on if there is 0 maps, a single map, a single map with no entries, and multiple maps. For example, we show the same view if there is no maps, or a single map with no entries.
- minor word updates and removing the extra helper text to try to simplify the amount of information viewed at once
- moves some button components into the preferred compact/small versions
- changing the query selector from a super select to a context menu and popover

Demo video, showing the simplified view when editing ML processor input map / output maps, and the new preset query selector:

[screen-capture (2).webm](https://github.com/user-attachments/assets/1da1d24e-474f-4e65-bee4-44fd9166acde)

### Issues Resolved

Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
