### PR TITLE
Onboard basic RAG preset

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -103,6 +103,7 @@ export enum PROCESSOR_TYPE {
   SORT = 'sort',
   TEXT_CHUNKING = 'text_chunking',
   NORMALIZATION = 'normalization-processor',
+  COLLAPSE = 'collapse',
 }
 
 export enum MODEL_TYPE {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -182,12 +182,17 @@ export const DELIMITER_OPTIONAL_FIELDS = ['delimiter'];
 export const SHARED_OPTIONAL_FIELDS = ['max_chunk_limit', 'description', 'tag'];
 
 /**
- * QUERY PRESETS
+ * DEFAULT FIELD VALUES
  */
 export const DEFAULT_TEXT_FIELD = 'my_text';
 export const DEFAULT_VECTOR_FIELD = 'my_embedding';
 export const DEFAULT_IMAGE_FIELD = 'my_image';
 export const DEFAULT_LABEL_FIELD = 'label';
+export const DEFAULT_LLM_RESPONSE_FIELD = 'llm_response';
+
+/**
+ * QUERY PRESETS
+ */
 export const VECTOR_FIELD_PATTERN = `{{vector_field}}`;
 export const TEXT_FIELD_PATTERN = `{{text_field}}`;
 export const IMAGE_FIELD_PATTERN = `{{image_field}}`;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -91,6 +91,7 @@ export enum WORKFLOW_TYPE {
   MULTIMODAL_SEARCH = 'Multimodal search',
   HYBRID_SEARCH = 'Hybrid search',
   SENTIMENT_ANALYSIS = 'Sentiment analysis',
+  RAG = 'Retrieval-augmented generation',
   CUSTOM = 'Custom',
   UNKNOWN = 'Unknown',
 }

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -489,6 +489,7 @@ export type QuickConfigureFields = {
   imageField?: string;
   labelField?: string;
   embeddingLength?: number;
+  llmResponseField?: string;
 };
 
 /**

--- a/public/configs/search_response_processors/collapse_processor.ts
+++ b/public/configs/search_response_processors/collapse_processor.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PROCESSOR_TYPE } from '../../../common';
+import { Processor } from '../processor';
+
+/**
+ * The collapse processor config. Used in search flows.
+ */
+export class CollapseProcessor extends Processor {
+  constructor() {
+    super();
+    this.type = PROCESSOR_TYPE.COLLAPSE;
+    this.name = 'Collapse Processor';
+    this.fields = [
+      {
+        id: 'field',
+        type: 'string',
+      },
+    ];
+    this.optionalFields = [
+      {
+        id: 'context_prefix',
+        type: 'string',
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'ignore_failure',
+        type: 'boolean',
+        value: false,
+      },
+    ];
+  }
+}

--- a/public/configs/search_response_processors/index.ts
+++ b/public/configs/search_response_processors/index.ts
@@ -7,3 +7,4 @@ export * from './ml_search_response_processor';
 export * from './split_search_response_processor';
 export * from './sort_search_response_processor';
 export * from './normalization_processor';
+export * from './collapse_processor';

--- a/public/general_components/general-component-styles.scss
+++ b/public/general_components/general-component-styles.scss
@@ -1,5 +1,5 @@
 .multi-select-filter {
   &--width {
-    width: 200px;
+    width: 300px;
   }
 }

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -42,7 +42,7 @@ const inputTabs = [
   },
   {
     id: TAB_ID.QUERY,
-    name: 'Run queries',
+    name: 'Run query',
     disabled: false,
   },
   {

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -79,7 +79,7 @@ describe('WorkflowDetail', () => {
       expect(getByText('Visual')).toBeInTheDocument();
       expect(getByText('JSON')).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Run ingestion' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Run queries' })).toBeInTheDocument();
+      expect(getByRole('tab', { name: 'Run query' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
     });

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -249,7 +249,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                             index: values.search.index.name,
                             body: JSON.stringify({
                               ...JSON.parse(values.search.request as string),
-                              search_pipeline: curSearchPipeline,
+                              search_pipeline: curSearchPipeline || {},
                             }),
                           },
                           dataSourceId,

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../../../common';
 import { formikToUiConfig } from '../../../utils';
 import {
+  CollapseProcessor,
   MLIngestProcessor,
   MLSearchRequestProcessor,
   MLSearchResponseProcessor,
@@ -288,6 +289,13 @@ export function ProcessorsList(props: ProcessorsListProps) {
                               addProcessor(
                                 new NormalizationProcessor().toObj()
                               );
+                            },
+                          },
+                          {
+                            name: 'Collapse Processor',
+                            onClick: () => {
+                              closePopover();
+                              addProcessor(new CollapseProcessor().toObj());
                             },
                           },
                         ],

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -233,7 +233,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
                 }}
               />
             </EuiCompressedFormRow>
