### PR TITLE
Rename visible plugin name to Search Studio

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -6,8 +6,8 @@
 import { MapEntry, QueryPreset, WORKFLOW_STATE } from './interfaces';
 import { customStringify } from './utils';
 
-export const PLUGIN_ID = 'flow-framework';
-export const SEARCH_STUDIO = 'Search Studio';
+export const PLUGIN_ID = 'search-studio';
+export const PLUGIN_NAME = 'Search Studio';
 
 /**
  * BACKEND FLOW FRAMEWORK APIs

--- a/public/app.tsx
+++ b/public/app.tsx
@@ -52,7 +52,7 @@ export const FlowFrameworkDashboardsApp = (props: Props) => {
         style={{ width: 190 }}
         items={[
           {
-            name: Navigation.FlowFramework,
+            name: Navigation.PluginName,
             id: 0,
             items: [
               {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -90,7 +90,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
             { text: '' },
           ]
         : [
-            BREADCRUMBS.FLOW_FRAMEWORK,
+            BREADCRUMBS.PLUGIN_NAME,
             BREADCRUMBS.WORKFLOWS(dataSourceEnabled ? dataSourceId : undefined),
             { text: workflowName },
           ]

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -25,7 +25,7 @@ import { WorkflowList } from './workflow_list';
 import { NewWorkflow } from './new_workflow';
 import { AppState, searchWorkflows, useAppDispatch } from '../../store';
 import { EmptyListMessage } from './empty_list_message';
-import { FETCH_ALL_QUERY, SEARCH_STUDIO } from '../../../common';
+import { FETCH_ALL_QUERY, PLUGIN_NAME } from '../../../common';
 import { ImportWorkflowModal } from './import_workflow';
 import { MountPoint } from '../../../../../src/core/public';
 import { DataSourceSelectableConfig } from '../../../../../src/plugins/data_source_management/public';
@@ -131,7 +131,7 @@ export function Workflows(props: WorkflowsProps) {
       SHOW_ACTIONS_IN_HEADER
         ? [BREADCRUMBS.TITLE]
         : [
-            BREADCRUMBS.FLOW_FRAMEWORK,
+            BREADCRUMBS.PLUGIN_NAME,
             BREADCRUMBS.WORKFLOWS(dataSourceEnabled ? dataSourceId : undefined),
           ]
     );
@@ -204,14 +204,15 @@ export function Workflows(props: WorkflowsProps) {
       );
     }, [getSavedObjectsClient, getNotifications(), props.setActionMenu]);
   }
-  const description =
-    'Design, experiment, and prototype your solutions with workflows. Build your search and last mile ingestion flows.';
+  const DESCRIPTION = `Design, experiment, and prototype your solutions with ${PLUGIN_NAME}. Build your search and last mile 
+  ingestion flows with a visual interface. Experiment with different configurations with prototyping tools and launch them 
+  into your environment.`;
+
   const pageTitleAndDescription = SHOW_ACTIONS_IN_HEADER ? (
     <HeaderControl
       controls={[
         {
-          description:
-            'Design, experiment, and prototype your solutions with Search Studio. Build your search and last mile ingestion flows with a visual interface. Experiment different configurations with prototyping tools and launch them into your environment.',
+          description: DESCRIPTION,
         },
       ]}
       setMountPoint={setAppDescriptionControls}
@@ -219,9 +220,9 @@ export function Workflows(props: WorkflowsProps) {
   ) : (
     <EuiFlexGroup direction="column" style={{ margin: '0px' }}>
       <EuiTitle size="l">
-        <h1>{SEARCH_STUDIO}</h1>
+        <h1>{PLUGIN_NAME}</h1>
       </EuiTitle>
-      <EuiText color="subdued">{description}</EuiText>
+      <EuiText color="subdued">{DESCRIPTION}</EuiText>
     </EuiFlexGroup>
   );
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -16,7 +16,7 @@ import {
   FlowFrameworkDashboardsPluginSetup,
   AppPluginStartDependencies,
 } from './types';
-import { PLUGIN_ID, SEARCH_STUDIO } from '../common';
+import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import {
   setCore,
   setRouteService,
@@ -45,7 +45,7 @@ export class FlowFrameworkDashboardsPlugin
     // Register the plugin in the side navigation
     core.application.register({
       id: PLUGIN_ID,
-      title: 'Flow Framework',
+      title: PLUGIN_NAME,
       category: {
         id: 'opensearch',
         label: 'OpenSearch plugins',
@@ -67,7 +67,7 @@ export class FlowFrameworkDashboardsPlugin
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
       {
         id: PLUGIN_ID,
-        title: SEARCH_STUDIO,
+        title: PLUGIN_NAME,
         category: DEFAULT_APP_CATEGORIES.configure,
         showInAllNavGroup: true,
       },

--- a/public/render_app.tsx
+++ b/public/render_app.tsx
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 import { AppMountParameters, CoreStart } from '../../../src/core/public';
 import { FlowFrameworkDashboardsApp } from './app';
 import { store } from './store';
+import { PLUGIN_ID } from '../common';
 
 // styling
 import './global-styles.scss';
@@ -38,14 +39,14 @@ export const renderApp = (
     params.element
   );
 
-  const expectedBasePath = '/app/flow-framework#';
+  const EXPECTED_BASE_PATH = `/app/${PLUGIN_ID}#`;
 
   const unlistenParentHistory = params.history.listen(() => {
     if (
       hideInAppSideNavBar &&
-      window.location.pathname.endsWith('/app/flow-framework')
+      window.location.pathname.endsWith(`/app/${PLUGIN_ID}`)
     ) {
-      window.location.href = `${expectedBasePath}`;
+      window.location.href = EXPECTED_BASE_PATH;
       window.dispatchEvent(new HashChangeEvent('hashchange'));
     }
   });

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -5,10 +5,10 @@
 
 import { constructHrefWithDataSourceId } from './utils';
 import { getUISettings } from '../../public/services';
-import { SEARCH_STUDIO } from '../../common/constants';
+import { PLUGIN_NAME } from '../../common/constants';
 
 export enum Navigation {
-  FlowFramework = 'Flow Framework',
+  PluginName = PLUGIN_NAME,
   Workflows = 'Workflows',
 }
 
@@ -19,14 +19,14 @@ export enum APP_PATH {
 }
 
 export const BREADCRUMBS = Object.freeze({
-  FLOW_FRAMEWORK: { text: 'Flow Framework' },
+  PLUGIN_NAME: { text: PLUGIN_NAME },
   WORKFLOWS: (dataSourceId?: string) => ({
     text: 'Workflows',
     href: constructHrefWithDataSourceId(APP_PATH.WORKFLOWS, dataSourceId),
   }),
-  TITLE: { text: SEARCH_STUDIO },
+  TITLE: { text: PLUGIN_NAME },
   TITLE_WITH_REF: (dataSourceId?: string) => ({
-    text: SEARCH_STUDIO,
+    text: PLUGIN_NAME,
     href: constructHrefWithDataSourceId(APP_PATH.WORKFLOWS, dataSourceId),
   }),
   WORKFLOW_NAME: (workflowName: string) => ({


### PR DESCRIPTION
### Description

Renames all of the visible titles of the plugin on the UI, including the plugin name in the OSD side nav bar, the url paths, and the breadcrumbs. Also minor cleanup to add constants and some consistency.

Screenshots of changes:

![side-nav](https://github.com/user-attachments/assets/a5555395-e023-4b7a-9d6f-71d9df39f968)

![url](https://github.com/user-attachments/assets/4c9b07c3-57ab-4160-bece-831348a7fc09)

![breadcrumbs](https://github.com/user-attachments/assets/de775842-398d-4273-96a6-e7cd8eeeddbd)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
