### PR TITLE
Onboard normalization processor

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -73,6 +73,7 @@ export enum PROCESSOR_TYPE {
   SPLIT = 'split',
   SORT = 'sort',
   TEXT_CHUNKING = 'text_chunking',
+  NORMALIZATION = 'normalization-processor',
 }
 
 export enum MODEL_TYPE {
@@ -129,6 +130,8 @@ export const TEXT_CHUNKING_PROCESSOR_LINK =
   'https://opensearch.org/docs/latest/ingest-pipelines/processors/text-chunking/';
 export const CREATE_WORKFLOW_LINK =
   'https://opensearch.org/docs/latest/automating-configurations/api/create-workflow/';
+export const NORMALIZATION_PROCESSOR_LINK =
+  'https://opensearch.org/docs/latest/search-plugins/search-pipelines/normalization-processor/';
 
 /**
  * Text chunking algorithm constants

--- a/public/configs/search_response_processors/index.ts
+++ b/public/configs/search_response_processors/index.ts
@@ -6,3 +6,4 @@
 export * from './ml_search_response_processor';
 export * from './split_search_response_processor';
 export * from './sort_search_response_processor';
+export * from './normalization_processor';

--- a/public/configs/search_response_processors/normalization_processor.ts
+++ b/public/configs/search_response_processors/normalization_processor.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PROCESSOR_TYPE } from '../../../common';
+import { Processor } from '../processor';
+
+/**
+ * The normalization processor config. Used in search flows.
+ */
+export class NormalizationProcessor extends Processor {
+  constructor() {
+    super();
+    this.type = PROCESSOR_TYPE.NORMALIZATION;
+    this.name = 'Normalization Processor';
+    this.fields = [];
+    this.optionalFields = [
+      {
+        id: 'weights',
+        type: 'string',
+      },
+      {
+        id: 'normalization_technique',
+        type: 'select',
+        selectOptions: ['min_max', 'l2'],
+      },
+      {
+        id: 'combination_technique',
+        type: 'select',
+        selectOptions: ['arithmetic_mean', 'geometric_mean', 'harmonic_mean'],
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+    ];
+  }
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiAccordion, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import {
+  IProcessorConfig,
+  PROCESSOR_CONTEXT,
+  WorkflowConfig,
+  NORMALIZATION_PROCESSOR_LINK,
+} from '../../../../../common';
+import { TextField } from '../input_fields';
+import { ConfigFieldList } from '../config_field_list';
+
+interface NormalizationProcessorInputsProps {
+  uiConfig: WorkflowConfig;
+  config: IProcessorConfig;
+  baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
+  context: PROCESSOR_CONTEXT;
+}
+
+/**
+ * Specialized component to render the normalization processor. Adds some helper text around weights field.
+ * In the future, may have a more customizable / guided way for specifying the array of weights.
+ * For example, could have some visual way of linking it to the underlying sub-queries in the query field,
+ * enforce its length = the number of queries, etc.
+ */
+export function NormalizationProcessorInputs(
+  props: NormalizationProcessorInputsProps
+) {
+  // extracting field info from the config
+  const optionalFields = props.config.optionalFields || [];
+  const weightsFieldPath = `${props.baseConfigPath}.${props.config.id}.weights`;
+  const optionalFieldsWithoutWeights = optionalFields.filter(
+    (field) => field.id !== 'weights'
+  );
+
+  return (
+    // We only have optional fields for this processor, so everything is nested under the accordion
+    <EuiAccordion
+      id={`advancedSettings${props.config.id}`}
+      buttonContent="Advanced settings"
+      paddingSize="none"
+    >
+      <EuiSpacer size="s" />
+      <EuiFlexItem>
+        <TextField
+          label={'Weights'}
+          helpText={`A comma-separated array of floating-point values specifying the weight for each query. For example: '0.8, 0.2'`}
+          helpLink={NORMALIZATION_PROCESSOR_LINK}
+          fieldPath={weightsFieldPath}
+          showError={true}
+        />
+      </EuiFlexItem>
+      <EuiSpacer size="s" />
+      <ConfigFieldList
+        configId={props.config.id}
+        configFields={optionalFieldsWithoutWeights}
+        baseConfigPath={props.baseConfigPath}
+      />
+    </EuiAccordion>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -15,6 +15,7 @@ import {
 import { MLProcessorInputs } from './ml_processor_inputs';
 import { ConfigFieldList } from '../config_field_list';
 import { TextChunkingProcessorInputs } from './text_chunking_processor_inputs';
+import { NormalizationProcessorInputs } from './normalization_processor_inputs';
 
 /**
  * Base component for rendering processor form inputs based on the processor type
@@ -59,6 +60,20 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
             el = (
               <EuiFlexItem>
                 <TextChunkingProcessorInputs
+                  uiConfig={props.uiConfig}
+                  config={props.config}
+                  baseConfigPath={props.baseConfigPath}
+                  context={props.context}
+                />
+                <EuiSpacer size={PROCESSOR_INPUTS_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case PROCESSOR_TYPE.NORMALIZATION: {
+            el = (
+              <EuiFlexItem>
+                <NormalizationProcessorInputs
                   uiConfig={props.uiConfig}
                   config={props.config}
                   baseConfigPath={props.baseConfigPath}

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -28,6 +28,7 @@ import {
   MLIngestProcessor,
   MLSearchRequestProcessor,
   MLSearchResponseProcessor,
+  NormalizationProcessor,
   SortIngestProcessor,
   SortSearchResponseProcessor,
   SplitIngestProcessor,
@@ -269,6 +270,15 @@ export function ProcessorsList(props: ProcessorsListProps) {
                               closePopover();
                               addProcessor(
                                 new SortSearchResponseProcessor().toObj()
+                              );
+                            },
+                          },
+                          {
+                            name: 'Normalization Processor',
+                            onClick: () => {
+                              closePopover();
+                              addProcessor(
+                                new NormalizationProcessor().toObj()
                               );
                             },
                           },

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -65,7 +65,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
           <EuiAccordion
             id="optionalConfiguration"
             buttonContent="Optional configuration"
-            initialIsOpen={true}
+            initialIsOpen={false}
           >
             <EuiSpacer size="m" />
             <EuiCompressedFormRow


### PR DESCRIPTION
### Description

Adds the normalization search phase results processor under the "Enhance search results" section on the form. Under the hood, this processor runs in between the query and fetch phases. We abstract out those details on the UI.

More details
- adds new `NormalizationProcessor` config class to persist its parameters, all of which are optional
- adds a dedicated `NormalizationProcessorInputs` component instead of defaulting to the `ConfigFieldList`. The reason for this, is we want to have special form logic for inputting the weight parameters. As mentioned in the code comment, we can expand this to potentially link the weights to the configured query, enforce the length, etc. For now, just add some helper text and a link to the documentation
- adds special parsing logic on `config_to_template_utils` to set up the properly-formatted JSON config body

Demo video, showing the configuration of the normalization processor. The generated JSON is below that.

[screen-capture (4).webm](https://github.com/user-attachments/assets/1b4b1390-f242-48fb-bffd-55e9951f3d6a)

Generated valid search pipeline:
```
{
  "search_pipeline_f1f73f72f0a53947": {
    "request_processors": [],
    "response_processors": [],
    "phase_results_processors": [
      {
        "normalization-processor": {
          "normalization": {
            "technique": "min_max"
          },
          "combination": {
            "technique": "arithmetic_mean",
            "parameters": {
              "weights": [
                0.5,
                0.3,
                0.2
              ]
            }
          }
        }
      }
    ]
  }
}
```

### Issues Resolved
Resolves #219 

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
