### PR TITLE
Add optional prompt template transformation in input transform

### DIFF
--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -31,10 +31,6 @@ export abstract class MLProcessor extends Processor {
     ];
     this.optionalFields = [
       {
-        id: 'description',
-        type: 'string',
-      },
-      {
         id: 'model_config',
         type: 'json',
       },
@@ -60,6 +56,10 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'tag',
+        type: 'string',
+      },
+      {
+        id: 'description',
         type: 'string',
       },
     ];

--- a/public/configs/search_response_processors/collapse_processor.ts
+++ b/public/configs/search_response_processors/collapse_processor.ts
@@ -5,6 +5,7 @@
 
 import { PROCESSOR_TYPE } from '../../../common';
 import { Processor } from '../processor';
+import { generateId } from '../../utils';
 
 /**
  * The collapse processor config. Used in search flows.
@@ -12,6 +13,7 @@ import { Processor } from '../processor';
 export class CollapseProcessor extends Processor {
   constructor() {
     super();
+    this.id = generateId('collapse_processor');
     this.type = PROCESSOR_TYPE.COLLAPSE;
     this.name = 'Collapse Processor';
     this.fields = [

--- a/public/configs/search_response_processors/normalization_processor.ts
+++ b/public/configs/search_response_processors/normalization_processor.ts
@@ -5,6 +5,7 @@
 
 import { PROCESSOR_TYPE } from '../../../common';
 import { Processor } from '../processor';
+import { generateId } from '../../utils';
 
 /**
  * The normalization processor config. Used in search flows.
@@ -12,6 +13,7 @@ import { Processor } from '../processor';
 export class NormalizationProcessor extends Processor {
   constructor() {
     super();
+    this.id = generateId('normalization_processor');
     this.type = PROCESSOR_TYPE.NORMALIZATION;
     this.name = 'Normalization Processor';
     this.fields = [];

--- a/public/pages/workflow_detail/tools/ingest/ingest.tsx
+++ b/public/pages/workflow_detail/tools/ingest/ingest.tsx
@@ -29,6 +29,7 @@ export function Ingest(props: IngestProps) {
       setOptions={{
         fontSize: '12px',
         autoScrollEditorIntoView: true,
+        wrap: true,
       }}
       tabSize={2}
     />

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -29,6 +29,7 @@ export function Query(props: QueryProps) {
       setOptions={{
         fontSize: '12px',
         autoScrollEditorIntoView: true,
+        wrap: true,
       }}
       tabSize={2}
     />

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -99,6 +99,7 @@ export function JsonField(props: JsonFieldProps) {
                 highlightActiveLine: !props.readOnly,
                 highlightSelectedWord: !props.readOnly,
                 highlightGutterLine: !props.readOnly,
+                wrap: true,
               }}
               aria-label="Code Editor"
               tabSize={2}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -74,10 +74,6 @@ interface InputTransformModalProps {
   onClose: () => void;
 }
 
-// TODO: InputTransformModal and OutputTransformModal are very similar, and can
-// likely be refactored and have more reusable components. Leave as-is until the
-// UI is more finalized.
-
 /**
  * A modal to configure advanced JSON-to-JSON transforms into a model's expected input
  */

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -209,6 +209,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         <InputTransformModal
           uiConfig={props.uiConfig}
           config={props.config}
+          baseConfigPath={props.baseConfigPath}
           context={props.context}
           inputMapField={inputMapField}
           inputMapFieldPath={inputMapFieldPath}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -258,6 +258,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                   showLineNumbers: false,
                   showGutter: false,
                   showPrintMargin: false,
+                  wrap: true,
                 }}
                 tabSize={2}
               />
@@ -322,6 +323,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                   showLineNumbers: false,
                   showGutter: false,
                   showPrintMargin: false,
+                  wrap: true,
                 }}
                 tabSize={2}
               />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -73,40 +73,40 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   // fetching input data state
   const [isFetching, setIsFetching] = useState<boolean>(false);
 
-  // source input / transformed output state
-  const [sourceInput, setSourceInput] = useState<string>('[]');
+  // source output / transformed output state
+  const [sourceOutput, setSourceOutput] = useState<string>('[]');
   const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
   // get the current output map
   const map = getIn(values, props.outputMapFieldPath) as MapArrayFormValue;
 
