### PR TITLE
Add presets for quick config fields

### DIFF
--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -28,6 +28,10 @@ interface QuickConfigureInputsProps {
   setFields(fields: QuickConfigureFields): void;
 }
 
+const DEFAULT_TEXT_FIELD = 'my_text';
+const DEFAULT_VECTOR_FIELD = 'my_embedding';
+const DEFAULT_IMAGE_FIELD = 'my_image';
+
 // Dynamic component to allow optional input configuration fields for different use cases.
 // Hooks back to the parent component with such field values
 export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
@@ -49,6 +53,35 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
 
   // Local field values state
   const [fieldValues, setFieldValues] = useState<QuickConfigureFields>({});
+
+  // on initial load, and when there are any deployed models found, set
+  // defaults for the field values for certain workflow types
+  useEffect(() => {
+    let defaultFieldValues = {} as QuickConfigureFields;
+    if (
+      props.workflowType === WORKFLOW_TYPE.SEMANTIC_SEARCH ||
+      props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH ||
+      props.workflowType === WORKFLOW_TYPE.HYBRID_SEARCH
+    ) {
+      defaultFieldValues = {
+        textField: DEFAULT_TEXT_FIELD,
+        vectorField: DEFAULT_VECTOR_FIELD,
+      };
+    }
+    if (props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH) {
+      defaultFieldValues = {
+        ...defaultFieldValues,
+        imageField: DEFAULT_IMAGE_FIELD,
+      };
+    }
+    if (deployedModels.length > 0) {
+      defaultFieldValues = {
+        ...defaultFieldValues,
+        embeddingModelId: deployedModels[0].id,
+      };
+    }
+    setFieldValues(defaultFieldValues);
+  }, [deployedModels]);
 
   // Hook to update the parent field values
   useEffect(() => {

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -173,7 +173,9 @@ function fetchHybridSearchMetadata(): UIState {
   });
   baseState.config.search.request.value = customStringify(TERM_QUERY);
   baseState.config.search.enrichResponse.processors = [
-    new NormalizationProcessor().toObj(),
+    injectDefaultWeightsInNormalizationProcessor(
+      new NormalizationProcessor().toObj()
+    ),
   ];
   baseState.config.search.enrichRequest.processors = [
     injectQueryTemplateInProcessor(
@@ -210,6 +212,28 @@ function injectQueryTemplateInProcessor(
             new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
             VECTOR_TEMPLATE_PLACEHOLDER
           ),
+        };
+      }
+      return updatedField;
+    }
+  );
+  return processorConfig;
+}
+
+// set default weights for a normalization processor. assumes there is 2 queries, and equally
+// balances the weight. We don't hardcode in the configuration, since we want to set
+// invalid defaults for arbitrary use cases (e.g., more than 2 queries). In this case, we
+// are already setting 2 queries by default, so we can make this assumption.
+function injectDefaultWeightsInNormalizationProcessor(
+  processorConfig: IProcessorConfig
+): IProcessorConfig {
+  processorConfig.optionalFields = processorConfig.optionalFields?.map(
+    (optionalField) => {
+      let updatedField = optionalField;
+      if (optionalField.id === 'weights') {
+        updatedField = {
+          ...updatedField,
+          value: '0.5, 0.5',
         };
       }
       return updatedField;

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -221,7 +221,7 @@ function injectQueryTemplateInProcessor(
 }
 
 // set default weights for a normalization processor. assumes there is 2 queries, and equally
-// balances the weight. We don't hardcode in the configuration, since we want to set
+// balances the weight. We don't hardcode in the configuration, since we don't want to set
 // invalid defaults for arbitrary use cases (e.g., more than 2 queries). In this case, we
 // are already setting 2 queries by default, so we can make this assumption.
 function injectDefaultWeightsInNormalizationProcessor(


### PR DESCRIPTION
### Description

This PR sets default values for the majority of the quick-configure fields when creating workflows from a preset.

![Screenshot 2024-08-29 at 9 29 46 AM](https://github.com/user-attachments/assets/820938ef-3eb4-4840-99d9-e4837ad5ddb7)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
