### PR TITLE
Add explicit save / revert buttons in search & ingest forms

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -655,7 +655,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         .unwrap()
                         .then(async (result) => {
                           setFieldValue('ingest.enabled', false);
-                          await validateAndUpdateWorkflow(false);
                           // @ts-ignore
                           await dispatch(
                             getWorkflow({

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -278,9 +278,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     setIngestProvisioned(hasProvisionedIngestResources(props.workflow));
   }, [props.workflow]);
 
-  // Utility fn to update the workflow template only. A get workflow API call is subsequently run
+  // Utility fn to update the workflow UI config only. A get workflow API call is subsequently run
   // to fetch the updated state.
-  async function updateWorkflowTemplate() {
+  async function updateWorkflowUiConfig() {
     setIsRunningSave(true);
     const updatedTemplate = {
       name: props.workflow?.name,
@@ -820,7 +820,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           }
                           isLoading={isRunningSave}
                           onClick={() => {
-                            updateWorkflowTemplate();
+                            updateWorkflowUiConfig();
                           }}
                         >
                           {`Save`}
@@ -892,7 +892,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           }
                           isLoading={isRunningSave}
                           onClick={() => {
-                            updateWorkflowTemplate();
+                            updateWorkflowUiConfig();
                           }}
                         >
                           {`Save`}
@@ -911,7 +911,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                             validateAndRunQuery();
                           }}
                         >
-                          Run query
+                          Build and run query
                         </EuiSmallButton>
                       </EuiFlexItem>
                     </>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -315,7 +315,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         });
       })
       .catch((error: any) => {
-        console.error('Error autosaving workflow: ', error);
+        console.error('Error saving workflow: ', error);
       })
       .finally(() => {
         setIsRunningSave(false);


### PR DESCRIPTION
### Description

This PR reverts the autosave functionality due to its ambiguity on when cluster resources are updated. To handle saving, this adds an explicit save button, and corresponding undo, to revert to the last saved state. Buttons are enabled/disabled based on the form state. Under the hood, when users click save, it runs the update workflow API with `reprovision=false`. Only the config is saved, but not the underlying workflow template or any associated resources. For full updates, users still have the ingest/search buttons. Updated text to more explicitly state what is happening when those are executed, which is actually building out the resources and running ingest/search. When users click the revert button, the form and transient UI config is reverted to the saved/indexed config.

Details on the different form states:
- all general form state is all handled by `formik` to detect value changes, when values are touched, etc.
- when ingest/search processors are added/removed, rather than updating the form, we have to re-create the form and updated form schema. This is because we generate the form based on metadata in the UI config (the config field types, defaults, etc.), and can't go vice-versa. Note this is why we pass the `setUiConfig` param to components, so it can be triggered on these particular actions. Because we can't listen on formik value changes for this part, we need standalone hooks to listen on when the current _uiConfig_ has updated. 

Implementation details:
- adds `unsavedIngestProcessors`/`unsavedSearchProcessors` flags to persist when there are form changes related to adding/removing ingest/search processors
- adds hooks to listen when the uiConfig has updated, and detect processor config changes to set `unsavedIngestProcessors`/`unsavedSearchProcessors`
- refactors the autosave logic to have a single `updateWorkflowUiConfig()` fn to update the UI config only, without any template or resource updates. Used in the new `Save` button
- adds revert/save buttons for both ingest/search conditions

Demo video, showing the new buttons functionality for ingest/search:

[screen-capture (16).webm](https://github.com/user-attachments/assets/2f3b537d-74f4-484b-a52b-b6d6cdf36b62)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