-  // selected output state
-  const outputOptions = map.map((_, idx) => ({
+  // selected transform state
+  const transformOptions = map.map((_, idx) => ({
     value: idx,
     text: `Prediction ${idx + 1}`,
   })) as EuiSelectOption[];
-  const [selectedOutputOption, setSelectedOutputOption] = useState<
+  const [selectedTransformOption, setSelectedTransformOption] = useState<
     number | undefined
-  >((outputOptions[0]?.value as number) ?? undefined);
+  >((transformOptions[0]?.value as number) ?? undefined);
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {
     if (
       !isEmpty(map) &&
-      !isEmpty(JSON.parse(sourceInput)) &&
-      selectedOutputOption !== undefined
+      !isEmpty(JSON.parse(sourceOutput)) &&
+      selectedTransformOption !== undefined
     ) {
-      let sampleSourceInput = {};
+      let sampleSourceOutput = {};
       try {
-        sampleSourceInput = JSON.parse(sourceInput);
+        sampleSourceOutput = JSON.parse(sourceOutput);
         const output = generateTransform(
-          sampleSourceInput,
-          map[selectedOutputOption]
+          sampleSourceOutput,
+          map[selectedTransformOption]
         );
         setTransformedOutput(customStringify(output));
       } catch {}
     }
-  }, [map, sourceInput, selectedOutputOption]);
+  }, [map, sourceOutput, selectedTransformOption]);
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
@@ -169,7 +169,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                             if (docObjs.length > 0) {
                               const sampleModelResult =
                                 docObjs[0]?.inference_results || {};
-                              setSourceInput(
+                              setSourceOutput(
                                 customStringify(sampleModelResult)
                               );
                             }
@@ -226,7 +226,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                           if (hits.length > 0) {
                             const sampleModelResult =
                               hits[0].inference_results || {};
-                            setSourceInput(customStringify(sampleModelResult));
+                            setSourceOutput(customStringify(sampleModelResult));
                           }
                         })
                         .catch((error: any) => {
@@ -250,7 +250,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 theme="textmate"
                 width="100%"
                 height="15vh"
-                value={sourceInput}
+                value={sourceOutput}
                 readOnly={true}
                 setOptions={{
                   fontSize: '12px',
@@ -281,14 +281,14 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                 // If the map we are adding is the first one, populate the selected option to index 0
                 onMapAdd={(curArray) => {
                   if (isEmpty(curArray)) {
-                    setSelectedOutputOption(0);
+                    setSelectedTransformOption(0);
                   }
                 }}
                 // If the map we are deleting is the one we last used to test, reset the state and
                 // default to the first map in the list.
                 onMapDelete={(idxToDelete) => {
-                  if (selectedOutputOption === idxToDelete) {
-                    setSelectedOutputOption(0);
+                  if (selectedTransformOption === idxToDelete) {
+                    setSelectedTransformOption(0);
                     setTransformedOutput('{}');
                   }
                 }}
@@ -297,15 +297,15 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
           </EuiFlexItem>
           <EuiFlexItem>
             <>
-              {outputOptions.length <= 1 ? (
+              {transformOptions.length <= 1 ? (
                 <EuiText>Transformed output</EuiText>
               ) : (
                 <EuiCompressedSelect
                   prepend={<EuiText>Transformed output for</EuiText>}
-                  options={outputOptions}
-                  value={selectedOutputOption}
+                  options={transformOptions}
+                  value={selectedTransformOption}
                   onChange={(e) => {
-                    setSelectedOutputOption(Number(e.target.value));
+                    setSelectedTransformOption(Number(e.target.value));
                   }}
                 />
               )}

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -214,6 +214,7 @@ export function Workspace(props: WorkspaceProps) {
                 setOptions={{
                   fontSize: '12px',
                   autoScrollEditorIntoView: true,
+                  wrap: true,
                 }}
                 tabSize={2}
               />


### PR DESCRIPTION
### Description
For RAG use cases, users may want to configure the prompt templates directly in the ML processors, dynamically using data inputs as part of the prompt. For example, collecting a list of documents as context to pass to an LLM to summarize and return a human-readable response.

This PR adds a component in the input transform modal to view the original prompt template, and the prompt template with any injected input values (if applicable).

More details:
- adds prompt-related state vars and custom hooks when a prompt and/or input parameters are populated in `InputTransformModal`
- dynamically renders the new components if a valid `prompt` field is found in the processor's `model_config` field
- allows toggling between showing the prompt or not
- allows toggling between showing the original prompt, or the transformed version, with injected parameter values
- disables toggling and auto-selects options based on the transformed options being populated or not
- also: defaults all of the JSON fields to have `wrap=true` so long values (e.g., prompts) don't stretch out on one line
- also: minor var name updates to be consistent based on input/output contexts

Note this is just a first iteration at exposing the prompt template in the transform modal, and being able to see the finally-produced template that the model will receive. It will likely change, handle more edge case states, handle direct prompt manipulation, more details, etc. in the future.

Demo video, showing the prompt template being populated with parameter values:

[screen-capture (22).webm](https://github.com/user-attachments/assets/d6250d76-108c-45a7-9106-a01fece4319b)

### Issues resolved
Makes progress on #380 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
