### PR TITLE
Onboard one-to-one config for ML search resp processors

### DIFF
--- a/public/configs/search_response_processors/ml_search_response_processor.ts
+++ b/public/configs/search_response_processors/ml_search_response_processor.ts
@@ -13,5 +13,12 @@ export class MLSearchResponseProcessor extends MLProcessor {
   constructor() {
     super();
     this.id = generateId('ml_processor_search_response');
+    this.optionalFields = [
+      {
+        id: 'one_to_one',
+        type: 'boolean',
+      },
+      ...(this.optionalFields || []),
+    ];
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -32,6 +32,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
   return (
     <EuiFlexItem grow={false}>
       {props.configFields.map((field, idx) => {
+        const fieldPath = `${props.baseConfigPath}.${props.configId}.${field.id}`;
         let el;
         switch (field.type) {
           case 'string': {
@@ -39,7 +40,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <TextField
                   label={camelCaseToTitleString(field.id)}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  fieldPath={fieldPath}
                   showError={true}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
@@ -50,10 +51,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
           case 'select': {
             el = (
               <EuiFlexItem key={idx}>
-                <SelectField
-                  field={field}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
-                />
+                <SelectField field={field} fieldPath={fieldPath} />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
             );
@@ -64,13 +62,13 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <BooleanField
                   label={camelCaseToTitleString(field.id)}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  fieldPath={fieldPath}
                   enabledOption={{
-                    id: 'true',
+                    id: `${fieldPath}_true`,
                     label: 'True',
                   }}
                   disabledOption={{
-                    id: 'false',
+                    id: `${fieldPath}_false`,
                     label: 'False',
                   }}
                   showLabel={true}
@@ -85,7 +83,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <NumberField
                   label={camelCaseToTitleString(field.id)}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  fieldPath={fieldPath}
                   showError={true}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
@@ -98,7 +96,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <JsonField
                   label={camelCaseToTitleString(field.id)}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  fieldPath={fieldPath}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
@@ -111,7 +109,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                 <JsonField
                   validate={false}
                   label={camelCaseToTitleString(field.id)}
-                  fieldPath={`${props.baseConfigPath}.${props.configId}.${field.id}`}
+                  fieldPath={fieldPath}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
+import { isEmpty } from 'lodash';
 import {
   EuiCallOut,
   EuiCompressedFormRow,
@@ -45,7 +46,7 @@ export function ModelField(props: ModelFieldProps) {
   // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
   const models = useSelector((state: AppState) => state.ml.models);
 
-  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched, values } = useFormikContext<WorkspaceFormValues>();
 
   // Deployed models state
   const [deployedModels, setDeployedModels] = useState<ModelItem[]>([]);
@@ -70,17 +71,18 @@ export function ModelField(props: ModelFieldProps) {
 
   return (
     <>
-      {!props.hasModelInterface && (
-        <>
-          <EuiCallOut
-            size="s"
-            title="The selected model does not have a model interface. Cannot automatically determine model inputs and outputs."
-            iconType={'alert'}
-            color="warning"
-          />
-          <EuiSpacer size="s" />
-        </>
-      )}
+      {!props.hasModelInterface &&
+        !isEmpty(getIn(values, props.fieldPath)?.id) && (
+          <>
+            <EuiCallOut
+              size="s"
+              title="The selected model does not have a model interface. Cannot automatically determine model inputs and outputs."
+              iconType={'alert'}
+              color="warning"
+            />
+            <EuiSpacer size="s" />
+          </>
+        )}
       <Field name={props.fieldPath}>
         {({ field, form }: FieldProps) => {
           return (


### PR DESCRIPTION
### Description

Onboards the added `one_to_one` configuration specifically for ML search response processors. For backend implementation, see https://github.com/opensearch-project/ml-commons/pull/2801.

- adds optional field to the response processor config
- minor bug fixes to the boolean form fields (there is issues with the `EuiRadioGroup` when duplicate option IDs visible on the DOM)
- minor bug fix to not display a "missing model interface" callout until a model is selected

Demo video, showing a model that is expecting a string input. When `one_to_one` is `false`, it fails, as the ML search resp processor collects all of the results into an array before sending to the model. When switching to `true`, it succeeds, since it treats each resp document as a standalone inference call, and does not nest in an array.

[screen-capture (12).webm](https://github.com/user-attachments/assets/5f5f972f-8bc1-4566-995e-5d233dedb1b2)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
