### PR TITLE
Prefill dimension if known remote model found; onboard search connectors API

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -22,7 +22,9 @@ export const FLOW_FRAMEWORK_SEARCH_WORKFLOW_STATE_ROUTE = `${FLOW_FRAMEWORK_WORK
  */
 export const ML_API_ROUTE_PREFIX = '/_plugins/_ml';
 export const ML_MODEL_ROUTE_PREFIX = `${ML_API_ROUTE_PREFIX}/models`;
+export const ML_CONNECTOR_ROUTE_PREFIX = `${ML_API_ROUTE_PREFIX}/connectors`;
 export const ML_SEARCH_MODELS_ROUTE = `${ML_MODEL_ROUTE_PREFIX}/_search`;
+export const ML_SEARCH_CONNECTORS_ROUTE = `${ML_CONNECTOR_ROUTE_PREFIX}/_search`;
 
 /**
  * NODE APIs
@@ -51,7 +53,32 @@ export const GET_PRESET_WORKFLOWS_NODE_API_PATH = `${BASE_WORKFLOW_NODE_API_PATH
 
 // ML Plugin node APIs
 export const BASE_MODEL_NODE_API_PATH = `${BASE_NODE_API_PATH}/model`;
+export const BASE_CONNECTOR_NODE_API_PATH = `${BASE_NODE_API_PATH}/connector`;
 export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
+export const SEARCH_CONNECTORS_NODE_API_PATH = `${BASE_CONNECTOR_NODE_API_PATH}/search`;
+
+/**
+ * Remote model dimensions. Used for attempting to pre-fill dimension size
+ * based on the specified remote model from a remote service, if found
+ */
+
+// Cohere
+export const COHERE_DIMENSIONS = {
+  [`embed-english-v3.0`]: 1024,
+  [`embed-english-light-v3.0`]: 384,
+  [`embed-multilingual-v3.0`]: 1024,
+  [`embed-multilingual-light-v3.0`]: 384,
+  [`embed-english-v2.0`]: 4096,
+  [`embed-english-light-v2.0`]: 1024,
+  [`embed-multilingual-v2.0`]: 768,
+};
+
+// OpenAI
+export const OPENAI_DIMENSIONS = {
+  [`text-embedding-3-small`]: 1536,
+  [`text-embedding-3-large`]: 3072,
+  [`text-embedding-ada-002`]: 1536,
+};
 
 /**
  * Various constants pertaining to Workflow configs

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -393,6 +393,11 @@ export type ModelInterface = {
   output: { [key: string]: ModelOutput };
 };
 
+export type ConnectorParameters = {
+  model?: string;
+  dimensions?: number;
+};
+
 export type Model = {
   id: string;
   name: string;
@@ -400,10 +405,21 @@ export type Model = {
   state: MODEL_STATE;
   modelConfig?: ModelConfig;
   interface?: ModelInterface;
+  connectorId?: string;
+};
+
+export type Connector = {
+  id: string;
+  name: string;
+  parameters?: ConnectorParameters;
 };
 
 export type ModelDict = {
   [modelId: string]: Model;
+};
+
+export type ConnectorDict = {
+  [connectorId: string]: Connector;
 };
 
 export type ModelFormValue = {

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -108,6 +108,9 @@ export function MapField(props: MapFieldProps) {
                                   fieldPath={`${props.fieldPath}.${idx}.key`}
                                   options={props.keyOptions as any[]}
                                   placeholder={props.keyPlaceholder || 'Input'}
+                                  autofill={
+                                    props.keyOptions?.length === 1 && idx === 0
+                                  }
                                 />
                               ) : (
                                 <TextField
@@ -133,6 +136,10 @@ export function MapField(props: MapFieldProps) {
                                   options={props.valueOptions || []}
                                   placeholder={
                                     props.valuePlaceholder || 'Output'
+                                  }
+                                  autofill={
+                                    props.valueOptions?.length === 1 &&
+                                    idx === 0
                                   }
                                 />
                               ) : (

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -43,7 +43,7 @@ export function ModelField(props: ModelFieldProps) {
   // Initial store is fetched when loading base <DetectorDetail /> page. We don't
   // re-fetch here as it could overload client-side if user clicks back and forth /
   // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
-  const models = useSelector((state: AppState) => state.models.models);
+  const models = useSelector((state: AppState) => state.ml.models);
 
   const { errors, touched } = useFormikContext<WorkspaceFormValues>();
 

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -13,6 +13,7 @@ interface SelectWithCustomOptionsProps {
   fieldPath: string;
   placeholder: string;
   options: any[];
+  autofill: boolean;
 }
 
 /**
@@ -30,13 +31,14 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
   // default to the top option. by default, this will re-trigger this hook with a populated
   // value, to then finally update the displayed option.
   useEffect(() => {
-    const formValue = getIn(values, props.fieldPath);
-    if (!isEmpty(formValue)) {
-      setSelectedOption([{ label: getIn(values, props.fieldPath) }]);
-    } else {
-      if (props.options.length > 0) {
-        setFieldTouched(props.fieldPath, true);
-        setFieldValue(props.fieldPath, props.options[0].label);
+    if (props.autofill) {
+      const formValue = getIn(values, props.fieldPath);
+      if (!isEmpty(formValue)) {
+        setSelectedOption([{ label: getIn(values, props.fieldPath) }]);
+      } else {
+        if (props.options.length > 0) {
+          setFieldValue(props.fieldPath, props.options[0].label);
+        }
       }
     }
   }, [getIn(values, props.fieldPath)]);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -53,7 +53,7 @@ interface MLProcessorInputsProps {
  * output map configuration forms, respectively.
  */
 export function MLProcessorInputs(props: MLProcessorInputsProps) {
-  const models = useSelector((state: AppState) => state.models.models);
+  const models = useSelector((state: AppState) => state.ml.models);
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
   >();

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -9,7 +9,6 @@ import { debounce, isEmpty, isEqual } from 'lodash';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -100,7 +99,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     setFieldValue,
     values,
     touched,
-    dirty,
   } = useFormikContext<WorkflowFormValues>();
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
@@ -650,15 +648,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 </EuiModalFooter>
               </EuiModal>
             )}
