### PR TITLE
Improve presets for use cases

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -153,6 +153,7 @@ export const SHARED_OPTIONAL_FIELDS = ['max_chunk_limit', 'description', 'tag'];
  */
 export const VECTOR_FIELD_PATTERN = `{{vector_field}}`;
 export const TEXT_FIELD_PATTERN = `{{text_field}}`;
+export const IMAGE_FIELD_PATTERN = `{{image_field}}`;
 export const QUERY_TEXT_PATTERN = `{{query_text}}`;
 export const QUERY_IMAGE_PATTERN = `{{query_image}}`;
 export const MODEL_ID_PATTERN = `{{model_id}}`;
@@ -163,7 +164,30 @@ export const FETCH_ALL_QUERY = {
   },
   size: 1000,
 };
-export const SEMANTIC_SEARCH_QUERY = {
+export const TERM_QUERY = {
+  query: {
+    term: {
+      [TEXT_FIELD_PATTERN]: {
+        value: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const KNN_QUERY = {
+  _source: {
+    excludes: [VECTOR_FIELD_PATTERN],
+  },
+  query: {
+    knn: {
+      [VECTOR_FIELD_PATTERN]: {
+        vector: `{{vector}}`,
+      },
+      k: 10,
+      model_id: MODEL_ID_PATTERN,
+    },
+  },
+};
+export const SEMANTIC_SEARCH_QUERY_NEURAL = {
   _source: {
     excludes: [VECTOR_FIELD_PATTERN],
   },
@@ -177,7 +201,7 @@ export const SEMANTIC_SEARCH_QUERY = {
     },
   },
 };
-export const MULTIMODAL_SEARCH_QUERY = {
+export const MULTIMODAL_SEARCH_QUERY_NEURAL = {
   _source: {
     excludes: [VECTOR_FIELD_PATTERN],
   },
@@ -192,7 +216,25 @@ export const MULTIMODAL_SEARCH_QUERY = {
     },
   },
 };
-export const HYBRID_SEARCH_QUERY = {
+export const MULTIMODAL_SEARCH_QUERY_BOOL = {
+  query: {
+    bool: {
+      must: [
+        {
+          match: {
+            [TEXT_FIELD_PATTERN]: QUERY_TEXT_PATTERN,
+          },
+        },
+        {
+          match: {
+            [IMAGE_FIELD_PATTERN]: QUERY_IMAGE_PATTERN,
+          },
+        },
+      ],
+    },
+  },
+};
+export const HYBRID_SEARCH_QUERY_MATCH_NEURAL = {
   _source: {
     excludes: [VECTOR_FIELD_PATTERN],
   },
@@ -219,6 +261,31 @@ export const HYBRID_SEARCH_QUERY = {
     },
   },
 };
+export const HYBRID_SEARCH_QUERY_MATCH_TERM = {
+  _source: {
+    excludes: [VECTOR_FIELD_PATTERN],
+  },
+  query: {
+    hybrid: {
+      queries: [
+        {
+          match: {
+            [TEXT_FIELD_PATTERN]: {
+              query: QUERY_TEXT_PATTERN,
+            },
+          },
+        },
+        {
+          term: {
+            [TEXT_FIELD_PATTERN]: {
+              value: QUERY_TEXT_PATTERN,
+            },
+          },
+        },
+      ],
+    },
+  },
+};
 
 export const QUERY_PRESETS = [
   {
@@ -226,16 +293,32 @@ export const QUERY_PRESETS = [
     query: customStringify(FETCH_ALL_QUERY),
   },
   {
-    name: WORKFLOW_TYPE.SEMANTIC_SEARCH,
-    query: customStringify(SEMANTIC_SEARCH_QUERY),
+    name: 'Term',
+    query: customStringify(TERM_QUERY),
+  },
+  {
+    name: 'Basic k-NN',
+    query: customStringify(KNN_QUERY),
+  },
+  {
+    name: `${WORKFLOW_TYPE.SEMANTIC_SEARCH} (neural)`,
+    query: customStringify(SEMANTIC_SEARCH_QUERY_NEURAL),
   },
   {
     name: WORKFLOW_TYPE.MULTIMODAL_SEARCH,
-    query: customStringify(MULTIMODAL_SEARCH_QUERY),
+    query: customStringify(MULTIMODAL_SEARCH_QUERY_BOOL),
   },
   {
-    name: WORKFLOW_TYPE.HYBRID_SEARCH,
-    query: customStringify(HYBRID_SEARCH_QUERY),
+    name: `${WORKFLOW_TYPE.MULTIMODAL_SEARCH} (neural)`,
+    query: customStringify(MULTIMODAL_SEARCH_QUERY_NEURAL),
+  },
+  {
+    name: `Hybrid search (match & term queries)`,
+    query: customStringify(HYBRID_SEARCH_QUERY_MATCH_TERM),
+  },
+  {
+    name: `Hybrid search (match & neural queries)`,
+    query: customStringify(HYBRID_SEARCH_QUERY_MATCH_NEURAL),
   },
 ] as QueryPreset[];
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -465,6 +465,7 @@ export type QuickConfigureFields = {
   embeddingModelId?: string;
   vectorField?: string;
   textField?: string;
+  imageField?: string;
   embeddingLength?: number;
 };
 

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -124,6 +124,26 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
               />
             </EuiCompressedFormRow>
             <EuiSpacer size="s" />
+            {props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH && (
+              <>
+                <EuiCompressedFormRow
+                  label={'Image field'}
+                  isInvalid={false}
+                  helpText="The name of the document field containing the image binary"
+                >
+                  <EuiCompressedFieldText
+                    value={fieldValues?.imageField || ''}
+                    onChange={(e) => {
+                      setFieldValues({
+                        ...fieldValues,
+                        imageField: e.target.value,
+                      });
+                    }}
+                  />
+                </EuiCompressedFormRow>
+                <EuiSpacer size="s" />
+              </>
+            )}
             <EuiCompressedFormRow
               label={'Vector field'}
               isInvalid={false}

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -18,8 +18,10 @@ import {
 } from '@elastic/eui';
 import {
   EMPTY_MAP_ENTRY,
+  IMAGE_FIELD_PATTERN,
   MODEL_ID_PATTERN,
   MapArrayFormValue,
+  MapFormValue,
   QuickConfigureFields,
   TEXT_FIELD_PATTERN,
   VECTOR_FIELD_PATTERN,
@@ -159,7 +161,8 @@ function injectQuickConfigureFields(
       // Semantic search / hybrid search: set defaults in the ingest processor, the index mappings,
       // and the preset query
       case WORKFLOW_TYPE.SEMANTIC_SEARCH:
-      case WORKFLOW_TYPE.HYBRID_SEARCH: {
+      case WORKFLOW_TYPE.HYBRID_SEARCH:
+      case WORKFLOW_TYPE.MULTIMODAL_SEARCH: {
         if (!isEmpty(quickConfigureFields) && workflow.ui_metadata?.config) {
           workflow.ui_metadata.config = updateIngestProcessorConfig(
             workflow.ui_metadata.config,
@@ -178,6 +181,7 @@ function injectQuickConfigureFields(
             quickConfigureFields
           );
         }
+        break;
       }
       case WORKFLOW_TYPE.CUSTOM:
       case undefined:
@@ -197,10 +201,21 @@ function updateIngestProcessorConfig(
     if (field.id === 'model' && fields.embeddingModelId) {
       field.value = { id: fields.embeddingModelId };
     }
-    if (field.id === 'input_map' && fields.textField) {
-      field.value = [
-        [{ key: '', value: fields.textField }],
-      ] as MapArrayFormValue;
+    if (field.id === 'input_map' && (fields.textField || fields.imageField)) {
+      const inputMap = [] as MapFormValue;
+      if (fields.textField) {
+        inputMap.push({
+          key: '',
+          value: fields.textField,
+        });
+      }
+      if (fields.imageField) {
+        inputMap.push({
+          key: '',
+          value: fields.imageField,
+        });
+      }
+      field.value = [inputMap] as MapArrayFormValue;
     }
     if (field.id === 'output_map' && fields.vectorField) {
       field.value = [
@@ -248,6 +263,20 @@ function updateIndexConfig(
       },
     });
   }
+  if (fields.imageField) {
+    const existingMappings = JSON.parse(
+      config.ingest.index.mappings.value as string
+    );
+    config.ingest.index.mappings.value = customStringify({
+      ...existingMappings,
+      properties: {
+        ...(existingMappings.properties || {}),
+        [fields.imageField]: {
+          type: 'binary',
+        },
+      },
+    });
+  }
   if (fields.vectorField) {
     const existingMappings = JSON.parse(
       config.ingest.index.mappings.value as string
@@ -290,6 +319,13 @@ function updateSearchRequestConfig(
       '') as string).replace(
       new RegExp(VECTOR_FIELD_PATTERN, 'g'),
       fields.vectorField
+    );
+  }
+  if (fields.imageField) {
+    config.search.request.value = ((config.search.request.value ||
+      '') as string).replace(
+      new RegExp(IMAGE_FIELD_PATTERN, 'g'),
+      fields.imageField
     );
   }
 

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiCompressedFormRow,
 } from '@elastic/eui';
 import {
+  EMPTY_MAP_ENTRY,
   MODEL_ID_PATTERN,
   MapArrayFormValue,
   QuickConfigureFields,
@@ -172,6 +173,10 @@ function injectQuickConfigureFields(
             workflow.ui_metadata.config,
             quickConfigureFields
           );
+          workflow.ui_metadata.config = updateSearchRequestProcessorConfig(
+            workflow.ui_metadata.config,
+            quickConfigureFields
+          );
         }
       }
       case WORKFLOW_TYPE.CUSTOM:
@@ -183,7 +188,7 @@ function injectQuickConfigureFields(
   return workflow;
 }
 
-// prefill ML ingest pipeline processor config, if applicable
+// prefill ML ingest processor config, if applicable
 function updateIngestProcessorConfig(
   config: WorkflowConfig,
   fields: QuickConfigureFields
@@ -201,6 +206,23 @@ function updateIngestProcessorConfig(
       field.value = [
         [{ key: fields.vectorField, value: '' }],
       ] as MapArrayFormValue;
+    }
+  });
+
+  return config;
+}
+
+// prefill ML search request processor config, if applicable
+function updateSearchRequestProcessorConfig(
+  config: WorkflowConfig,
+  fields: QuickConfigureFields
+): WorkflowConfig {
+  config.search.enrichRequest.processors[0].fields.forEach((field) => {
+    if (field.id === 'model' && fields.embeddingModelId) {
+      field.value = { id: fields.embeddingModelId };
+    }
+    if (field.id === 'input_map' || field.id === 'output_map') {
+      field.value = [[EMPTY_MAP_ENTRY]] as MapArrayFormValue;
     }
   });
 

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -4,7 +4,11 @@
  */
 
 import { snakeCase } from 'lodash';
-import { MLIngestProcessor, NormalizationProcessor } from '../../../configs';
+import {
+  MLIngestProcessor,
+  MLSearchRequestProcessor,
+  NormalizationProcessor,
+} from '../../../configs';
 import {
   WorkflowTemplate,
   START_FROM_SCRATCH_WORKFLOW_NAME,
@@ -125,6 +129,9 @@ function fetchSemanticSearchMetadata(): UIState {
     [`index.knn`]: true,
   });
   baseState.config.search.request.value = customStringify(TERM_QUERY);
+  baseState.config.search.enrichRequest.processors = [
+    new MLSearchRequestProcessor().toObj(),
+  ];
   return baseState;
 }
 
@@ -153,6 +160,9 @@ function fetchHybridSearchMetadata(): UIState {
   baseState.config.search.request.value = customStringify(TERM_QUERY);
   baseState.config.search.enrichResponse.processors = [
     new NormalizationProcessor().toObj(),
+  ];
+  baseState.config.search.enrichRequest.processors = [
+    new MLSearchRequestProcessor().toObj(),
   ];
   return baseState;
 }

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { snakeCase } from 'lodash';
-import { MLIngestProcessor } from '../../../configs';
+import { MLIngestProcessor, NormalizationProcessor } from '../../../configs';
 import {
   WorkflowTemplate,
   START_FROM_SCRATCH_WORKFLOW_NAME,
@@ -13,9 +13,8 @@ import {
   WORKFLOW_TYPE,
   FETCH_ALL_QUERY,
   customStringify,
-  SEMANTIC_SEARCH_QUERY,
-  MULTIMODAL_SEARCH_QUERY,
-  HYBRID_SEARCH_QUERY,
+  TERM_QUERY,
+  MULTIMODAL_SEARCH_QUERY_BOOL,
 } from '../../../../common';
 import { generateId } from '../../../utils';
 
@@ -125,9 +124,7 @@ function fetchSemanticSearchMetadata(): UIState {
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });
-  baseState.config.search.request.value = customStringify(
-    SEMANTIC_SEARCH_QUERY
-  );
+  baseState.config.search.request.value = customStringify(TERM_QUERY);
   return baseState;
 }
 
@@ -140,7 +137,7 @@ function fetchMultimodalSearchMetadata(): UIState {
     [`index.knn`]: true,
   });
   baseState.config.search.request.value = customStringify(
-    MULTIMODAL_SEARCH_QUERY
+    MULTIMODAL_SEARCH_QUERY_BOOL
   );
   return baseState;
 }
@@ -153,7 +150,10 @@ function fetchHybridSearchMetadata(): UIState {
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });
-  baseState.config.search.request.value = customStringify(HYBRID_SEARCH_QUERY);
+  baseState.config.search.request.value = customStringify(TERM_QUERY);
+  baseState.config.search.enrichResponse.processors = [
+    new NormalizationProcessor().toObj(),
+  ];
   return baseState;
 }
 

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -146,6 +146,9 @@ function fetchMultimodalSearchMetadata(): UIState {
   baseState.config.search.request.value = customStringify(
     MULTIMODAL_SEARCH_QUERY_BOOL
   );
+  baseState.config.search.enrichRequest.processors = [
+    new MLSearchRequestProcessor().toObj(),
+  ];
   return baseState;
 }
 

--- a/server/resources/templates/hybrid_search.json
+++ b/server/resources/templates/hybrid_search.json
@@ -1,6 +1,6 @@
 {
     "name": "Hybrid Search",
-    "description": "A basic workflow containing the ingest pipeline and index configurations for performing hybrid search",
+    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing hybrid search",
     "version": {
         "template": "1.0.0",
         "compatibility": [

--- a/server/resources/templates/multimodal_search.json
+++ b/server/resources/templates/multimodal_search.json
@@ -1,6 +1,6 @@
 {
     "name": "Multimodal Search",
-    "description": "A basic workflow containing the ingest pipeline and index configurations for performing multimodal search",
+    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing multimodal search",
     "version": {
         "template": "1.0.0",
         "compatibility": [

--- a/server/resources/templates/semantic_search.json
+++ b/server/resources/templates/semantic_search.json
@@ -1,6 +1,6 @@
 {
     "name": "Semantic Search",
-    "description": "A basic workflow containing the ingest pipeline and index configurations for performing semantic search",
+    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing semantic search",
     "version": {
         "template": "1.0.0",
         "compatibility": [


### PR DESCRIPTION
### Description
Improves the presets for the OOTB use cases:
- adds more preset queries
- sets a default ML search response processor for semantic/hybrid/MM
- improves default queries for semantic/hybrid/MM
- adds a quick-configure image field for MM
- tunes descriptions for semantic/hybrid/MM

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
