### PR TITLE
More preset automation & usability improvements

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -159,6 +159,7 @@ export const QUERY_IMAGE_PATTERN = `{{query_image}}`;
 export const MODEL_ID_PATTERN = `{{model_id}}`;
 export const VECTOR = 'vector';
 export const VECTOR_PATTERN = `{{${VECTOR}}}`;
+export const VECTOR_TEMPLATE_PLACEHOLDER = `\$\{${VECTOR}\}`;
 export const DEFAULT_K = 10;
 
 export const FETCH_ALL_QUERY = {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -157,6 +157,9 @@ export const IMAGE_FIELD_PATTERN = `{{image_field}}`;
 export const QUERY_TEXT_PATTERN = `{{query_text}}`;
 export const QUERY_IMAGE_PATTERN = `{{query_image}}`;
 export const MODEL_ID_PATTERN = `{{model_id}}`;
+export const VECTOR = 'vector';
+export const VECTOR_PATTERN = `{{${VECTOR}}}`;
+export const DEFAULT_K = 10;
 
 export const FETCH_ALL_QUERY = {
   query: {
@@ -180,10 +183,9 @@ export const KNN_QUERY = {
   query: {
     knn: {
       [VECTOR_FIELD_PATTERN]: {
-        vector: `{{vector}}`,
+        vector: VECTOR_PATTERN,
+        k: DEFAULT_K,
       },
-      k: 10,
-      model_id: MODEL_ID_PATTERN,
     },
   },
 };
@@ -196,7 +198,7 @@ export const SEMANTIC_SEARCH_QUERY_NEURAL = {
       [VECTOR_FIELD_PATTERN]: {
         query_text: QUERY_TEXT_PATTERN,
         model_id: MODEL_ID_PATTERN,
-        k: 100,
+        k: DEFAULT_K,
       },
     },
   },
@@ -211,7 +213,7 @@ export const MULTIMODAL_SEARCH_QUERY_NEURAL = {
         query_text: QUERY_TEXT_PATTERN,
         query_image: QUERY_IMAGE_PATTERN,
         model_id: MODEL_ID_PATTERN,
-        k: 100,
+        k: DEFAULT_K,
       },
     },
   },