-            {onIngest &&
-              dirty &&
-              hasProvisionedSearchResources(props.workflow) && (
-                <EuiCallOut
-                  title="Making changes to ingest may affect your configured search flow"
-                  iconType={'alert'}
-                  color="warning"
-                />
-              )}
             {onIngestAndUnprovisioned && (
               <>
                 <EuiSpacer size="m" />

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -24,6 +24,7 @@ import {
   useAppDispatch,
   getWorkflowPresets,
   searchModels,
+  searchConnectors,
 } from '../../../store';
 import { enrichPresetWorkflowWithUiMetadata } from './utils';
 import { getDataSourceId } from '../../../utils';
@@ -56,11 +57,12 @@ export function NewWorkflow(props: NewWorkflowProps) {
 
   // on initial load:
   // 1. fetch the workflow presets persisted on server-side
-  // 2. fetch the ML models. these may be used in quick-create views when selecting a preset,
+  // 2. fetch the ML models and connectors. these may be used in quick-create views when selecting a preset,
   //    so we optimize by fetching once at the top-level here.
   useEffect(() => {
     dispatch(getWorkflowPresets());
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
+    dispatch(searchConnectors({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
   }, []);
 
   // initial hook to populate all workflows

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -117,6 +117,11 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
               embeddingLength: dimensions,
             });
           }
+        } else {
+          setFieldValues({
+            ...fieldValues,
+            embeddingLength: undefined,
+          });
         }
       }
     }

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -98,6 +98,8 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
     if (selectedModel?.connectorId !== undefined) {
       const connector = connectors[selectedModel.connectorId];
       if (connector !== undefined) {
+        // some APIs allow specifically setting the dimensions at runtime,
+        // so we check for that first.
         if (connector.parameters?.dimensions !== undefined) {
           setFieldValues({
             ...fieldValues,

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -16,8 +16,10 @@ import {
   EuiCompressedFieldNumber,
 } from '@elastic/eui';
 import {
+  COHERE_DIMENSIONS,
   MODEL_STATE,
   Model,
+  OPENAI_DIMENSIONS,
   QuickConfigureFields,
   WORKFLOW_TYPE,
 } from '../../../../common';
@@ -35,7 +37,7 @@ const DEFAULT_IMAGE_FIELD = 'my_image';
 // Dynamic component to allow optional input configuration fields for different use cases.
 // Hooks back to the parent component with such field values
 export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
-  const models = useSelector((state: AppState) => state.models.models);
+  const { models, connectors } = useSelector((state: AppState) => state.ml);
 
   // Deployed models state
   const [deployedModels, setDeployedModels] = useState<Model[]>([]);
@@ -87,6 +89,38 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
   useEffect(() => {
     props.setFields(fieldValues);
   }, [fieldValues]);
+
+  // Try to pre-fill the dimensions based on the chosen model
+  useEffect(() => {
+    const selectedModel = deployedModels.find(
+      (model) => model.id === fieldValues.embeddingModelId
+    );
+    if (selectedModel?.connectorId !== undefined) {
+      const connector = connectors[selectedModel.connectorId];
+      if (connector !== undefined) {
+        if (connector.parameters?.dimensions !== undefined) {
+          setFieldValues({
+            ...fieldValues,
+            embeddingLength: connector.parameters?.dimensions,
+          });
+        } else if (connector.parameters?.model !== undefined) {
+          const dimensions =
+            // @ts-ignore
+            COHERE_DIMENSIONS[connector.parameters?.model] ||
+            // @ts-ignore
+            (OPENAI_DIMENSIONS[connector.parameters?.model] as
+              | number
+              | undefined);
+          if (dimensions !== undefined) {
+            setFieldValues({
+              ...fieldValues,
+              embeddingLength: dimensions,
+            });
+          }
+        }
+      }
+    }
+  }, [fieldValues.embeddingModelId, deployedModels, connectors]);
 
   return (
     <>
@@ -196,7 +230,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <EuiCompressedFormRow
               label={'Embedding length'}
               isInvalid={false}
-              helpText="The length / dimension of the generated vector embeddings"
+              helpText="The length / dimension of the generated vector embeddings. Autofilled values may be inaccurate."
             >
               <EuiCompressedFieldNumber
                 value={fieldValues?.embeddingLength || ''}

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -24,6 +24,7 @@ import {
   SimulateIngestPipelineDoc,
   BULK_NODE_API_PATH,
   BASE_NODE_API_PATH,
+  SEARCH_CONNECTORS_NODE_API_PATH,
 } from '../common';
 
 /**
@@ -108,6 +109,11 @@ export interface RouteService {
     body: {},
     dataSourceId?: string
   ) => Promise<any | HttpFetchError>;
+  searchConnectors: (
+    body: {},
+    dataSourceId?: string
+  ) => Promise<any | HttpFetchError>;
+
   simulatePipeline: (
     body: {
       pipeline: IngestPipelineConfig;
@@ -334,6 +340,19 @@ export function configureRoutes(core: CoreStart): RouteService {
         const url = dataSourceId
           ? `${BASE_NODE_API_PATH}/${dataSourceId}/model/search`
           : SEARCH_MODELS_NODE_API_PATH;
+        const response = await core.http.post<{ respString: string }>(url, {
+          body: JSON.stringify(body),
+        });
+        return response;
+      } catch (e: any) {
+        return e as HttpFetchError;
+      }
+    },
+    searchConnectors: async (body: {}, dataSourceId?: string) => {
+      try {
+        const url = dataSourceId
+          ? `${BASE_NODE_API_PATH}/${dataSourceId}/connector/search`
+          : SEARCH_CONNECTORS_NODE_API_PATH;
         const response = await core.http.post<{ respString: string }>(url, {
           body: JSON.stringify(body),
         });

--- a/public/store/reducers/index.ts
+++ b/public/store/reducers/index.ts
@@ -6,4 +6,4 @@
 export * from './opensearch_reducer';
 export * from './workflows_reducer';
 export * from './presets_reducer';
-export * from './models_reducer';
+export * from './ml_reducer';

--- a/public/store/store.ts
+++ b/public/store/store.ts
@@ -10,13 +10,13 @@ import {
   opensearchReducer,
   workflowsReducer,
   presetsReducer,
-  modelsReducer,
+  mlReducer,
 } from './reducers';
 
 const rootReducer = combineReducers({
   workflows: workflowsReducer,
   presets: presetsReducer,
-  models: modelsReducer,
+  ml: mlReducer,
   opensearch: opensearchReducer,
 });
 

--- a/server/cluster/ml_plugin.ts
+++ b/server/cluster/ml_plugin.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ML_SEARCH_MODELS_ROUTE } from '../../common';
+import {
+  ML_SEARCH_CONNECTORS_ROUTE,
+  ML_SEARCH_MODELS_ROUTE,
+} from '../../common';
 
 /**
  * Used during the plugin's setup() lifecycle phase to register various client actions
@@ -20,6 +23,14 @@ export function mlPlugin(Client: any, config: any, components: any) {
   mlClient.searchModels = ca({
     url: {
       fmt: ML_SEARCH_MODELS_ROUTE,
+    },
+    needBody: true,
+    method: 'POST',
+  });
+
+  mlClient.searchConnectors = ca({
+    url: {
+      fmt: ML_SEARCH_CONNECTORS_ROUTE,
     },
     needBody: true,
     method: 'POST',

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -4,6 +4,8 @@
  */
 
 import {
+  Connector,
+  ConnectorDict,
   DEFAULT_NEW_WORKFLOW_STATE_TYPE,
   INDEX_NOT_FOUND_EXCEPTION,
   MODEL_ALGORITHM,
@@ -126,10 +128,32 @@ export function getModelsFromResponses(modelHits: SearchHit[]): ModelDict {
             modelHit._source?.model_config?.embedding_dimension,
         },
         interface: modelInterface,
+        connectorId: modelHit._source?.connector_id,
       } as Model;
     }
   });
   return modelDict;
+}
+
+export function getConnectorsFromResponses(
+  modelHits: SearchHit[]
+): ConnectorDict {
+  const connectorDict = {} as ConnectorDict;
+  modelHits.forEach((connectorHit: SearchHit) => {
+    const connectorId = connectorHit._id;
+
+    // in case of schema changes from ML plugin, this may crash. That is ok, as the error
+    // produced will help expose the root cause
+    connectorDict[connectorId] = {
+      id: connectorId,
+      name: connectorHit._source?.name,
+      parameters: {
+        model: connectorHit._source?.parameters?.model,
+        dimensions: connectorHit._source?.parameters.dimensions,
+      },
+    } as Connector;
+  });
+  return connectorDict;
 }
 
 // Convert the workflow state into a readable/presentable state on frontend


### PR DESCRIPTION
### Description

This PR adds a set of constants for common embedding models from popular remote services. If a model name is found in the connector blueprint, and it is a model that we persist a constant for, we prefill the dimensions with the known value.

More details:
- onboards the search connectors API to fetch connector details (in this case, any specified 'model' name found)
- adds dimensions constants for OpenAI and Cohere popular embedding models
- adds basic Connector-based interfaces
- adds a hook in `QuickConfigureInputs` to try to derive the `dimensions` when a model is selected. this is done by traversing to the associated connector ID, extracting out the details, and looking for the model name
- minor tuning of the select dropdown in the maps 

Demo video, showing the "Embedding length" field being auto-populated:

[screen-capture (8).webm](https://github.com/user-attachments/assets/ef4c324f-9e85-45e7-84cf-3a9d757c03ae)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