-            <EuiSpacer size="s" />{' '}
+            <EuiSpacer size="s" />
             {props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH && (
               <>
                 <EuiCompressedFormRow

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -19,6 +19,7 @@ import {
   COHERE_DIMENSIONS,
   DEFAULT_IMAGE_FIELD,
   DEFAULT_LABEL_FIELD,
+  DEFAULT_LLM_RESPONSE_FIELD,
   DEFAULT_TEXT_FIELD,
   DEFAULT_VECTOR_FIELD,
   MODEL_STATE,
@@ -84,6 +85,13 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
         };
         break;
       }
+      case WORKFLOW_TYPE.RAG: {
+        defaultFieldValues = {
+          textField: DEFAULT_TEXT_FIELD,
+          llmResponseField: DEFAULT_LLM_RESPONSE_FIELD,
+        };
+        break;
+      }
       case WORKFLOW_TYPE.CUSTOM:
       default:
         break;
@@ -143,10 +151,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
 
   return (
     <>
-      {(props.workflowType === WORKFLOW_TYPE.SEMANTIC_SEARCH ||
-        props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH ||
-        props.workflowType === WORKFLOW_TYPE.HYBRID_SEARCH ||
-        props.workflowType === WORKFLOW_TYPE.SENTIMENT_ANALYSIS) && (
+      {props.workflowType !== WORKFLOW_TYPE.CUSTOM ? (
         <>
           <EuiSpacer size="m" />
           <EuiAccordion
@@ -159,12 +164,16 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
               label={
                 props.workflowType === WORKFLOW_TYPE.SENTIMENT_ANALYSIS
                   ? 'Model'
+                  : props.workflowType === WORKFLOW_TYPE.RAG
+                  ? 'Large language model'
                   : 'Embedding model'
               }
               isInvalid={false}
               helpText={
                 props.workflowType === WORKFLOW_TYPE.SENTIMENT_ANALYSIS
                   ? 'The sentiment analysis model'
+                  : props.workflowType === WORKFLOW_TYPE.RAG
+                  ? 'The large language model to generate user-friendly responses'
                   : 'The model to generate embeddings'
               }
             >
@@ -209,6 +218,8 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
               helpText={`The name of the text document field to be ${
                 props.workflowType === WORKFLOW_TYPE.SENTIMENT_ANALYSIS
                   ? 'analyzed'
+                  : props.workflowType === WORKFLOW_TYPE.RAG
+                  ? 'used as context to the large language model (LLM)'
                   : 'embedded'
               }`}
             >
@@ -222,7 +233,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
                 }}
               />
             </EuiCompressedFormRow>
-            <EuiSpacer size="s" />
+            <EuiSpacer size="s" />{' '}
             {props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH && (
               <>
                 <EuiCompressedFormRow
@@ -297,9 +308,26 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
                 />
               </EuiCompressedFormRow>
             )}
+            {props.workflowType === WORKFLOW_TYPE.RAG && (
+              <EuiCompressedFormRow
+                label={'LLM response field'}
+                isInvalid={false}
+                helpText="The name of the field containing the large language model (LLM) response"
+              >
+                <EuiCompressedFieldText
+                  value={fieldValues?.llmResponseField || ''}
+                  onChange={(e) => {
+                    setFieldValues({
+                      ...fieldValues,
+                      llmResponseField: e.target.value,
+                    });
+                  }}
+                />
+              </EuiCompressedFormRow>
+            )}
           </EuiAccordion>
         </>
-      )}
+      ) : undefined}
     </>
   );
 }

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -5,8 +5,10 @@
 
 import { snakeCase } from 'lodash';
 import {
+  CollapseProcessor,
   MLIngestProcessor,
   MLSearchRequestProcessor,
+  MLSearchResponseProcessor,
   NormalizationProcessor,
 } from '../../../configs';
 import {
@@ -48,6 +50,10 @@ export function enrichPresetWorkflowWithUiMetadata(
     }
     case WORKFLOW_TYPE.SENTIMENT_ANALYSIS: {
       uiMetadata = fetchSentimentAnalysisMetadata();
+      break;
+    }
+    case WORKFLOW_TYPE.RAG: {
+      uiMetadata = fetchRAGMetadata();
       break;
     }
     default: {
@@ -202,6 +208,21 @@ export function fetchSentimentAnalysisMetadata(): UIState {
   baseState.config.search.request.value = customStringify(TERM_QUERY_LABEL);
   baseState.config.search.enrichRequest.processors = [
     new MLSearchRequestProcessor().toObj(),
+  ];
+  return baseState;
+}
+
+export function fetchRAGMetadata(): UIState {
+  let baseState = fetchEmptyMetadata();
+  baseState.type = WORKFLOW_TYPE.RAG;
+  baseState.config.ingest.index.name.value = generateId('my_index', 6);
+  baseState.config.search.request.value = customStringify(FETCH_ALL_QUERY);
+  baseState.config.search.enrichRequest.processors = [
+    new MLSearchRequestProcessor().toObj(),
+  ];
+  baseState.config.search.enrichResponse.processors = [
+    new MLSearchResponseProcessor().toObj(),
+    new CollapseProcessor().toObj(),
   ];
   return baseState;
 }

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -217,9 +217,6 @@ export function fetchRAGMetadata(): UIState {
   baseState.type = WORKFLOW_TYPE.RAG;
   baseState.config.ingest.index.name.value = generateId('my_index', 6);
   baseState.config.search.request.value = customStringify(FETCH_ALL_QUERY);
-  baseState.config.search.enrichRequest.processors = [
-    new MLSearchRequestProcessor().toObj(),
-  ];
   baseState.config.search.enrichResponse.processors = [
     new MLSearchResponseProcessor().toObj(),
     new CollapseProcessor().toObj(),

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -315,6 +315,7 @@ export function processorConfigsToTemplateProcessors(
       }
       case PROCESSOR_TYPE.SPLIT:
       case PROCESSOR_TYPE.SORT:
+      case PROCESSOR_TYPE.COLLAPSE:
       default: {
         const formValues = processorConfigToFormik(processorConfig);
         let finalFormValues = {} as FormikValues;

--- a/server/resources/templates/rag.json
+++ b/server/resources/templates/rag.json
@@ -1,0 +1,14 @@
+{
+    "name": "Retrieval-Augmented Generation",
+    "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation",
+    "version": {
+        "template": "1.0.0",
+        "compatibility": [
+            "2.17.0",
+            "3.0.0"
+        ]
+    },
+    "ui_metadata": {
+        "type": "Retrieval-augmented generation"
+    }
+}


### PR DESCRIPTION
### Description
Adds a basic RAG preset to the library. Pre-populates:
- ML search response processor with an LLM to generate results (defaults to many-to-one)
- `collapse` response processor to only return unique ML responses (in many-to-one case, this will be one result)

More details:
- onboards `collapse` search response processor
- adds an `llmResponse` quick-config field, and default quick-config field values for the new RAG usecase
- fixes bug of input transform fetching failing on search response processors when no prior search request or search response processors
- refactors helper fns in `QuickConfigureModal` and makes them more generic

Notes:
- future PRs will improve the prompt template editing experience. For now, it is entirely free-form.
- future PRs will improve the checking of `full_response_path` when implementing transforms with JSON path. See tracking issue #368 
- future PRs will improve the many_to_one/one_to_one toggling experience. See tracking issue #367 

Demo video, showing a RAG usecase using a deployed LLM model with some sample review documents. The model does not have an interface or configured prompt template, so both are manually filled in. The final result is a single response containing the LLM's summary of the documents found during search.

[screen-capture (17).webm](https://github.com/user-attachments/assets/6321550d-3b16-4d52-abb5-222de3173de2)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
