### PR TITLE
Add quick-create fields in the create flow and form pre-population

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -146,8 +146,14 @@ export const DELIMITER_OPTIONAL_FIELDS = ['delimiter'];
 export const SHARED_OPTIONAL_FIELDS = ['max_chunk_limit', 'description', 'tag'];
 
 /**
- * QUERIES
+ * QUERY PRESETS
  */
+export const VECTOR_FIELD_PATTERN = `{{vector_field}}`;
+export const TEXT_FIELD_PATTERN = `{{text_field}}`;
+export const QUERY_TEXT_PATTERN = `{{query_text}}`;
+export const QUERY_IMAGE_PATTERN = `{{query_image}}`;
+export const MODEL_ID_PATTERN = `{{model_id}}`;
+
 export const FETCH_ALL_QUERY = {
   query: {
     match_all: {},
@@ -156,13 +162,13 @@ export const FETCH_ALL_QUERY = {
 };
 export const SEMANTIC_SEARCH_QUERY = {
   _source: {
-    excludes: [`{{vector_field}}`],
+    excludes: [VECTOR_FIELD_PATTERN],
   },
   query: {
     neural: {
-      [`{{vector_field}}`]: {
-        query_text: `{{query_text}}`,
-        model_id: `{{model_id}}`,
+      [VECTOR_FIELD_PATTERN]: {
+        query_text: QUERY_TEXT_PATTERN,
+        model_id: MODEL_ID_PATTERN,
         k: 100,
       },
     },
@@ -170,14 +176,14 @@ export const SEMANTIC_SEARCH_QUERY = {
 };
 export const MULTIMODAL_SEARCH_QUERY = {
   _source: {
-    excludes: [`{{vector_field}}`],
+    excludes: [VECTOR_FIELD_PATTERN],
   },
   query: {
     neural: {
-      [`{{vector_field}}`]: {
-        query_text: `{{query_text}}`,
-        query_image: `{{query_image}}`,
-        model_id: `{{model_id}}`,
+      [VECTOR_FIELD_PATTERN]: {
+        query_text: QUERY_TEXT_PATTERN,
+        query_image: QUERY_IMAGE_PATTERN,
+        model_id: MODEL_ID_PATTERN,
         k: 100,
       },
     },
@@ -185,23 +191,23 @@ export const MULTIMODAL_SEARCH_QUERY = {
 };
 export const HYBRID_SEARCH_QUERY = {
   _source: {
-    excludes: [`{{vector_field}}`],
+    excludes: [VECTOR_FIELD_PATTERN],
   },
   query: {
     hybrid: {
       queries: [
         {
           match: {
-            [`{{text_field}}`]: {
-              query: `{{query_text}}`,
+            [TEXT_FIELD_PATTERN]: {
+              query: QUERY_TEXT_PATTERN,
             },
           },
         },
         {
           neural: {
-            [`{{vector_field}}`]: {
-              query_text: `{{query_text}}`,
-              model_id: `{{model_id}}`,
+            [VECTOR_FIELD_PATTERN]: {
+              query_text: QUERY_TEXT_PATTERN,
+              model_id: MODEL_ID_PATTERN,
               k: 5,
             },
           },

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -463,6 +463,9 @@ export type QueryPreset = {
 
 export type QuickConfigureFields = {
   embeddingModelId?: string;
+  vectorField?: string;
+  textField?: string;
+  embeddingLength?: number;
 };
 
 /**

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -461,6 +461,10 @@ export type QueryPreset = {
   query: string;
 };
 
+export type QuickConfigureFields = {
+  embeddingModelId?: string;
+};
+
 /**
  ********** OPENSEARCH TYPES/INTERFACES ************
  */

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -72,7 +72,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                     setFieldValue(props.queryFieldPath, preset.query);
                     setPopoverOpen(false);
                   },
-                  size: 's',
+                  size: 'full',
                 })),
               },
             ]}

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -14,9 +14,19 @@ import {
 } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import { UseCase } from './use_case';
-import { Workflow, WorkflowTemplate } from '../../../../common';
-import { AppState, useAppDispatch, getWorkflowPresets } from '../../../store';
+import {
+  FETCH_ALL_QUERY,
+  Workflow,
+  WorkflowTemplate,
+} from '../../../../common';
+import {
+  AppState,
+  useAppDispatch,
+  getWorkflowPresets,
+  searchModels,
+} from '../../../store';
 import { enrichPresetWorkflowWithUiMetadata } from './utils';
+import { getDataSourceId } from '../../../utils';
 
 interface NewWorkflowProps {}
 
@@ -27,6 +37,7 @@ interface NewWorkflowProps {}
  */
 export function NewWorkflow(props: NewWorkflowProps) {
   const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
 
   // workflows state
   const { presetWorkflows, loading } = useSelector(
@@ -43,9 +54,13 @@ export function NewWorkflow(props: NewWorkflowProps) {
     setSearchQuery(query);
   }, 200);
 
-  // initial state
+  // on initial load:
+  // 1. fetch the workflow presets persisted on server-side
+  // 2. fetch the ML models. these may be used in quick-create views when selecting a preset,
+  //    so we optimize by fetching once at the top-level here.
   useEffect(() => {
     dispatch(getWorkflowPresets());
+    dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
   }, []);
 
   // initial hook to populate all workflows

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -127,7 +127,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <EuiCompressedFormRow
               label={'Vector field'}
               isInvalid={false}
-              helpText="The name of the document vield containing the vector embedding"
+              helpText="The name of the document field containing the vector embedding"
             >
               <EuiCompressedFieldText
                 value={fieldValues?.vectorField || ''}
@@ -143,7 +143,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <EuiCompressedFormRow
               label={'Embedding length'}
               isInvalid={false}
-              helpText="The length of the generated vector embeddings"
+              helpText="The length / dimension of the generated vector embeddings"
             >
               <EuiCompressedFieldNumber
                 value={fieldValues?.embeddingLength || ''}

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -11,6 +11,9 @@ import {
   EuiSpacer,
   EuiCompressedSuperSelect,
   EuiSuperSelectOption,
+  EuiAccordion,
+  EuiCompressedFieldText,
+  EuiCompressedFieldNumber,
 } from '@elastic/eui';
 import {
   MODEL_STATE,
@@ -52,68 +55,109 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
     props.setFields(fieldValues);
   }, [fieldValues]);
 
-  // reusable embedding model selector component
-  function EmbeddingModelSelector() {
-    return (
-      <EuiCompressedFormRow
-        label={'Embedding model'}
-        error={'Invalid'}
-        isInvalid={false}
-      >
-        <EuiCompressedSuperSelect
-          options={deployedModels.map(
-            (option) =>
-              ({
-                value: option.id,
-                inputDisplay: (
-                  <>
-                    <EuiText size="s">{option.name}</EuiText>
-                  </>
-                ),
-                dropdownDisplay: (
-                  <>
-                    <EuiText size="s">{option.name}</EuiText>
-                    <EuiText size="xs" color="subdued">
-                      Deployed
-                    </EuiText>
-                    <EuiText size="xs" color="subdued">
-                      {option.algorithm}
-                    </EuiText>
-                  </>
-                ),
-                disabled: false,
-              } as EuiSuperSelectOption<string>)
-          )}
-          valueOfSelected={fieldValues?.embeddingModelId || ''}
-          onChange={(option: string) => {
-            setFieldValues({
-              ...fieldValues,
-              embeddingModelId: option,
-            });
-          }}
-          isInvalid={false}
-        />
-      </EuiCompressedFormRow>
-    );
-  }
-
-  return (() => {
-    switch (props.workflowType) {
-      case WORKFLOW_TYPE.SEMANTIC_SEARCH:
-      case WORKFLOW_TYPE.MULTIMODAL_SEARCH:
-      case WORKFLOW_TYPE.HYBRID_SEARCH: {
-        return (
-          <>
-            <EmbeddingModelSelector />
+  return (
+    <>
+      {(props.workflowType === WORKFLOW_TYPE.SEMANTIC_SEARCH ||
+        props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH ||
+        props.workflowType === WORKFLOW_TYPE.HYBRID_SEARCH) && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiAccordion
+            id="optionalConfiguration"
+            buttonContent="Optional configuration"
+            initialIsOpen={true}
+          >
+            <EuiSpacer size="m" />
+            <EuiCompressedFormRow
+              label={'Embedding model'}
+              isInvalid={false}
+              helpText="The model to generate embeddings"
+            >
+              <EuiCompressedSuperSelect
+                options={deployedModels.map(
+                  (option) =>
+                    ({
+                      value: option.id,
+                      inputDisplay: (
+                        <>
+                          <EuiText size="s">{option.name}</EuiText>
+                        </>
+                      ),
+                      dropdownDisplay: (
+                        <>
+                          <EuiText size="s">{option.name}</EuiText>
+                          <EuiText size="xs" color="subdued">
+                            Deployed
+                          </EuiText>
+                          <EuiText size="xs" color="subdued">
+                            {option.algorithm}
+                          </EuiText>
+                        </>
+                      ),
+                      disabled: false,
+                    } as EuiSuperSelectOption<string>)
+                )}
+                valueOfSelected={fieldValues?.embeddingModelId || ''}
+                onChange={(option: string) => {
+                  setFieldValues({
+                    ...fieldValues,
+                    embeddingModelId: option,
+                  });
+                }}
+                isInvalid={false}
+              />
+            </EuiCompressedFormRow>
             <EuiSpacer size="s" />
-          </>
-        );
-      }
-      case WORKFLOW_TYPE.CUSTOM:
-      case undefined:
-      default: {
-        return <></>;
-      }
-    }
-  })();
+            <EuiCompressedFormRow
+              label={'Text field'}
+              isInvalid={false}
+              helpText="The name of the document field containing plaintext"
+            >
+              <EuiCompressedFieldText
+                value={fieldValues?.textField || ''}
+                onChange={(e) => {
+                  setFieldValues({
+                    ...fieldValues,
+                    textField: e.target.value,
+                  });
+                }}
+              />
+            </EuiCompressedFormRow>
+            <EuiSpacer size="s" />
+            <EuiCompressedFormRow
+              label={'Vector field'}
+              isInvalid={false}
+              helpText="The name of the document vield containing the vector embedding"
+            >
+              <EuiCompressedFieldText
+                value={fieldValues?.vectorField || ''}
+                onChange={(e) => {
+                  setFieldValues({
+                    ...fieldValues,
+                    vectorField: e.target.value,
+                  });
+                }}
+              />
+            </EuiCompressedFormRow>
+            <EuiSpacer size="s" />
+            <EuiCompressedFormRow
+              label={'Embedding length'}
+              isInvalid={false}
+              helpText="The length of the generated vector embeddings"
+            >
+              <EuiCompressedFieldNumber
+                value={fieldValues?.embeddingLength || ''}
+                onChange={(e) => {
+                  setFieldValues({
+                    ...fieldValues,
+                    embeddingLength: Number(e.target.value),
+                  });
+                }}
+              />
+            </EuiCompressedFormRow>
+          </EuiAccordion>
+        </>
+      )}
+    </>
+  );
 }

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  EuiCompressedFormRow,
+  EuiText,
+  EuiSpacer,
+  EuiCompressedSuperSelect,
+  EuiSuperSelectOption,
+} from '@elastic/eui';
+import {
+  MODEL_STATE,
+  Model,
+  QuickConfigureFields,
+  WORKFLOW_TYPE,
+} from '../../../../common';
+import { AppState } from '../../../store';
+
+interface QuickConfigureInputsProps {
+  workflowType?: WORKFLOW_TYPE;
+  setFields(fields: QuickConfigureFields): void;
+}
+
+// Dynamic component to allow optional input configuration fields for different use cases.
+// Hooks back to the parent component with such field values
+export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
+  const models = useSelector((state: AppState) => state.models.models);
+
+  // Deployed models state
+  const [deployedModels, setDeployedModels] = useState<Model[]>([]);
+
+  // Hook to update available deployed models
+  useEffect(() => {
+    if (models) {
+      setDeployedModels(
+        Object.values(models).filter(
+          (model) => model.state === MODEL_STATE.DEPLOYED
+        )
+      );
+    }
+  }, [models]);
+
+  // Local field values state
+  const [fieldValues, setFieldValues] = useState<QuickConfigureFields>({});
+
+  // Hook to update the parent field values
+  useEffect(() => {
+    props.setFields(fieldValues);
+  }, [fieldValues]);
+
+  // reusable embedding model selector component
+  function EmbeddingModelSelector() {
+    return (
+      <EuiCompressedFormRow
+        label={'Embedding model'}
+        error={'Invalid'}
+        isInvalid={false}
+      >
+        <EuiCompressedSuperSelect
+          options={deployedModels.map(
+            (option) =>
+              ({
+                value: option.id,
+                inputDisplay: (
+                  <>
+                    <EuiText size="s">{option.name}</EuiText>
+                  </>
+                ),
+                dropdownDisplay: (
+                  <>
+                    <EuiText size="s">{option.name}</EuiText>
+                    <EuiText size="xs" color="subdued">
+                      Deployed
+                    </EuiText>
+                    <EuiText size="xs" color="subdued">
+                      {option.algorithm}
+                    </EuiText>
+                  </>
+                ),
+                disabled: false,
+              } as EuiSuperSelectOption<string>)
+          )}
+          valueOfSelected={fieldValues?.embeddingModelId || ''}
+          onChange={(option: string) => {
+            setFieldValues({
+              ...fieldValues,
+              embeddingModelId: option,
+            });
+          }}
+          isInvalid={false}
+        />
+      </EuiCompressedFormRow>
+    );
+  }
+
+  return (() => {
+    switch (props.workflowType) {
+      case WORKFLOW_TYPE.SEMANTIC_SEARCH:
+      case WORKFLOW_TYPE.MULTIMODAL_SEARCH:
+      case WORKFLOW_TYPE.HYBRID_SEARCH: {
+        return (
+          <>
+            <EmbeddingModelSelector />
+            <EuiSpacer size="s" />
+          </>
+        );
+      }
+      case WORKFLOW_TYPE.CUSTOM:
+      case undefined:
+      default: {
+        return <></>;
+      }
+    }
+  })();
+}

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -40,6 +40,9 @@ interface QuickConfigureModalProps {
   onClose(): void;
 }
 
+// Modal to handle workflow creation. Includes a static field to set the workflow name, and
+// an optional set of quick-configure fields, that when populated, help pre-populate
+// some of the detailed workflow configuration.
 export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
@@ -152,7 +155,8 @@ function injectQuickConfigureFields(
 ): Workflow {
   if (workflow.ui_metadata?.type) {
     switch (workflow.ui_metadata?.type) {
-      // Semantic search / hybrid search: set defaults in the ingest processor and preset query
+      // Semantic search / hybrid search: set defaults in the ingest processor, the index mappings,
+      // and the preset query
       case WORKFLOW_TYPE.SEMANTIC_SEARCH:
       case WORKFLOW_TYPE.HYBRID_SEARCH: {
         if (!isEmpty(quickConfigureFields) && workflow.ui_metadata?.config) {

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -16,11 +16,19 @@ import {
   EuiCompressedFieldText,
   EuiCompressedFormRow,
 } from '@elastic/eui';
-import { WORKFLOW_NAME_REGEXP, Workflow } from '../../../../common';
+import {
+  MODEL_ID_PATTERN,
+  QuickConfigureFields,
+  WORKFLOW_NAME_REGEXP,
+  WORKFLOW_TYPE,
+  Workflow,
+} from '../../../../common';
 import { APP_PATH } from '../../../utils';
 import { processWorkflowName } from './utils';
 import { createWorkflow, useAppDispatch } from '../../../store';
 import { constructUrlWithParams, getDataSourceId } from '../../../utils/utils';
+import { QuickConfigureInputs } from './quick_configure_inputs';
+import { isEmpty } from 'lodash';
 
 interface QuickConfigureModalProps {
   workflow: Workflow;
@@ -37,11 +45,15 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
     processWorkflowName(props.workflow.name)
   );
 
+  const [quickConfigureFields, setQuickConfigureFields] = useState<
+    QuickConfigureFields
+  >({});
+
   // is creating state
   const [isCreating, setIsCreating] = useState<boolean>(false);
 
   // custom sanitization on workflow name
-  function isInvalid(name: string): boolean {
+  function isInvalidName(name: string): boolean {
     return (
       name === '' ||
       name.length > 100 ||
@@ -53,14 +65,14 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
     <EuiModal onClose={() => props.onClose()}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Set a unique name for your workflow`}</p>
+          <p>{`Quick configure`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
         <EuiCompressedFormRow
           label={'Name'}
           error={'Invalid name'}
-          isInvalid={isInvalid(workflowName)}
+          isInvalid={isInvalidName(workflowName)}
         >
           <EuiCompressedFieldText
             placeholder={processWorkflowName(props.workflow.name)}
@@ -70,20 +82,30 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
             }}
           />
         </EuiCompressedFormRow>
+        <QuickConfigureInputs
+          workflowType={props.workflow.ui_metadata?.type}
+          setFields={setQuickConfigureFields}
+        />
       </EuiModalBody>
       <EuiModalFooter>
         <EuiSmallButtonEmpty onClick={() => props.onClose()}>
           Cancel
         </EuiSmallButtonEmpty>
         <EuiSmallButton
-          disabled={isInvalid(workflowName) || isCreating}
+          disabled={isInvalidName(workflowName) || isCreating}
           isLoading={isCreating}
           onClick={() => {
             setIsCreating(true);
-            const workflowToCreate = {
+            let workflowToCreate = {
               ...props.workflow,
               name: workflowName,
             };
+            if (!isEmpty(quickConfigureFields)) {
+              workflowToCreate = injectQuickConfigureFields(
+                workflowToCreate,
+                quickConfigureFields
+              );
+            }
             dispatch(
               createWorkflow({
                 apiBody: workflowToCreate,
@@ -116,4 +138,70 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
       </EuiModalFooter>
     </EuiModal>
   );
+}
+
+// helper fn to populate UI config values if there are some quick configure fields available
+function injectQuickConfigureFields(
+  workflow: Workflow,
+  quickConfigureFields: QuickConfigureFields
+): Workflow {
+  if (workflow.ui_metadata?.type) {
+    switch (workflow.ui_metadata?.type) {
+      // Semantic search / hybrid search: set defaults in the ingest processor and preset query
+      case WORKFLOW_TYPE.SEMANTIC_SEARCH:
+      case WORKFLOW_TYPE.HYBRID_SEARCH: {
+        if (
+          !isEmpty(quickConfigureFields.embeddingModelId) &&
+          typeof quickConfigureFields.embeddingModelId === 'string'
+        ) {
+          console.log('entering injection');
+          workflow = updateIngestProcessorConfig(
+            workflow,
+            quickConfigureFields.embeddingModelId
+          );
+          workflow = updateSearchRequestConfig(
+            workflow,
+            quickConfigureFields.embeddingModelId
+          );
+        }
+      }
+      case WORKFLOW_TYPE.CUSTOM:
+      case undefined:
+      default:
+        break;
+    }
+  }
+  return workflow;
+}
+
+// given a model ID, update the ML processor config
+function updateIngestProcessorConfig(
+  workflow: Workflow,
+  modelId: string
+): Workflow {
+  if (workflow.ui_metadata?.config) {
+    workflow.ui_metadata.config.ingest.enrich.processors[0].fields.forEach(
+      (field) => {
+        if (field.id === 'model') {
+          field.value = { id: modelId };
+        }
+      }
+    );
+  }
+  return workflow;
+}
+
+// given a model ID, replace placeholders in the preset query
+function updateSearchRequestConfig(
+  workflow: Workflow,
+  modelId: string
+): Workflow {
+  if (workflow.ui_metadata?.config) {
+    workflow.ui_metadata.config.search.request.value = ((workflow.ui_metadata
+      .config.search.request.value || '') as string).replace(
+      MODEL_ID_PATTERN,
+      modelId
+    );
+  }
+  return workflow;
 }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  EuiSmallButton,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiSmallButtonEmpty,
+  EuiCompressedFieldText,
+  EuiCompressedFormRow,
+} from '@elastic/eui';
+import { WORKFLOW_NAME_REGEXP, Workflow } from '../../../../common';
+import { APP_PATH } from '../../../utils';
+import { processWorkflowName } from './utils';
+import { createWorkflow, useAppDispatch } from '../../../store';
+import { constructUrlWithParams, getDataSourceId } from '../../../utils/utils';
+
+interface QuickConfigureModalProps {
+  workflow: Workflow;
+  onClose(): void;
+}
+
+export function QuickConfigureModal(props: QuickConfigureModalProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+  const history = useHistory();
+
+  // workflow name state
+  const [workflowName, setWorkflowName] = useState<string>(
+    processWorkflowName(props.workflow.name)
+  );
+
+  // is creating state
+  const [isCreating, setIsCreating] = useState<boolean>(false);
+
+  // custom sanitization on workflow name
+  function isInvalid(name: string): boolean {
+    return (
+      name === '' ||
+      name.length > 100 ||
+      WORKFLOW_NAME_REGEXP.test(name) === false
+    );
+  }
+
+  return (
+    <EuiModal onClose={() => props.onClose()}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Set a unique name for your workflow`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiCompressedFormRow
+          label={'Name'}
+          error={'Invalid name'}
+          isInvalid={isInvalid(workflowName)}
+        >
+          <EuiCompressedFieldText
+            placeholder={processWorkflowName(props.workflow.name)}
+            value={workflowName}
+            onChange={(e) => {
+              setWorkflowName(e.target.value);
+            }}
+          />
+        </EuiCompressedFormRow>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButtonEmpty onClick={() => props.onClose()}>
+          Cancel
+        </EuiSmallButtonEmpty>
+        <EuiSmallButton
+          disabled={isInvalid(workflowName) || isCreating}
+          isLoading={isCreating}
+          onClick={() => {
+            setIsCreating(true);
+            const workflowToCreate = {
+              ...props.workflow,
+              name: workflowName,
+            };
+            dispatch(
+              createWorkflow({
+                apiBody: workflowToCreate,
+                dataSourceId,
+              })
+            )
+              .unwrap()
+              .then((result) => {
+                setIsCreating(false);
+                const { workflow } = result;
+                history.replace(
+                  constructUrlWithParams(
+                    APP_PATH.WORKFLOWS,
+
+                    workflow.id,
+                    dataSourceId
+                  )
+                );
+              })
+              .catch((err: any) => {
+                setIsCreating(false);
+                console.error(err);
+              });
+          }}
+          fill={true}
+          color="primary"
+        >
+          Create
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import {
   EuiText,
   EuiFlexGroup,
@@ -13,118 +12,25 @@ import {
   EuiCard,
   EuiHorizontalRule,
   EuiSmallButton,
-  EuiModal,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiSmallButtonEmpty,
-  EuiCompressedFieldText,
-  EuiCompressedFormRow,
 } from '@elastic/eui';
-import { WORKFLOW_NAME_REGEXP, Workflow } from '../../../../common';
-import { APP_PATH } from '../../../utils';
-import { processWorkflowName } from './utils';
-import { createWorkflow, useAppDispatch } from '../../../store';
-import { constructUrlWithParams, getDataSourceId } from '../../../utils/utils';
+import { Workflow } from '../../../../common';
+import { QuickConfigureModal } from './quick_configure_modal';
 
 interface UseCaseProps {
   workflow: Workflow;
 }
 
 export function UseCase(props: UseCaseProps) {
-  const dispatch = useAppDispatch();
-  const dataSourceId = getDataSourceId();
-  const history = useHistory();
-
   // name modal state
   const [isNameModalOpen, setIsNameModalOpen] = useState<boolean>(false);
-
-  // workflow name state
-  const [workflowName, setWorkflowName] = useState<string>(
-    processWorkflowName(props.workflow.name)
-  );
-
-  // is creating state
-  const [isCreating, setIsCreating] = useState<boolean>(false);
-
-  // custom sanitization on workflow name
-  function isInvalid(name: string): boolean {
-    return (
-      name === '' ||
-      name.length > 100 ||
-      WORKFLOW_NAME_REGEXP.test(name) === false
-    );
-  }
 
   return (
     <>
       {isNameModalOpen && (
-        <EuiModal onClose={() => setIsNameModalOpen(false)}>
-          <EuiModalHeader>
-            <EuiModalHeaderTitle>
-              <p>{`Set a unique name for your workflow`}</p>
-            </EuiModalHeaderTitle>
-          </EuiModalHeader>
-          <EuiModalBody>
-            <EuiCompressedFormRow
-              label={'Name'}
-              error={'Invalid name'}
-              isInvalid={isInvalid(workflowName)}
-            >
-              <EuiCompressedFieldText
-                placeholder={processWorkflowName(props.workflow.name)}
-                value={workflowName}
-                onChange={(e) => {
-                  setWorkflowName(e.target.value);
-                }}
-              />
-            </EuiCompressedFormRow>
-          </EuiModalBody>
-          <EuiModalFooter>
-            <EuiSmallButtonEmpty onClick={() => setIsNameModalOpen(false)}>
-              Cancel
-            </EuiSmallButtonEmpty>
-            <EuiSmallButton
-              disabled={isInvalid(workflowName) || isCreating}
-              isLoading={isCreating}
-              onClick={() => {
-                setIsCreating(true);
-                const workflowToCreate = {
-                  ...props.workflow,
-                  name: workflowName,
-                };
-                dispatch(
-                  createWorkflow({
-                    apiBody: workflowToCreate,
-                    dataSourceId,
-                  })
-                )
-                  .unwrap()
-                  .then((result) => {
-                    setIsCreating(false);
-                    const { workflow } = result;
-                    history.replace(
-                      constructUrlWithParams(
-                        APP_PATH.WORKFLOWS,
-
-                        workflow.id,
-                        dataSourceId
-                      )
-                    );
-                  })
-                  .catch((err: any) => {
-                    setIsCreating(false);
-                    console.error(err);
-                  });
-              }}
-              fill={true}
-              color="primary"
-            >
-              Create
-            </EuiSmallButton>
-          </EuiModalFooter>
-        </EuiModal>
+        <QuickConfigureModal
+          workflow={props.workflow}
+          onClose={() => setIsNameModalOpen(false)}
+        />
       )}
       <EuiCard
         title={

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -45,6 +45,9 @@ export function UseCase(props: UseCaseProps) {
     processWorkflowName(props.workflow.name)
   );
 
+  // is creating state
+  const [isCreating, setIsCreating] = useState<boolean>(false);
+
   // custom sanitization on workflow name
   function isInvalid(name: string): boolean {
     return (
@@ -83,8 +86,10 @@ export function UseCase(props: UseCaseProps) {
               Cancel
             </EuiSmallButtonEmpty>
             <EuiSmallButton
-              disabled={isInvalid(workflowName)}
+              disabled={isInvalid(workflowName) || isCreating}
+              isLoading={isCreating}
               onClick={() => {
+                setIsCreating(true);
                 const workflowToCreate = {
                   ...props.workflow,
                   name: workflowName,
@@ -97,6 +102,7 @@ export function UseCase(props: UseCaseProps) {
                 )
                   .unwrap()
                   .then((result) => {
+                    setIsCreating(false);
                     const { workflow } = result;
                     history.replace(
                       constructUrlWithParams(
@@ -108,6 +114,7 @@ export function UseCase(props: UseCaseProps) {
                     );
                   })
                   .catch((err: any) => {
+                    setIsCreating(false);
                     console.error(err);
                   });
               }}


### PR DESCRIPTION
### Description

This is a continuation of the usability improvements. Specifically, this PR adds several standard quick-config fields to common use cases that users can optionally populate, before entering the advanced editor view. When populated, the values are then propagated into the workflow config in various places. Details below.

Implementation details:
- adds a `QuickConfigureFields` type containing a set of optional fields
- adds a `QuickConfigureInputs` component, that dynamically renders form fields based on the use case. For example, a custom/blank use case, vs. a semantic search use case, vs other advanced / hybrid search / neural sparse search / future use cases, will have different inputs exposed. Current implementation shows the same fields available to semantic/multimodal/hybrid; this will expand in the future
- refactors the modal to configure the name (and expands its functionality) into a standalone `QuickConfigureModal` component. Exposes `QuickConfigureFields` if applicable, and maintains any/all of those field values. When actually executing the creation, those field values are injected into the workflow configs to auto-populate different parts of the form. See `injectQuickConfigureFields` and its child fns for details. The main idea, is each use case, we can maintain different logic for how some quick-create fields gets added into the initial workflow config when finally creating it and sending user to the detailed edit view.

Demo video, showing the list of optional inputs in the modal. When filled out, you can see the values show up in different places in the form, such as 1/ the ML processor ingest processor config's model, input map, and output map, 2/ the knn index mappings, and 3/ the query on the search flow. 

[screen-capture (3).webm](https://github.com/user-attachments/assets/d147f8e2-494e-4031-9da8-8cde8d28a5a8)

### Issues Resolved
Makes progress on #23 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
