### PR TITLE
Integrate model interface info in advanced transform modals

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -377,9 +377,14 @@ export type ModelConfig = {
 export type ModelInput = {
   type: string;
   description?: string;
+  items?: ModelInput;
+  properties?: ModelInputMap;
 };
 
 export type ModelOutput = ModelInput;
+
+export type ModelInputMap = { [key: string]: ModelInput };
+export type ModelOutputMap = { [key: string]: ModelOutput };
 
 // For rendering options, we extract the name (the key in the input/output obj) and combine into a single obj
 export type ModelInputFormField = ModelInput & {
@@ -389,8 +394,8 @@ export type ModelInputFormField = ModelInput & {
 export type ModelOutputFormField = ModelInputFormField;
 
 export type ModelInterface = {
-  input: { [key: string]: ModelInput };
-  output: { [key: string]: ModelOutput };
+  input: ModelInput;
+  output: ModelOutput;
 };
 
 export type ConnectorParameters = {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -22,7 +22,7 @@ import {
   customStringify,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
-import { MDSQueryParams } from '../../common/interfaces';
+import { MDSQueryParams, ModelInputMap } from '../../common/interfaces';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
 import * as pluginManifest from '../../opensearch_dashboards.json';
@@ -205,13 +205,7 @@ export function generateTransform(input: {}, map: MapFormValue): {} {
 export function parseModelInputs(
   modelInterface: ModelInterface | undefined
 ): ModelInputFormField[] {
-  const modelInputsObj = get(
-    modelInterface,
-    // model interface input values will always be nested under a base "parameters" obj.
-    // we iterate through the obj properties to extract the individual inputs
-    'input.properties.parameters.properties',
-    {}
-  ) as { [key: string]: ModelInput };
+  const modelInputsObj = parseModelInputsObj(modelInterface);
   return Object.keys(modelInputsObj).map(
     (inputName: string) =>
       ({
@@ -219,6 +213,19 @@ export function parseModelInputs(
         ...modelInputsObj[inputName],
       } as ModelInputFormField)
   );
+}
+
+// Derive the collection of model inputs as an obj
+export function parseModelInputsObj(
+  modelInterface: ModelInterface | undefined
+): ModelInputMap {
+  return get(
+    modelInterface,
+    // model interface input values will always be nested under a base "parameters" obj.
+    // we iterate through the obj properties to extract the individual inputs
+    'input.properties.parameters.properties',
+    {}
+  ) as ModelInputMap;
 }
 
 // Derive the collection of model outputs from the model interface JSONSchema into a form-ready list


### PR DESCRIPTION
### Description

Adds more details and validation feedback in the transform modals. Specifically:
- for both input/output modals: remove the "generate" button and automatically generate the transforms if there is enough valid inputs to do it
- for input modal: add a "View model inputs" button at the bottom to fetch the model's input interface (if applicable). Opens up a popover with the JSON details
- for input modal: adds a validation icon indicating success/failure based on the generated output meeting the JSON schema requirements as defined by the model interface (if applicable)

Demo video below, using the example model with configured model interface. The UI indicates validation success or failure when there are correct and incorrect schemas produced by the input maps.
```
POST /_plugins/_ml/models/_register
{
  "name": "OpenAI embedding model strict interface v3",
  "function_name": "remote",
  "model_group_id": "...",
  "description": "An OpenAI embedding model with a defined interface.",
  "connector_id": "...",
  "interface": {
    "input": {
      "type": "object",
      "properties": {
        "parameters": {
          "type": "object",
          "properties": {
            "input": {
              "type": "string",
              "description": "String representing the plaintext input"
            }
          },
          "required": ["input"],
          "additionalProperties": false
        }
      },
      "required": ["parameters"],
      "additionalProperties": true
    },
    "output": {
      "type": "object",
      "properties": {
        "inference_results": {
          "type": "array",
          "items": {
            "type": "object",
            "data": {
              "type": "array",
              "items": {
                "type": "number"
              }
            }
          }
        }
      },
      "required": ["inference_results"],
      "additionalProperties": false
    }
  }
}
```

[screen-capture (10).webm](https://github.com/user-attachments/assets/b4f33ed6-04a5-4638-8f57-19fa4e0ac55f)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
