### PR TITLE
Refine 'Search Studio' URL handling in Side Nav with NewHomePage enabled

### DIFF
--- a/public/render_app.tsx
+++ b/public/render_app.tsx
@@ -38,5 +38,20 @@ export const renderApp = (
     params.element
   );
 
-  return () => ReactDOM.unmountComponentAtNode(params.element);
+  const expectedBasePath = '/app/flow-framework#';
+
+  const unlistenParentHistory = params.history.listen(() => {
+    if (
+      hideInAppSideNavBar &&
+      window.location.pathname.endsWith('/app/flow-framework')
+    ) {
+      window.location.href = `${expectedBasePath}`;
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
+  });
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(params.element);
+    unlistenParentHistory();
+  };
 };


### PR DESCRIPTION
### Description

- #### Resolved the following issue: 
When 'Search Studio' is selected from the SideNav on the 'workflow detail' page, the page was not redirecting to the 'workflows' page.

- #### Below screen Recording shows the issue that I am trying to resolve.
[screen-capture (15).webm](https://github.com/user-attachments/assets/a297076f-bf97-44c1-92a2-49fb08a41bec)

- The [dashboards-flow-framework](https://github.com/opensearch-project/dashboards-flow-framework) uses a hash router. To ensure proper redirection, the hash has been added at the end of the URL.

- #### Issue Resolved here and can be seen in below screen recording. 

[screen-capture (16).webm](https://github.com/user-attachments/assets/95147dd1-acae-479a-a3ee-9277ac3916e9)



### Check List

- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
