### PR TITLE
Improve and simplify processor form configs

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -396,6 +396,7 @@ export const DATE_FORMAT_PATTERN = 'MM/DD/YY hh:mm A';
 export const EMPTY_FIELD_STRING = '--';
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
 export const ERROR_GETTING_WORKFLOW_MSG = 'Failed to retrieve template';
+export const NO_TEMPLATES_FOUND_MSG = 'There are no templates';
 export const NO_MODIFICATIONS_FOUND_TEXT =
   'Template does not contain any modifications';
 export const JSONPATH_ROOT_SELECTOR = '$.';

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -30,6 +30,7 @@ import {
   ERROR_GETTING_WORKFLOW_MSG,
   FETCH_ALL_QUERY,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
+  NO_TEMPLATES_FOUND_MSG,
   getCharacterLimitedString,
 } from '../../../common';
 import { MountPoint } from '../../../../../src/core/public';
@@ -105,7 +106,8 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
   }, []);
 
-  return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ? (
+  return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ||
+    errorMessage.includes(NO_TEMPLATES_FOUND_MSG) ? (
     <EuiFlexGroup direction="column" alignItems="center">
       <EuiFlexItem grow={3}>
         <EuiEmptyPrompt

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -108,9 +108,6 @@ export function MapField(props: MapFieldProps) {
                                   fieldPath={`${props.fieldPath}.${idx}.key`}
                                   options={props.keyOptions as any[]}
                                   placeholder={props.keyPlaceholder || 'Input'}
-                                  autofill={
-                                    props.keyOptions?.length === 1 && idx === 0
-                                  }
                                 />
                               ) : (
                                 <TextField
@@ -124,7 +121,7 @@ export function MapField(props: MapFieldProps) {
                           </EuiFlexItem>
                           <EuiFlexItem
                             grow={false}
-                            style={{ marginTop: '14px' }}
+                            style={{ marginTop: '10px' }}
                           >
                             <EuiIcon type="sortRight" />
                           </EuiFlexItem>
@@ -136,10 +133,6 @@ export function MapField(props: MapFieldProps) {
                                   options={props.valueOptions || []}
                                   placeholder={
                                     props.valuePlaceholder || 'Output'
-                                  }
-                                  autofill={
-                                    props.valueOptions?.length === 1 &&
-                                    idx === 0
                                   }
                                 />
                               ) : (
@@ -158,7 +151,6 @@ export function MapField(props: MapFieldProps) {
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiSmallButtonIcon
-                          style={{ marginTop: '8px' }}
                           iconType={'trash'}
                           color="danger"
                           aria-label="Delete"

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -13,7 +13,6 @@ interface SelectWithCustomOptionsProps {
   fieldPath: string;
   placeholder: string;
   options: any[];
-  autofill: boolean;
 }
 
 /**
@@ -27,19 +26,11 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
   // selected option state
   const [selectedOption, setSelectedOption] = useState<any[]>([]);
 
-  // update the selected option when the form is updated. if the form is empty,
-  // default to the top option. by default, this will re-trigger this hook with a populated
-  // value, to then finally update the displayed option.
+  // set the visible option when the underlying form is updated.
   useEffect(() => {
-    if (props.autofill) {
-      const formValue = getIn(values, props.fieldPath);
-      if (!isEmpty(formValue)) {
-        setSelectedOption([{ label: getIn(values, props.fieldPath) }]);
-      } else {
-        if (props.options.length > 0) {
-          setFieldValue(props.fieldPath, props.options[0].label);
-        }
-      }
+    const formValue = getIn(values, props.fieldPath);
+    if (!isEmpty(formValue)) {
+      setSelectedOption([{ label: formValue }]);
     }
   }, [getIn(values, props.fieldPath)]);
 
@@ -73,7 +64,7 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
   return (
     <EuiComboBox
       fullWidth={true}
-      compressed={false}
+      compressed={true}
       placeholder={props.placeholder}
       singleSelection={{ asPlainText: true }}
       isClearable={false}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -28,6 +28,7 @@ import {
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
   MapArrayFormValue,
+  ModelInterface,
   PROCESSOR_CONTEXT,
   SearchHit,
   SimulateIngestPipelineResponse,
@@ -47,7 +48,7 @@ import {
   useAppDispatch,
 } from '../../../../store';
 import { getCore } from '../../../../services';
-import { getDataSourceId } from '../../../../utils/utils';
+import { getDataSourceId, parseModelInputs } from '../../../../utils/utils';
 import { MapArrayField } from '../input_fields';
 
 interface InputTransformModalProps {
@@ -56,7 +57,7 @@ interface InputTransformModalProps {
   context: PROCESSOR_CONTEXT;
   inputMapField: IConfigField;
   inputMapFieldPath: string;
-  inputFields: any[];
+  modelInterface: ModelInterface | undefined;
   onClose: () => void;
 }
 
@@ -87,6 +88,10 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const [selectedOutputOption, setSelectedOutputOption] = useState<
     number | undefined
   >((outputOptions[0]?.value as number) ?? undefined);
+
+  // TODO: integrated with Ajv to fetch any model interface and perform validation
+  // on the produced output on-the-fly. For examples, see
+  // https://www.npmjs.com/package/ajv
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
@@ -254,7 +259,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                     ? 'Query field'
                     : 'Document field'
                 }
-                keyOptions={props.inputFields}
+                keyOptions={parseModelInputs(props.modelInterface)}
                 // If the map we are adding is the first one, populate the selected option to index 0
                 onMapAdd={(curArray) => {
                   if (isEmpty(curArray)) {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -274,15 +274,19 @@ export function InputTransformModal(props: InputTransformModalProps) {
           </EuiFlexItem>
           <EuiFlexItem>
             <>
-              <EuiCompressedSelect
-                prepend={<EuiText>Expected output for</EuiText>}
-                options={outputOptions}
-                value={selectedOutputOption}
-                onChange={(e) => {
-                  setSelectedOutputOption(Number(e.target.value));
-                  setTransformedOutput('{}');
-                }}
-              />
+              {outputOptions.length === 1 ? (
+                <EuiText>Expected output</EuiText>
+              ) : (
+                <EuiCompressedSelect
+                  prepend={<EuiText>Expected output for</EuiText>}
+                  options={outputOptions}
+                  value={selectedOutputOption}
+                  onChange={(e) => {
+                    setSelectedOutputOption(Number(e.target.value));
+                    setTransformedOutput('{}');
+                  }}
+                />
+              )}
               <EuiSpacer size="s" />
               <EuiSmallButton
                 style={{ width: '100px' }}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -22,10 +22,9 @@ import {
   PROCESSOR_CONTEXT,
   WorkflowConfig,
   JSONPATH_ROOT_SELECTOR,
-  ModelInputFormField,
-  ModelOutputFormField,
   ML_INFERENCE_DOCS_LINK,
   WorkflowFormValues,
+  ModelInterface,
 } from '../../../../../common';
 import { MapArrayField, ModelField } from '../input_fields';
 import { isEmpty } from 'lodash';
@@ -108,9 +107,9 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   >(false);
 
   // model interface state
-  const [hasModelInterface, setHasModelInterface] = useState<boolean>(true);
-  const [inputFields, setInputFields] = useState<ModelInputFormField[]>([]);
-  const [outputFields, setOutputFields] = useState<ModelOutputFormField[]>([]);
+  const [modelInterface, setModelInterface] = useState<
+    ModelInterface | undefined
+  >(undefined);
 
   // Hook to listen when the selected model has changed. We do a few checks here:
   // 1: update model interface states
@@ -136,15 +135,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   // reusable function to update interface states based on the model ID
   function updateModelInterfaceStates(modelId: string) {
     const newSelectedModel = models[modelId];
-    if (newSelectedModel?.interface !== undefined) {
-      setInputFields(parseModelInputs(newSelectedModel.interface));
-      setOutputFields(parseModelOutputs(newSelectedModel.interface));
-      setHasModelInterface(true);
-    } else {
-      setInputFields([]);
-      setOutputFields([]);
-      setHasModelInterface(false);
-    }
+    setModelInterface(newSelectedModel?.interface);
   }
 
   return (
@@ -156,7 +147,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           context={props.context}
           inputMapField={inputMapField}
           inputMapFieldPath={inputMapFieldPath}
-          inputFields={inputFields}
+          modelInterface={modelInterface}
           onClose={() => setIsInputTransformModalOpen(false)}
         />
       )}
@@ -167,14 +158,14 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           context={props.context}
           outputMapField={outputMapField}
           outputMapFieldPath={outputMapFieldPath}
-          outputFields={outputFields}
+          modelInterface={modelInterface}
           onClose={() => setIsOutputTransformModalOpen(false)}
         />
       )}
       <ModelField
         field={modelField}
         fieldPath={modelFieldPath}
-        hasModelInterface={hasModelInterface}
+        hasModelInterface={modelInterface !== undefined}
         onModelChange={onModelChange}
       />
       {!isEmpty(getIn(values, modelFieldPath)?.id) && (
@@ -226,7 +217,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 ? 'Query field'
                 : 'Document field'
             }
-            keyOptions={inputFields}
+            keyOptions={parseModelInputs(modelInterface)}
           />
           <EuiSpacer size="l" />
           <EuiFlexGroup direction="row">
@@ -274,7 +265,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : 'Document field'
             }
             valuePlaceholder="Model output field"
-            valueOptions={outputFields}
+            valueOptions={parseModelOutputs(modelInterface)}
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -28,6 +28,7 @@ import {
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
   MapArrayFormValue,
+  ModelInterface,
   PROCESSOR_CONTEXT,
   SearchHit,
   SearchPipelineConfig,
@@ -49,7 +50,7 @@ import {
 } from '../../../../store';
 import { getCore } from '../../../../services';
 import { MapArrayField } from '../input_fields';
-import { getDataSourceId } from '../../../../utils/utils';
+import { getDataSourceId, parseModelOutputs } from '../../../../utils/utils';
 
 interface OutputTransformModalProps {
   uiConfig: WorkflowConfig;
@@ -57,7 +58,7 @@ interface OutputTransformModalProps {
   context: PROCESSOR_CONTEXT;
   outputMapField: IConfigField;
   outputMapFieldPath: string;
-  outputFields: any[];
+  modelInterface: ModelInterface | undefined;
   onClose: () => void;
 }
 
@@ -237,7 +238,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Document field"
                 valuePlaceholder="Model output field"
-                valueOptions={props.outputFields}
+                valueOptions={parseModelOutputs(props.modelInterface)}
                 // If the map we are adding is the first one, populate the selected option to index 0
                 onMapAdd={(curArray) => {
                   if (isEmpty(curArray)) {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -79,7 +79,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   // selected output state
   const outputOptions = map.map((_, idx) => ({
     value: idx,
-    text: `Prediction output ${idx + 1}`,
+    text: `Prediction ${idx + 1}`,
   })) as EuiSelectOption[];
   const [selectedOutputOption, setSelectedOutputOption] = useState<
     number | undefined
@@ -257,15 +257,19 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
           </EuiFlexItem>
           <EuiFlexItem>
             <>
-              <EuiCompressedSelect
-                prepend={<EuiText>Expected output for</EuiText>}
-                options={outputOptions}
-                value={selectedOutputOption}
-                onChange={(e) => {
-                  setSelectedOutputOption(Number(e.target.value));
-                  setTransformedOutput('{}');
-                }}
-              />
+              {outputOptions.length === 1 ? (
+                <EuiText>Expected output</EuiText>
+              ) : (
+                <EuiCompressedSelect
+                  prepend={<EuiText>Expected output for</EuiText>}
+                  options={outputOptions}
+                  value={selectedOutputOption}
+                  onChange={(e) => {
+                    setSelectedOutputOption(Number(e.target.value));
+                    setTransformedOutput('{}');
+                  }}
+                />
+              )}
               <EuiSpacer size="s" />
               <EuiSmallButton
                 style={{ width: '100px' }}

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -51,6 +51,10 @@ const PANEL_ID = 0;
 export function ProcessorsList(props: ProcessorsListProps) {
   const { values } = useFormikContext<WorkflowFormValues>();
 
+  // Processor added state. Used to automatically open accordion when a new
+  // processor is added, assuming users want to immediately configure it.
+  const [processorAdded, setProcessorAdded] = useState<boolean>(false);
+
   // Popover state when adding new processors
   const [isPopoverOpen, setPopover] = useState(false);
   const closePopover = () => {
@@ -75,6 +79,7 @@ export function ProcessorsList(props: ProcessorsListProps) {
   // (getting any updated/interim values along the way) and add to
   // the list of processors
   function addProcessor(processor: IProcessorConfig): void {
+    setProcessorAdded(true);
     const existingConfig = cloneDeep(props.uiConfig as WorkflowConfig);
     let newConfig = formikToUiConfig(values, existingConfig);
     switch (props.context) {
@@ -139,6 +144,9 @@ export function ProcessorsList(props: ProcessorsListProps) {
         return (
           <EuiFlexItem key={processorIndex}>
             <EuiAccordion
+              initialIsOpen={
+                processorAdded && processorIndex === processors.length - 1
+              }
               id={`accordion${processor.id}`}
               buttonContent={`${processor.name || 'Processor'}`}
               extraAction={

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -10,10 +10,10 @@ import {
   EuiContextMenu,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHorizontalRule,
   EuiPanel,
   EuiPopover,
-  EuiText,
+  EuiAccordion,
+  EuiSpacer,
 } from '@elastic/eui';
 import { cloneDeep } from 'lodash';
 import { useFormikContext } from 'formik';
@@ -138,36 +138,37 @@ export function ProcessorsList(props: ProcessorsListProps) {
       {processors.map((processor: IProcessorConfig, processorIndex) => {
         return (
           <EuiFlexItem key={processorIndex}>
-            <EuiPanel>
-              <EuiFlexGroup direction="row" justifyContent="spaceBetween">
-                <EuiFlexItem grow={false}>
-                  <EuiText>{processor.name || 'Processor'}</EuiText>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiSmallButtonIcon
-                    iconType={'trash'}
-                    color="danger"
-                    aria-label="Delete"
-                    onClick={() => {
-                      deleteProcessor(processor.id);
-                    }}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiHorizontalRule size="full" margin="s" />
-              <ProcessorInputs
-                uiConfig={props.uiConfig}
-                config={processor}
-                baseConfigPath={
-                  props.context === PROCESSOR_CONTEXT.INGEST
-                    ? 'ingest.enrich'
-                    : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                    ? 'search.enrichRequest'
-                    : 'search.enrichResponse'
-                }
-                context={props.context}
-              />
-            </EuiPanel>
+            <EuiAccordion
+              id={`accordion${processor.id}`}
+              buttonContent={`${processor.name || 'Processor'}`}
+              extraAction={
+                <EuiSmallButtonIcon
+                  style={{ marginTop: '8px' }}
+                  iconType={'trash'}
+                  color="danger"
+                  aria-label="Delete"
+                  onClick={() => {
+                    deleteProcessor(processor.id);
+                  }}
+                />
+              }
+            >
+              <EuiSpacer size="s" />
+              <EuiPanel>
+                <ProcessorInputs
+                  uiConfig={props.uiConfig}
+                  config={processor}
+                  baseConfigPath={
+                    props.context === PROCESSOR_CONTEXT.INGEST
+                      ? 'ingest.enrich'
+                      : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                      ? 'search.enrichRequest'
+                      : 'search.enrichResponse'
+                  }
+                  context={props.context}
+                />
+              </EuiPanel>
+            </EuiAccordion>
           </EuiFlexItem>
         );
       })}
@@ -178,7 +179,6 @@ export function ProcessorsList(props: ProcessorsListProps) {
               <EuiSmallButton
                 iconType="arrowDown"
                 iconSide="right"
-                size="s"
                 onClick={() => {
                   setPopover(!isPopoverOpen);
                 }}

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -203,7 +203,7 @@ export function generateTransform(input: {}, map: MapFormValue): {} {
 
 // Derive the collection of model inputs from the model interface JSONSchema into a form-ready list
 export function parseModelInputs(
-  modelInterface: ModelInterface
+  modelInterface: ModelInterface | undefined
 ): ModelInputFormField[] {
   const modelInputsObj = get(
     modelInterface,
@@ -223,7 +223,7 @@ export function parseModelInputs(
 
 // Derive the collection of model outputs from the model interface JSONSchema into a form-ready list
 export function parseModelOutputs(
-  modelInterface: ModelInterface
+  modelInterface: ModelInterface | undefined
 ): ModelOutputFormField[] {
   const modelOutputsObj = get(modelInterface, 'output.properties', {}) as {
     [key: string]: ModelOutput;


### PR DESCRIPTION
### Description

PR to clean up and simplify some of the forms for configuring processors, and some other minor improvements. Specifically:
- wraps the processor forms in an accordion. They are all set to be closed by default, except when adding a new one inline, in which case defaults to being open to have less friction for starting to edit/config the newly added processor
- passes model interface instead of the derived model inputs/outputs as much to simplify the amount of state components, and set it up for downstream validation (to be added in a later PR)
- adds parsing logic in `QuickConfigureModal` to derive default key/value pairs in the input / output maps based on any model interface, if applicable. Adds flexibility and default support for multiple input/output fields, compared to 1, before.
- simplifies logic in `SelectWithCustomOptions` to just pull displayed values based on the form input, instead of adhoc form manipulation which caused bugs in certain scenarios
- makes the selector in the input/output map forms compressed and realigns some of the components that needed adjusted after #336 
- handles an edge case of no existing workflows on the details page

Demo video, showing:
- processors wrapped in accordion
- bug fixed to allow custom inputs in the input map / output map
- compressed view and form alignment

[screen-capture (9).webm](https://github.com/user-attachments/assets/0c947042-da60-43ae-b7fd-cfef9ee3db6d)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
