### PR TITLE
Fetch default options for ML processor config maps

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -410,6 +410,7 @@ export const DEFAULT_NEW_WORKFLOW_STATE = WORKFLOW_STATE.NOT_STARTED;
 export const DEFAULT_NEW_WORKFLOW_STATE_TYPE = ('NOT_STARTED' as any) as typeof WORKFLOW_STATE;
 export const DATE_FORMAT_PATTERN = 'MM/DD/YY hh:mm A';
 export const EMPTY_FIELD_STRING = '--';
+export const OMIT_SYSTEM_INDEX_PATTERN = '*,-.*';
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
 export const ERROR_GETTING_WORKFLOW_MSG = 'Failed to retrieve template';
 export const NO_TEMPLATES_FOUND_MSG = 'There are no templates';

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@types/jsonpath": "^0.2.4",
+    "flattie": "^1.1.1",
     "formik": "2.4.2",
     "jsonpath": "^1.1.1",
     "reactflow": "^11.8.3",

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -6,13 +6,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import {
-  RouteComponentProps,
-  Route,
-  Switch,
-  Router,
-  Redirect,
-} from 'react-router-dom';
+import { RouteComponentProps, Route, Switch, Router } from 'react-router-dom';
 import { WorkflowDetail } from './workflow_detail';
 import { WorkflowDetailRouterProps } from '../../pages';
 import '@testing-library/jest-dom';

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -32,6 +32,7 @@ import {
   FETCH_ALL_QUERY,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
   NO_TEMPLATES_FOUND_MSG,
+  OMIT_SYSTEM_INDEX_PATTERN,
   getCharacterLimitedString,
 } from '../../../common';
 import { MountPoint } from '../../../../../src/core/public';
