### PR TITLE
Add existing indices as a source data option; improve config autofilling

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -34,6 +34,7 @@ export const BASE_NODE_API_PATH = '/api/flow_framework';
 // OpenSearch node APIs
 export const BASE_OPENSEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/opensearch`;
 export const CAT_INDICES_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/catIndices`;
+export const GET_MAPPINGS_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/mappings`;
 export const SEARCH_INDEX_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/search`;
 export const INGEST_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/ingest`;
 export const BULK_NODE_API_PATH = `${BASE_OPENSEARCH_NODE_API_PATH}/bulk`;

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -238,12 +238,12 @@ export type NormalizationProcessor = SearchProcessor & {
 };
 
 export type IndexConfiguration = {
-  settings: {};
+  settings: { [key: string]: any };
   mappings: IndexMappings;
 };
 
 export type IndexMappings = {
-  properties: {};
+  properties: { [key: string]: any };
 };
 
 export type TemplateNode = {

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import moment from 'moment';
-import { DATE_FORMAT_PATTERN } from './';
+import { DATE_FORMAT_PATTERN, WORKFLOW_TYPE, Workflow } from './';
 import { isEmpty } from 'lodash';
 
 export function toFormattedDate(timestampMillis: number): String {
@@ -38,4 +38,15 @@ export function getCharacterLimitedString(
 
 export function customStringify(jsonObj: {}): string {
   return JSON.stringify(jsonObj, undefined, 2);
+}
+
+export function isVectorSearchUseCase(workflow: Workflow | undefined): boolean {
+  return (
+    workflow?.ui_metadata?.type !== undefined &&
+    [
+      WORKFLOW_TYPE.HYBRID_SEARCH,
+      WORKFLOW_TYPE.MULTIMODAL_SEARCH,
+      WORKFLOW_TYPE.SEMANTIC_SEARCH,
+    ].includes(workflow?.ui_metadata?.type)
+  );
 }

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useRef, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
 import {
@@ -21,6 +20,7 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
   WorkflowSchema,
+  customStringify,
 } from '../../../common';
 import {
   isValidUiWorkflow,
@@ -286,11 +286,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       </EuiFlexItem>
       <EuiFlexItem grow={7}>
         <EuiCodeBlock language="json" fontSize="m" isCopyable={false}>
-          {JSON.stringify(
-            reduceToTemplate(props.workflow as Workflow),
-            undefined,
-            2
-          )}
+          {customStringify(reduceToTemplate(props.workflow as Workflow))}
         </EuiCodeBlock>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -21,6 +21,7 @@ import { getCore } from '../../services';
 import { WorkflowDetailHeader } from './components';
 import {
   AppState,
+  catIndices,
   getWorkflow,
   searchModels,
   useAppDispatch,
@@ -101,9 +102,11 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   // On initial load:
   // - fetch workflow
   // - fetch available models as their IDs may be used when building flows
+  // - fetch all indices
   useEffect(() => {
     dispatch(getWorkflow({ workflowId, dataSourceId }));
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
+    dispatch(catIndices({ pattern: '*,-.*', dataSourceId }));
   }, []);
 
   return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ||

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -8,12 +8,13 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { SourceData } from './source_data';
 import { EnrichData } from './enrich_data';
 import { IngestData } from './ingest_data';
-import { WorkflowConfig } from '../../../../../common';
+import { Workflow, WorkflowConfig } from '../../../../../common';
 
 interface IngestInputsProps {
   setIngestDocs: (docs: string) => void;
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
+  workflow: Workflow | undefined;
 }
 
 /**
@@ -24,6 +25,7 @@ export function IngestInputs(props: IngestInputsProps) {
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
         <SourceData
+          workflow={props.workflow}
           uiConfig={props.uiConfig}
           setIngestDocs={props.setIngestDocs}
         />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -23,7 +23,10 @@ export function IngestInputs(props: IngestInputsProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <SourceData setIngestDocs={props.setIngestDocs} />
+        <SourceData
+          uiConfig={props.uiConfig}
+          setIngestDocs={props.setIngestDocs}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -106,13 +106,10 @@ export function SourceData(props: SourceDataProps) {
           setFieldValue('ingest.docs', customStringify(docObjs));
         });
 
-      // 2. fetch and set index mappings
+      // 2. fetch index mappings, and try to set default key/values for the ML processor input/output maps, if applicable
       dispatch(getMappings({ index: selectedIndex, dataSourceId }))
         .unwrap()
         .then((resp: IndexMappings) => {
-          setFieldValue('ingest.index.mappings', customStringify(resp));
-
-          // 3. try to set default key/values for the ML processor input/output maps, if applicable
           const {
             processorId,
             inputMapEntry,
@@ -262,10 +259,6 @@ export function SourceData(props: SourceDataProps) {
                 <>
                   <EuiText color="subdued" size="s">
                     Up to 5 sample documents will be automatically populated.
-                  </EuiText>
-                  <EuiText color="subdued" size="s">
-                    The currently-configured index mappings will be overwritten
-                    to match any selected index.
                   </EuiText>
                   <EuiSpacer size="s" />
                   <EuiCompressedSuperSelect

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -86,7 +86,7 @@ export function SourceData(props: SourceDataProps) {
     undefined
   );
   useEffect(() => {
-    if (selectedIndex !== undefined && isVectorSearchUseCase(props.workflow)) {
+    if (selectedIndex !== undefined) {
       // 1. fetch and set sample docs
       dispatch(
         searchIndex({
@@ -107,28 +107,30 @@ export function SourceData(props: SourceDataProps) {
         });
 
       // 2. fetch index mappings, and try to set defaults for the ML processor configs, if applicable
-      dispatch(getMappings({ index: selectedIndex, dataSourceId }))
-        .unwrap()
-        .then((resp: IndexMappings) => {
-          const { processorId, inputMapEntry } = getProcessorInfo(
-            props.uiConfig,
-            values
-          );
-          if (processorId !== undefined && inputMapEntry !== undefined) {
-            // set/overwrite default text field for the input map. may be empty.
-            if (inputMapEntry !== undefined) {
-              const textFieldFormPath = `ingest.enrich.${processorId}.input_map.0.0.value`;
-              const curTextField = getIn(values, textFieldFormPath) as string;
-              if (!Object.keys(resp.properties).includes(curTextField)) {
-                const defaultTextField =
-                  Object.keys(resp.properties).find((fieldName) => {
-                    return resp.properties[fieldName]?.type === 'text';
-                  }) || '';
-                setFieldValue(textFieldFormPath, defaultTextField);
+      if (isVectorSearchUseCase(props.workflow)) {
+        dispatch(getMappings({ index: selectedIndex, dataSourceId }))
+          .unwrap()
+          .then((resp: IndexMappings) => {
+            const { processorId, inputMapEntry } = getProcessorInfo(
+              props.uiConfig,
+              values
+            );
+            if (processorId !== undefined && inputMapEntry !== undefined) {
+              // set/overwrite default text field for the input map. may be empty.
+              if (inputMapEntry !== undefined) {
+                const textFieldFormPath = `ingest.enrich.${processorId}.input_map.0.0.value`;
+                const curTextField = getIn(values, textFieldFormPath) as string;
+                if (!Object.keys(resp.properties).includes(curTextField)) {
+                  const defaultTextField =
+                    Object.keys(resp.properties).find((fieldName) => {
+                      return resp.properties[fieldName]?.type === 'text';
+                    }) || '';
+                  setFieldValue(textFieldFormPath, defaultTextField);
+                }
               }
             }
-          }
-        });
+          });
+      }
     }
   }, [selectedIndex]);
 

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import {
   EuiCompressedFormRow,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
 } from '@elastic/eui';
@@ -31,7 +31,7 @@ export function SelectField(props: SelectFieldProps) {
       {({ field, form }: FieldProps) => {
         return (
           <EuiCompressedFormRow label={camelCaseToTitleString(props.field.id)}>
-            <EuiSuperSelect
+            <EuiCompressedSuperSelect
               options={
                 props.field.selectOptions
                   ? props.field.selectOptions.map(

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -257,12 +257,10 @@ export function InputTransformModal(props: InputTransformModalProps) {
                         .unwrap()
                         .then(async (resp) => {
                           setSourceInput(
-                            JSON.stringify(
+                            customStringify(
                               resp.hits.hits.map(
                                 (hit: SearchHit) => hit._source
-                              ),
-                              undefined,
-                              2
+                              )
                             )
                           );
                         })

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -210,12 +210,10 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         .unwrap()
                         .then(async (resp) => {
                           setSourceInput(
-                            JSON.stringify(
+                            customStringify(
                               resp.hits.hits.map(
                                 (hit: SearchHit) => hit._source
-                              ),
-                              undefined,
-                              2
+                              )
                             )
                           );
                         })

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -12,20 +12,19 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
   EuiTitle,
   EuiSpacer,
 } from '@elastic/eui';
-import { SearchHit, WorkflowFormValues } from '../../../../../common';
-import { JsonField } from '../input_fields';
 import {
-  AppState,
-  catIndices,
-  searchIndex,
-  useAppDispatch,
-} from '../../../../store';
+  SearchHit,
+  WorkflowFormValues,
+  customStringify,
+} from '../../../../../common';
+import { JsonField } from '../input_fields';
+import { AppState, searchIndex, useAppDispatch } from '../../../../store';
 import { getDataSourceId } from '../../../../utils/utils';
 import { EditQueryModal } from './edit_query_modal';
 
@@ -74,14 +73,6 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
     }
   }, [values?.search?.request]);
 
-  // Initialization hook to fetch available indices (if applicable)
-  useEffect(() => {
-    if (!ingestEnabled) {
-      // Fetch all indices besides system indices
-      dispatch(catIndices({ pattern: '*,-.*', dataSourceId }));
-    }
-  }, []);
-
   return (
     <>
       {isEditModalOpen && (
@@ -104,7 +95,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
                 readOnly={true}
               />
             ) : (
-              <EuiSuperSelect
+              <EuiCompressedSuperSelect
                 options={Object.values(indices).map(
                   (option) =>
                     ({
@@ -162,10 +153,8 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
                   .unwrap()
                   .then(async (resp) => {
                     props.setQueryResponse(
-                      JSON.stringify(
-                        resp.hits.hits.map((hit: SearchHit) => hit._source),
-                        undefined,
-                        2
+                      customStringify(
+                        resp.hits.hits.map((hit: SearchHit) => hit._source)
                       )
                     );
                   })

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -534,10 +534,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             .unwrap()
             .then(async (resp) => {
               props.setQueryResponse(
-                JSON.stringify(
-                  resp.hits.hits.map((hit: SearchHit) => hit._source),
-                  undefined,
-                  2
+                customStringify(
+                  resp.hits.hits.map((hit: SearchHit) => hit._source)
                 )
               );
             })

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -725,6 +725,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     setIngestDocs={props.setIngestDocs}
                     uiConfig={props.uiConfig}
                     setUiConfig={props.setUiConfig}
+                    workflow={props.workflow}
                   />
                 ) : (
                   <SearchInputs

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -82,7 +82,7 @@ function fetchEmptyMetadata(): UIState {
           name: {
             id: 'indexName',
             type: 'string',
-            value: 'my-new-index',
+            value: generateId('my_index', 6),
           },
           mappings: {
             id: 'indexMappings',

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -25,6 +25,7 @@ import {
   BULK_NODE_API_PATH,
   BASE_NODE_API_PATH,
   SEARCH_CONNECTORS_NODE_API_PATH,
+  GET_MAPPINGS_NODE_API_PATH,
 } from '../common';
 
 /**
@@ -78,6 +79,10 @@ export interface RouteService {
   getWorkflowPresets: () => Promise<any | HttpFetchError>;
   catIndices: (
     pattern: string,
+    dataSourceId?: string
+  ) => Promise<any | HttpFetchError>;
+  getMappings: (
+    index: string,
     dataSourceId?: string
   ) => Promise<any | HttpFetchError>;
   searchIndex: ({
@@ -264,6 +269,19 @@ export function configureRoutes(core: CoreStart): RouteService {
           : CAT_INDICES_NODE_API_PATH;
         const response = await core.http.get<{ respString: string }>(
           `${url}/${pattern}`
+        );
+        return response;
+      } catch (e: any) {
+        return e as HttpFetchError;
+      }
+    },
+    getMappings: async (index: string, dataSourceId?: string) => {
+      try {
+        const url = dataSourceId
+          ? `${BASE_NODE_API_PATH}/${dataSourceId}/opensearch/mappings`
+          : GET_MAPPINGS_NODE_API_PATH;
+        const response = await core.http.get<{ respString: string }>(
+          `${url}/${index}`
         );
         return response;
       } catch (e: any) {

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -20,6 +20,7 @@ const initialState = {
 
 const OPENSEARCH_PREFIX = 'opensearch';
 const CAT_INDICES_ACTION = `${OPENSEARCH_PREFIX}/catIndices`;
+const GET_MAPPINGS_ACTION = `${OPENSEARCH_PREFIX}/mappings`;
 const SEARCH_INDEX_ACTION = `${OPENSEARCH_PREFIX}/search`;
 const INGEST_ACTION = `${OPENSEARCH_PREFIX}/ingest`;
 const BULK_ACTION = `${OPENSEARCH_PREFIX}/bulk`;
@@ -40,6 +41,26 @@ export const catIndices = createAsyncThunk(
     if (response instanceof HttpFetchError) {
       return rejectWithValue(
         'Error running cat indices: ' + response.body.message
+      );
+    } else {
+      return response;
+    }
+  }
+);
+
+export const getMappings = createAsyncThunk(
+  GET_MAPPINGS_ACTION,
+  async (
+    { index, dataSourceId }: { index: string; dataSourceId?: string },
+    { rejectWithValue }
+  ) => {
+    const response: any | HttpFetchError = await getRouteService().getMappings(
+      index,
+      dataSourceId
+    );
+    if (response instanceof HttpFetchError) {
+      return rejectWithValue(
+        'Error getting index mappings: ' + response.body.message
       );
     } else {
       return response;
@@ -169,6 +190,10 @@ const opensearchSlice = createSlice({
         state.loading = true;
         state.errorMessage = '';
       })
+      .addCase(getMappings.pending, (state, action) => {
+        state.loading = true;
+        state.errorMessage = '';
+      })
       .addCase(searchIndex.pending, (state, action) => {
         state.loading = true;
         state.errorMessage = '';
@@ -186,6 +211,10 @@ const opensearchSlice = createSlice({
         state.loading = false;
         state.errorMessage = '';
       })
+      .addCase(getMappings.fulfilled, (state, action) => {
+        state.loading = false;
+        state.errorMessage = '';
+      })
       .addCase(searchIndex.fulfilled, (state, action) => {
         state.loading = false;
         state.errorMessage = '';
@@ -195,6 +224,10 @@ const opensearchSlice = createSlice({
         state.errorMessage = '';
       })
       .addCase(catIndices.rejected, (state, action) => {
+        state.errorMessage = action.payload as string;
+        state.loading = false;
+      })
+      .addCase(getMappings.rejected, (state, action) => {
         state.errorMessage = action.payload as string;
         state.loading = false;
       })


### PR DESCRIPTION
### Description

This PR adds a third option to specify the source data - from an existing index. When selected, x number of documents are automatically fetched and populated. Additionally, when data is fetched from an existing index (or from an uploaded document, attempt to prefill some config data. More specifically:
- if index data is automatically populated, 1/ clear and update ML ingest processors (if applicable) with new text/vector fields (image is ignored for now, as we don't have a clear default pattern in ML processors for this use case. Additionally, would increase the level of fine-grained assumptions we already make)
- if uploaded document data is automatically populated, clear some fields in the ML ingest processors (if applicable)

Additional improvements:
- cleans up remaining stringify operations to use `customStringify()`
- moves index fetching to the top-level `WorkflowDetail` page so it is optimized and only called once
- moves remaining form components that should be compressed (`EuiSuperSelect` -> `EuiCompressedSuperSelect`)

Demo video, showing a workflow with some sample data, then creating another workflow, building a semantic search use case on top of that existing workflow's data using the new multi-option UI for data source selection. Also shows the underlying configs updated when data is populated via manual entry or file upload. Note this does not currently overwrite any default index mappings; users will still need to ensure this is up-to-date before creating.

[screen-capture (13).webm](https://github.com/user-attachments/assets/d06662fc-bf49-49d9-ae57-208128a00e53)


### Issues Resolved

[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
