### PR TITLE
Set default outputs and display schema based on `full_response_path`

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -410,6 +410,11 @@ export const QUERY_PRESETS = [
 /**
  * MISCELLANEOUS
  */
+export enum PROCESSOR_CONTEXT {
+  INGEST = 'ingest',
+  SEARCH_REQUEST = 'search_request',
+  SEARCH_RESPONSE = 'search_response',
+}
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
@@ -434,9 +439,6 @@ export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
-
-export enum PROCESSOR_CONTEXT {
-  INGEST = 'ingest',
-  SEARCH_REQUEST = 'search_request',
-  SEARCH_RESPONSE = 'search_response',
-}
+export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
+  'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
+export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -79,6 +79,10 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   ) as IConfigField;
   const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${outputMapField.id}`;
   const outputMapValue = getIn(values, outputMapFieldPath);
+  const fullResponsePath = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.full_response_path`
+  );
 
   // preview availability states
   // if there are preceding search request processors, we cannot fetch and display the interim transformed query.
@@ -228,6 +232,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         <OutputTransformModal
           uiConfig={props.uiConfig}
           config={props.config}
+          baseConfigPath={props.baseConfigPath}
           context={props.context}
           outputMapField={outputMapField}
           outputMapFieldPath={outputMapFieldPath}
@@ -345,7 +350,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : 'New document field'
             }
             valuePlaceholder="Model output field"
-            valueOptions={parseModelOutputs(modelInterface)}
+            valueOptions={
+              fullResponsePath
+                ? undefined
+                : parseModelOutputs(modelInterface, false)
+            }
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -8,6 +8,8 @@ import jsonpath from 'jsonpath';
 import { escape, get } from 'lodash';
 import {
   JSONPATH_ROOT_SELECTOR,
+  MODEL_OUTPUT_SCHEMA_FULL_PATH,
+  MODEL_OUTPUT_SCHEMA_NESTED_PATH,
   MapFormValue,
   ModelInputFormField,
   ModelInterface,
@@ -18,10 +20,13 @@ import {
   WORKFLOW_RESOURCE_TYPE,
   WORKFLOW_STEP_TYPE,
   Workflow,
-  customStringify,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
-import { MDSQueryParams, ModelInputMap } from '../../common/interfaces';
+import {
+  MDSQueryParams,
+  ModelInputMap,
+  ModelOutputMap,
+} from '../../common/interfaces';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
 import * as pluginManifest from '../../opensearch_dashboards.json';
@@ -221,11 +226,19 @@ export function parseModelInputsObj(
   ) as ModelInputMap;
 }
 
-// Derive the collection of model outputs from the model interface JSONSchema into a form-ready list
+// Derive the collection of model outputs from the model interface JSONSchema into a form-ready list.
+// Expose the full path or nested path depending on fullResponsePath
 export function parseModelOutputs(
-  modelInterface: ModelInterface | undefined
+  modelInterface: ModelInterface | undefined,
+  fullResponsePath: boolean = false
 ): ModelOutputFormField[] {
-  const modelOutputsObj = get(modelInterface, 'output.properties', {}) as {
+  const modelOutputsObj = get(
+    modelInterface,
+    fullResponsePath
+      ? MODEL_OUTPUT_SCHEMA_FULL_PATH
+      : MODEL_OUTPUT_SCHEMA_NESTED_PATH,
+    {}
+  ) as {
     [key: string]: ModelOutput;
   };
   return Object.keys(modelOutputsObj).map(
@@ -237,6 +250,20 @@ export function parseModelOutputs(
   );
 }
 
+// Derive the collection of model outputs as an obj.
+// Expose the full path or nested path depending on fullResponsePath
+export function parseModelOutputsObj(
+  modelInterface: ModelInterface | undefined,
+  fullResponsePath: boolean = false
+): ModelOutputMap {
+  return get(
+    modelInterface,
+    fullResponsePath
+      ? MODEL_OUTPUT_SCHEMA_FULL_PATH
+      : MODEL_OUTPUT_SCHEMA_NESTED_PATH,
+    {}
+  ) as ModelOutputMap;
+}
 export const getDataSourceFromURL = (location: {
   search: string;
 }): MDSQueryParams => {


### PR DESCRIPTION
### Description

ML inference processors parse out the response differently depending on if `full_response_path` is true or not. The model interfaces will always include the full path. To help abstract this on the UI, we can implement the same parsing logic to get to the nested model output data when `full_response_path=false`. This way, it is consistent across the interface, and the configured output map configuration. The path to get such nested data is `inference_results[0].output[0].dataAsMap`.

More details:
- only displays preset options for model outputs when `full_response_path=false`. Else, it will not be useful, as the path would always start with `inference_results` arr, and users would need to write full JSON path here to get to the nested data they want
- adds a "View output schema" button that is visible when a model output interface is defined. Shows the full interface, or the nested interface, depending on if `full_response_path` is true/false, respectively.

Demo video, showing a model with an output interface. The nested interface in `dataAsMap` includes a single `response` field as a string. When `full_response_path=false`, we show the model output options in a dropdown, and show the nested interface. When `full_response_path=true`, we leave the model output field as freeform text w/ no options, and show the whole nested interface. 

[screen-capture (23).webm](https://github.com/user-attachments/assets/9bfb0044-8671-4341-b847-fca327808690)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
