### PR TITLE
Minor consistency fixes

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -111,6 +111,7 @@ export function MapField(props: MapFieldProps) {
                                 />
                               ) : (
                                 <TextField
+                                  fullWidth={true}
                                   fieldPath={`${props.fieldPath}.${idx}.key`}
                                   placeholder={props.keyPlaceholder || 'Input'}
                                   showError={false}
@@ -136,6 +137,7 @@ export function MapField(props: MapFieldProps) {
                                 />
                               ) : (
                                 <TextField
+                                  fullWidth={true}
                                   fieldPath={`${props.fieldPath}.${idx}.value`}
                                   placeholder={
                                     props.valuePlaceholder || 'Output'

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -21,6 +21,7 @@ interface TextFieldProps {
   helpText?: string;
   placeholder?: string;
   showError?: boolean;
+  fullWidth?: boolean;
 }
 
 /**
@@ -28,12 +29,12 @@ interface TextFieldProps {
  */
 export function TextField(props: TextFieldProps) {
   const { errors, touched } = useFormikContext<WorkspaceFormValues>();
-
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
         return (
           <EuiCompressedFormRow
+            fullWidth={props.fullWidth}
             key={props.fieldPath}
             label={props.label}
             labelAppend={
@@ -50,6 +51,7 @@ export function TextField(props: TextFieldProps) {
             isInvalid={getIn(errors, field.name) && getIn(touched, field.name)}
           >
             <EuiFieldText
+              fullWidth={props.fullWidth}
               {...field}
               placeholder={props.placeholder || ''}
               compressed={false}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -99,6 +99,10 @@ export function InputTransformModal(props: InputTransformModalProps) {
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
             <>
+              <EuiText color="subdued">
+                Fetch some sample input data and how it is transformed.
+              </EuiText>
+              <EuiSpacer size="s" />
               <EuiText>Expected input</EuiText>
               <EuiSmallButton
                 style={{ width: '100px' }}
@@ -124,7 +128,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                           simulatePipeline({
                             apiBody: {
                               pipeline: curIngestPipeline as IngestPipelineConfig,
-                              docs: curDocs,
+                              docs: [curDocs[0]],
                             },
                             dataSourceId,
                           })
@@ -139,7 +143,13 @@ export function InputTransformModal(props: InputTransformModalProps) {
                             );
                           });
                       } else {
-                        setSourceInput(values.ingest.docs);
+                        try {
+                          const docObjs = JSON.parse(
+                            values.ingest.docs
+                          ) as {}[];
+                          if (docObjs.length > 0)
+                            setSourceInput(customStringify([docObjs[0]]));
+                        } catch {}
                       }
                       break;
                     }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -96,6 +96,10 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
             <>
+              <EuiText color="subdued">
+                Fetch some sample output data and how it is transformed.
+              </EuiText>
+              <EuiSpacer size="s" />
               <EuiText>Expected input</EuiText>
               <EuiSmallButton
                 style={{ width: '100px' }}
@@ -128,7 +132,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         simulatePipeline({
                           apiBody: {
                             pipeline: curIngestPipeline,
-                            docs: curDocs,
+                            docs: [curDocs[0]],
                           },
                           dataSourceId,
                         })

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -111,7 +111,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <EuiCompressedFormRow
               label={'Text field'}
               isInvalid={false}
-              helpText="The name of the text document field to be vectorized"
+              helpText="The name of the text document field to be embedded"
             >
               <EuiCompressedFieldText
                 value={fieldValues?.textField || ''}

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -111,7 +111,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <EuiCompressedFormRow
               label={'Text field'}
               isInvalid={false}
-              helpText="The name of the document field containing plaintext"
+              helpText="The name of the text document field to be vectorized"
             >
               <EuiCompressedFieldText
                 value={fieldValues?.textField || ''}


### PR DESCRIPTION
### Description

Small PR to make a few things consistent:
1. The sample input in the input and output transform modals. Now, all scenarios will display a single input out of the array of results. This is to prevent over-using ML inference calls, and to be consistent with the produced output transform, which is only outputting a single value by default. Adds helper text in the modals as well.
2. The text fields in the input/output transforms do not stretch by default, but the select option does (select option shows up when there is a model interface and a preset list of available input/output fields)

Screenshot of modal:

![Screenshot 2024-08-27 at 4 24 01 PM](https://github.com/user-attachments/assets/d223026b-9afb-4f8c-9134-6ba16770c2bf)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
