### PR TITLE
Fix parsing of ML response processor

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useFormikContext, getIn } from 'formik';
-import { cloneDeep, get, isEmpty, set } from 'lodash';
+import { cloneDeep, isEmpty, set } from 'lodash';
 import {
   EuiCodeEditor,
   EuiFlexGroup,
@@ -168,7 +168,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                             const docObjs = unwrapTransformedDocs(resp);
                             if (docObjs.length > 0) {
                               const sampleModelResult =
-                                docObjs[0]?.inference_results;
+                                docObjs[0]?.inference_results || {};
                               setSourceInput(
                                 customStringify(sampleModelResult)
                               );
@@ -224,11 +224,8 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                             (hit: SearchHit) => hit._source
                           ) as any[];
                           if (hits.length > 0) {
-                            const sampleModelResult = get(
-                              hits,
-                              '0.inference_results.0',
-                              {}
-                            );
+                            const sampleModelResult =
+                              hits[0].inference_results || {};
                             setSourceInput(customStringify(sampleModelResult));
                           }
                         })


### PR DESCRIPTION
### Description

Recent bug fix enabled testing of the ML response processor output transforms: https://github.com/opensearch-project/ml-commons/pull/2944

As a result, there was a single parsing issue. This is a one-line fix to fix that. Also sets defaults for if `inference_results` is undefined, don't display `undefined` as a value.

Demo video:

[screen-capture (20).webm](https://github.com/user-attachments/assets/9ced6de6-7786-4837-a434-00c069f0ab78)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