@@ -106,7 +107,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   useEffect(() => {
     dispatch(getWorkflow({ workflowId, dataSourceId }));
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
-    dispatch(catIndices({ pattern: '*,-.*', dataSourceId }));
+    dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
   }, []);
 
   return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ||

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -37,8 +37,8 @@ interface MapArrayFieldProps {
   valuePlaceholder?: string;
   onMapAdd?: (curArray: MapArrayFormValue) => void;
   onMapDelete?: (idxToDelete: number) => void;
-  keyOptions?: any[];
-  valueOptions?: any[];
+  keyOptions?: { label: string }[];
+  valueOptions?: { label: string }[];
 }
 
 /**

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -31,8 +31,8 @@ interface MapFieldProps {
   helpText?: string;
   keyPlaceholder?: string;
   valuePlaceholder?: string;
-  keyOptions?: any[];
-  valueOptions?: any[];
+  keyOptions?: { label: string }[];
+  valueOptions?: { label: string }[];
 }
 
 /**

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -12,7 +12,7 @@ import { WorkspaceFormValues } from '../../../../../common';
 interface SelectWithCustomOptionsProps {
   fieldPath: string;
   placeholder: string;
-  options: any[];
+  options: { label: string }[];
 }
 
 /**
@@ -50,13 +50,15 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
     return (
       <EuiFlexGroup direction="row" alignItems="flexStart" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiText size="s">{option.label}</EuiText>
+          <EuiText size="s">{option.label || ''}</EuiText>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued" style={{ marginTop: '2px' }}>
-            {`(${option.type || 'unknown type'})`}
-          </EuiText>
-        </EuiFlexItem>
+        {option.type && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued" style={{ marginTop: '2px' }}>
+              {`(${option.type})`}
+            </EuiText>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     );
   }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -68,6 +68,7 @@ interface InputTransformModalProps {
   inputMapField: IConfigField;
   inputMapFieldPath: string;
   modelInterface: ModelInterface | undefined;
+  valueOptions: { label: string }[];
   onClose: () => void;
 }
 
@@ -163,7 +164,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 Fetch some sample input data and see how it is transformed.
               </EuiText>
               <EuiSpacer size="s" />
-              <EuiText>Expected input</EuiText>
+              <EuiText>Source input</EuiText>
               <EuiSmallButton
                 style={{ width: '100px' }}
                 onClick={async () => {
@@ -266,7 +267,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                         })
                         .catch((error: any) => {
                           getCore().notifications.toasts.addDanger(
-                            `Failed to fetch input data`
+                            `Failed to fetch source input data`
                           );
                         });
                       break;
@@ -307,12 +308,13 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
                 helpLink={ML_INFERENCE_DOCS_LINK}
                 keyPlaceholder="Model input field"
+                keyOptions={parseModelInputs(props.modelInterface)}
                 valuePlaceholder={
                   props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                     ? 'Query field'
                     : 'Document field'
                 }
-                keyOptions={parseModelInputs(props.modelInterface)}
+                valueOptions={props.valueOptions}
                 // If the map we are adding is the first one, populate the selected option to index 0
                 onMapAdd={(curArray) => {
                   if (isEmpty(curArray)) {
@@ -356,10 +358,10 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 )}
                 <EuiFlexItem grow={true}>
                   {outputOptions.length === 1 ? (
-                    <EuiText>Expected output</EuiText>
+                    <EuiText>Transformed input</EuiText>
                   ) : (
                     <EuiCompressedSelect
-                      prepend={<EuiText>Expected output for</EuiText>}
+                      prepend={<EuiText>Transformed input for</EuiText>}
                       options={outputOptions}
                       value={selectedOutputOption}
                       onChange={(e) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -178,7 +178,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     } catch {}
   }, [values?.search?.request]);
   useEffect(() => {
-    const indexName = values?.ingest?.index?.name as string | undefined;
+    const indexName = values?.search?.index?.name as string | undefined;
     if (indexName !== undefined && indices[indexName] !== undefined) {
       dispatch(
         getMappings({
@@ -201,7 +201,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           }
         });
     }
-  }, [values?.ingest?.index?.name]);
+  }, [values?.search?.index?.name]);
 
   return (
     <>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -213,6 +213,13 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           inputMapField={inputMapField}
           inputMapFieldPath={inputMapFieldPath}
           modelInterface={modelInterface}
+          valueOptions={
+            props.context === PROCESSOR_CONTEXT.INGEST
+              ? docFields
+              : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+              ? queryFields
+              : indexMappingFields
+          }
           onClose={() => setIsInputTransformModalOpen(false)}
         />
       )}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -126,7 +126,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 Fetch some sample output data and see how it is transformed.
               </EuiText>
               <EuiSpacer size="s" />
-              <EuiText>Expected input</EuiText>
+              <EuiText>Source output</EuiText>
               <EuiSmallButton
                 style={{ width: '100px' }}
                 onClick={async () => {
@@ -219,7 +219,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                         })
                         .catch((error: any) => {
                           getCore().notifications.toasts.addDanger(
-                            `Failed to fetch input data`
+                            `Failed to fetch source output data`
                           );
                         });
                       break;
@@ -282,10 +282,10 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
           <EuiFlexItem>
             <>
               {outputOptions.length === 1 ? (
-                <EuiText>Expected output</EuiText>
+                <EuiText>Transformed output</EuiText>
               ) : (
                 <EuiCompressedSelect
-                  prepend={<EuiText>Expected output for</EuiText>}
+                  prepend={<EuiText>Transformed output for</EuiText>}
                   options={outputOptions}
                   value={selectedOutputOption}
                   onChange={(e) => {

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -3,12 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { ConfigureSearchRequest } from './configure_search_request';
 import { EnrichSearchRequest } from './enrich_search_request';
 import { EnrichSearchResponse } from './enrich_search_response';
-import { WorkflowConfig } from '../../../../../common';
+import {
+  OMIT_SYSTEM_INDEX_PATTERN,
+  WorkflowConfig,
+} from '../../../../../common';
+import { catIndices, useAppDispatch } from '../../../../store';
+import { getDataSourceId } from '../../../../utils';
 
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
@@ -21,6 +26,15 @@ interface SearchInputsProps {
  * The base component containing all of the search-related inputs
  */
 export function SearchInputs(props: SearchInputsProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+  // re-fetch indices on initial load. When users are first creating,
+  // they may enter this page without getting the updated index info
+  // for a newly-created index, so we re-fetch that here.
+  useEffect(() => {
+    dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
+  }, []);
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>

--- a/public/store/reducers/ml_reducer.ts
+++ b/public/store/reducers/ml_reducer.ts
@@ -8,7 +8,7 @@ import { ConnectorDict, ModelDict } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
 
-const initialState = {
+export const INITIAL_ML_STATE = {
   loading: false,
   errorMessage: '',
   models: {} as ModelDict,
@@ -64,7 +64,7 @@ export const searchConnectors = createAsyncThunk(
 
 const mlSlice = createSlice({
   name: 'ml',
-  initialState,
+  initialState: INITIAL_ML_STATE,
   reducers: {},
   extraReducers: (builder) => {
     builder

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
 
-const initialState = {
+export const INITIAL_OPENSEARCH_STATE = {
   loading: false,
   errorMessage: '',
   indices: {} as { [key: string]: Index },
@@ -183,7 +183,7 @@ export const simulatePipeline = createAsyncThunk(
 
 const opensearchSlice = createSlice({
   name: OPENSEARCH_PREFIX,
-  initialState,
+  initialState: INITIAL_OPENSEARCH_STATE,
   reducers: {},
   extraReducers: (builder) => {
     builder

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -8,6 +8,7 @@ import { getRouteService } from '../../services';
 import {
   Index,
   IngestPipelineConfig,
+  OMIT_SYSTEM_INDEX_PATTERN,
   SimulateIngestPipelineDoc,
 } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
@@ -33,7 +34,7 @@ export const catIndices = createAsyncThunk(
     { rejectWithValue }
   ) => {
     // defaulting to fetch everything except system indices (starting with '.')
-    const patternString = pattern || '*,-.*';
+    const patternString = pattern || OMIT_SYSTEM_INDEX_PATTERN;
     const response: any | HttpFetchError = await getRouteService().catIndices(
       patternString,
       dataSourceId

--- a/public/store/reducers/presets_reducer.ts
+++ b/public/store/reducers/presets_reducer.ts
@@ -8,7 +8,7 @@ import { WorkflowTemplate } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
 
-const initialState = {
+export const INITIAL_PRESETS_STATE = {
   loading: false,
   errorMessage: '',
   presetWorkflows: [] as Partial<WorkflowTemplate>[],
@@ -35,7 +35,7 @@ export const getWorkflowPresets = createAsyncThunk(
 
 const presetsSlice = createSlice({
   name: 'presets',
-  initialState,
+  initialState: INITIAL_PRESETS_STATE,
   reducers: {},
   extraReducers: (builder) => {
     builder

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -8,7 +8,7 @@ import { WorkflowDict, WorkflowTemplate } from '../../../common';
 import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
 
-const initialState = {
+export const INITIAL_WORKFLOWS_STATE = {
   loading: false,
   errorMessage: '',
   workflows: {} as WorkflowDict,
@@ -223,7 +223,7 @@ export const deleteWorkflow = createAsyncThunk(
 
 const workflowsSlice = createSlice({
   name: 'workflows',
-  initialState,
+  initialState: INITIAL_WORKFLOWS_STATE,
   reducers: {},
   extraReducers: (builder) => {
     builder

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {
+  INITIAL_ML_STATE,
+  INITIAL_OPENSEARCH_STATE,
+  INITIAL_PRESETS_STATE,
+  INITIAL_WORKFLOWS_STATE,
+} from '../public/store';
 import { WORKFLOW_TYPE } from '../common/constants';
 import { UIState, Workflow } from '../common/interfaces';
 import {
@@ -19,13 +25,10 @@ export function mockStore(
 ) {
   return {
     getState: () => ({
-      opensearch: {
-        errorMessage: '',
-      },
-      ml: {},
+      opensearch: INITIAL_OPENSEARCH_STATE,
+      ml: INITIAL_ML_STATE,
       workflows: {
-        loading: false,
-        errorMessage: '',
+        ...INITIAL_WORKFLOWS_STATE,
         workflows: {
           [workflowId]: generateWorkflow(
             workflowId,
@@ -34,6 +37,7 @@ export function mockStore(
           ),
         },
       },
+      presets: INITIAL_PRESETS_STATE,
     }),
     dispatch: jest.fn(),
     subscribe: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+flattie@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flattie/-/flattie-1.1.1.tgz#88182235723113667d36217fec55359275d6fe3d"
+  integrity sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==
+
 formik@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.2.tgz#a1115457cfb012a5c782cea3ad4b40b2fe36fa18"


### PR DESCRIPTION
### Description
This PR adds functionality to dynamically fetch a list of options when configuring input / output maps for ML processors. Specifically, adds support for 3 scenarios:
1. List of document fields as values for input maps when the document form field is populated (ingest)
2. List of query fields as values for input maps when the query form is populated (search)
3. List of document fields as values for input maps when configuring ML search response processors. References the selected index's mappings to populate options, including the field mapping type.

Note the dropdown still allows custom options if users need (e.g., pulling out a single value from an array, aggregation via JSONPath, etc.).

More details
- adds `docFields`/`queryFields`/`indexMappingFields` as state vars in `MLProcessorInputs` to handle the options as mentioned above
- adds MIT-licensed [flattie](https://www.npmjs.com/package/flattie) to flatten nested JSON objs. Used for getting all options (keys) of a document or query JSON which can be deeply nested.
- more type safety on the options props passed to the form components
- index fetching on `SearchInputs` base component so any index created from ingest, has all details available on the search form without requiring refresh. This is useful to fetch the index mappings to populate options for ML search response processors.
- replacing the default query path logic on ML search request processors to derive from the query itself instead of hardcoding

Demo video, showing the options visible in the 3 different contexts of ML processors (ingest, search req, search resp):

[screen-capture (15).webm](https://github.com/user-attachments/assets/496be2e3-3c23-4622-9d17-991c28d527bf)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