@@ -228,6 +230,32 @@ export const MULTIMODAL_SEARCH_QUERY_BOOL = {
         {
           match: {
             [IMAGE_FIELD_PATTERN]: QUERY_IMAGE_PATTERN,
+          },
+        },
+      ],
+    },
+  },
+};
+export const HYBRID_SEARCH_QUERY_MATCH_KNN = {
+  _source: {
+    excludes: [VECTOR_FIELD_PATTERN],
+  },
+  query: {
+    hybrid: {
+      queries: [
+        {
+          match: {
+            [TEXT_FIELD_PATTERN]: {
+              query: QUERY_TEXT_PATTERN,
+            },
+          },
+        },
+        {
+          knn: {
+            [VECTOR_FIELD_PATTERN]: {
+              vector: VECTOR_PATTERN,
+              k: DEFAULT_K,
+            },
           },
         },
       ],
@@ -253,7 +281,7 @@ export const HYBRID_SEARCH_QUERY_MATCH_NEURAL = {
             [VECTOR_FIELD_PATTERN]: {
               query_text: QUERY_TEXT_PATTERN,
               model_id: MODEL_ID_PATTERN,
-              k: 5,
+              k: DEFAULT_K,
             },
           },
         },
@@ -311,6 +339,10 @@ export const QUERY_PRESETS = [
   {
     name: `${WORKFLOW_TYPE.MULTIMODAL_SEARCH} (neural)`,
     query: customStringify(MULTIMODAL_SEARCH_QUERY_NEURAL),
+  },
+  {
+    name: `Hybrid search (match & k-NN queries)`,
+    query: customStringify(HYBRID_SEARCH_QUERY_MATCH_KNN),
   },
   {
     name: `Hybrid search (match & term queries)`,

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -26,14 +26,18 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
   // selected option state
   const [selectedOption, setSelectedOption] = useState<any[]>([]);
 
-  // update the selected option when the form is updated. set to empty if the form value is undefined
-  // or an empty string ('')
+  // update the selected option when the form is updated. if the form is empty,
+  // default to the top option. by default, this will re-trigger this hook with a populated
+  // value, to then finally update the displayed option.
   useEffect(() => {
     const formValue = getIn(values, props.fieldPath);
     if (!isEmpty(formValue)) {
       setSelectedOption([{ label: getIn(values, props.fieldPath) }]);
     } else {
-      setSelectedOption([]);
+      if (props.options.length > 0) {
+        setFieldTouched(props.fieldPath, true);
+        setFieldValue(props.fieldPath, props.options[0].label);
+      }
     }
   }, [getIn(values, props.fieldPath)]);
 

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -12,10 +12,12 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiSmallButton,
   EuiSuperSelect,
   EuiSuperSelectOption,
   EuiText,
   EuiTitle,
+  EuiSpacer,
 } from '@elastic/eui';
 import { SearchHit, WorkflowFormValues } from '../../../../../common';
 import { JsonField } from '../input_fields';
@@ -142,41 +144,46 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
-            fill={false}
-            style={{ width: '100px' }}
-            size="s"
-            onClick={() => {
-              // for this test query, we don't want to involve any configured search pipelines, if any exist
-              // see https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/#disabling-the-default-pipeline-for-a-request
-              dispatch(
-                searchIndex({
-                  apiBody: {
-                    index: values.search.index.name,
-                    body: values.search.request,
-                    searchPipeline: '_none',
-                  },
-                  dataSourceId,
-                })
-              )
-                .unwrap()
-                .then(async (resp) => {
-                  props.setQueryResponse(
-                    JSON.stringify(
-                      resp.hits.hits.map((hit: SearchHit) => hit._source),
-                      undefined,
-                      2
-                    )
-                  );
-                })
-                .catch((error: any) => {
-                  props.setQueryResponse('');
-                  console.error('Error running query: ', error);
-                });
-            }}
-          >
-            Test
-          </EuiButton>
+          <>
+            <EuiSmallButton
+              fill={false}
+              style={{ width: '100px' }}
+              onClick={() => {
+                // for this test query, we don't want to involve any configured search pipelines, if any exist
+                // see https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/#disabling-the-default-pipeline-for-a-request
+                dispatch(
+                  searchIndex({
+                    apiBody: {
+                      index: values.search.index.name,
+                      body: values.search.request,
+                      searchPipeline: '_none',
+                    },
+                    dataSourceId,
+                  })
+                )
+                  .unwrap()
+                  .then(async (resp) => {
+                    props.setQueryResponse(
+                      JSON.stringify(
+                        resp.hits.hits.map((hit: SearchHit) => hit._source),
+                        undefined,
+                        2
+                      )
+                    );
+                  })
+                  .catch((error: any) => {
+                    props.setQueryResponse('');
+                    console.error('Error running query: ', error);
+                  });
+              }}
+            >
+              Test
+            </EuiSmallButton>
+            <EuiSpacer size="s" />
+            <EuiText size="s" color="subdued">
+              Run query without any search pipeline configuration.
+            </EuiText>
+          </>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -129,7 +129,7 @@ function fetchSemanticSearchMetadata(): UIState {
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.SEMANTIC_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
-  baseState.config.ingest.index.name.value = 'my-knn-index';
+  baseState.config.ingest.index.name.value = generateId('knn_index', 6);
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });
@@ -147,7 +147,7 @@ function fetchMultimodalSearchMetadata(): UIState {
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.MULTIMODAL_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
-  baseState.config.ingest.index.name.value = 'my-knn-index';
+  baseState.config.ingest.index.name.value = generateId('knn_index', 6);
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });
@@ -167,7 +167,7 @@ function fetchHybridSearchMetadata(): UIState {
   let baseState = fetchEmptyMetadata();
   baseState.type = WORKFLOW_TYPE.HYBRID_SEARCH;
   baseState.config.ingest.enrich.processors = [new MLIngestProcessor().toObj()];
-  baseState.config.ingest.index.name.value = 'my-knn-index';
+  baseState.config.ingest.index.name.value = generateId('knn_index', 6);
   baseState.config.ingest.index.settings.value = customStringify({
     [`index.knn`]: true,
   });

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -19,8 +19,10 @@ import {
   customStringify,
   TERM_QUERY,
   MULTIMODAL_SEARCH_QUERY_BOOL,
-  KNN_QUERY,
   IProcessorConfig,
+  VECTOR_TEMPLATE_PLACEHOLDER,
+  VECTOR_PATTERN,
+  KNN_QUERY,
   HYBRID_SEARCH_QUERY_MATCH_KNN,
 } from '../../../../common';
 import { generateId } from '../../../utils';
@@ -191,7 +193,9 @@ export function processWorkflowName(workflowName: string): string {
     : snakeCase(workflowName);
 }
 
-// populate the `query_template` config value with a given query preset
+// populate the `query_template` config value with a given query template
+// by default, we replace any vector pattern ("{{vector}}") with the unquoted
+// vector template placeholder (${vector}) so it becomes a proper template
 function injectQueryTemplateInProcessor(
   processorConfig: IProcessorConfig,
   queryObj: {}
@@ -202,7 +206,10 @@ function injectQueryTemplateInProcessor(
       if (optionalField.id === 'query_template') {
         updatedField = {
           ...updatedField,
-          value: customStringify(queryObj),
+          value: customStringify(queryObj).replace(
+            new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
+            VECTOR_TEMPLATE_PLACEHOLDER
+          ),
         };
       }
       return updatedField;

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -30,15 +30,15 @@ import { DataSourceAttributes } from '../../../../src/plugins/data_source/common
 import { SavedObject } from '../../../../src/core/public';
 import semver from 'semver';
 
-// Append 16 random characters
-export function generateId(prefix?: string): string {
+// Generate a random ID. Optionally add a prefix. Optionally
+// override the default # characters to generate.
+export function generateId(prefix?: string, numChars: number = 16): string {
   const uniqueChar = () => {
     // eslint-disable-next-line no-bitwise
     return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
   };
-  return `${
-    prefix || ''
-  }_${uniqueChar()}${uniqueChar()}${uniqueChar()}${uniqueChar()}`;
+  const uniqueId = `${uniqueChar()}${uniqueChar()}${uniqueChar()}${uniqueChar()}`;
+  return `${prefix || ''}_${uniqueId.substring(0, numChars)}`;
 }
 
 export function sleep(ms: number) {


### PR DESCRIPTION
### Description
This PR adds a handful of usability improvements:
1.  allows the query template fields in the ML search request processors to be automatically populated
2. adds random name generation for index creation to prevent the easy case of name clashing when creating multiple workflows
3. sets default values for the select dropdowns (automatic population of the input maps when using a model with an interface)

Demo video showing that when all quick-config fields are filled out, and when using a model with an interface, ingest & search can be fully working by only configuring:
1/ passing in sample documents to ingest, and
2/ the query and input map for the search request processor (this may further be automated in the near future)

[screen-capture (7).webm](https://github.com/user-attachments/assets/dd996f83-1767-4edb-9c31-f4b4b02217b8)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
