### PR TITLE
Standardize source data to input/output transform modals

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -394,8 +394,8 @@ export type ModelInputFormField = ModelInput & {
 export type ModelOutputFormField = ModelInputFormField;
 
 export type ModelInterface = {
-  input: ModelInput;
-  output: ModelOutput;
+  input?: ModelInput;
+  output?: ModelOutput;
 };
 
 export type ConnectorParameters = {

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -59,6 +59,7 @@ export function BooleanField(props: BooleanFieldProps) {
               }
               onChange={(id) => {
                 form.setFieldValue(field.name, !field.value);
+                form.setFieldTouched(field.name, true);
               }}
             />
           </EuiCompressedFormRow>

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -147,7 +147,7 @@ export function prepareDocsForSimulate(
 // to format them into a more readable string to display
 export function unwrapTransformedDocs(
   simulatePipelineResponse: SimulateIngestPipelineResponse
-) {
+): any[] {
   let errorDuringSimulate = undefined as string | undefined;
   const transformedDocsSources = simulatePipelineResponse.docs.map(
     (transformedDoc) => {
@@ -167,7 +167,7 @@ export function unwrapTransformedDocs(
       `Failed to simulate ingest on all documents: ${errorDuringSimulate}`
     );
   }
-  return customStringify(transformedDocsSources);
+  return transformedDocsSources;
 }
 
 // ML inference processors will use standard dot notation or JSONPath depending on the input.
@@ -181,9 +181,6 @@ export function generateTransform(input: {}, map: MapFormValue): {} {
       if (mapEntry.value.startsWith(JSONPATH_ROOT_SELECTOR)) {
         // JSONPath transform
         transformedResult = jsonpath.query(input, path);
-        // Non-JSONPath bracket notation not supported - throw an error
-      } else if (mapEntry.value.includes('[') || mapEntry.value.includes(']')) {
-        throw new Error();
         // Standard dot notation
       } else {
         transformedResult = get(input, path);

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -12,7 +12,9 @@ import {
   MODEL_STATE,
   Model,
   ModelDict,
+  ModelInput,
   ModelInterface,
+  ModelOutput,
   NO_MODIFICATIONS_FOUND_TEXT,
   SearchHit,
   WORKFLOW_RESOURCE_TYPE,
@@ -107,9 +109,17 @@ export function getModelsFromResponses(modelHits: SearchHit[]): ModelDict {
         | undefined;
       let modelInterface = undefined as ModelInterface | undefined;
       if (indexedModelInterface !== undefined) {
+        let parsedInput = undefined as ModelInput | undefined;
+        let parsedOutput = undefined as ModelOutput | undefined;
+        try {
+          parsedInput = JSON.parse(indexedModelInterface.input);
+        } catch {}
+        try {
+          parsedOutput = JSON.parse(indexedModelInterface.output);
+        } catch {}
         modelInterface = {
-          input: JSON.parse(indexedModelInterface.input),
-          output: JSON.parse(indexedModelInterface.output),
+          input: parsedInput,
+          output: parsedOutput,
         } as ModelInterface;
       }
 


### PR DESCRIPTION
### Description
This PR standardizes the generated source input to consistently match exactly the way the ML processors will transform the inputs. For `full_response_path=false/true`, both are displayed exactly how the ML processor will parse it. The one caveat is, there is still work to be done on the search response side to handle many-to-one/one-to-one toggling better.

Also has other small fixes:
- handles when input or output is missing from the model interface (both are not required)
- handles empty search pipeline edge case when simulating source output
- triggers `touched` when toggling boolean field - before, changing these values was not triggering save to be available.
- removes the invalid check of bracket notation not available for the input/output map configurations
- adds loading logic when fetching to prevent overloading potentially expensive calls (simulation on ingest/search pipelines can be using ML credits & have large latency)
- fixes bug of showing multi-predict selector when input map is empty

Demo video, showing the updated input transforms and output transform source data for ingest/search req. Extra data, arrays, etc. have all been removed to consistently show the exact input JSON to the ML processor inputs, including when full_response_path is true/false

[screen-capture (19).webm](https://github.com/user-attachments/assets/6fd26626-3a8e-4b9d-9cf7-e369fcd63b07)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
