### PR TITLE
Support one-to-one / many-to-one sample inputs/outputs in ML search resp processors

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -410,6 +410,11 @@ export const QUERY_PRESETS = [
 /**
  * MISCELLANEOUS
  */
+export enum PROCESSOR_CONTEXT {
+  INGEST = 'ingest',
+  SEARCH_REQUEST = 'search_request',
+  SEARCH_RESPONSE = 'search_response',
+}
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
@@ -434,9 +439,6 @@ export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
-
-export enum PROCESSOR_CONTEXT {
-  INGEST = 'ingest',
-  SEARCH_REQUEST = 'search_request',
-  SEARCH_RESPONSE = 'search_response',
-}
+export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
+  'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
+export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -36,7 +36,7 @@ export function getCharacterLimitedString(
     : '';
 }
 
-export function customStringify(jsonObj: {}): string {
+export function customStringify(jsonObj: {} | []): string {
   return JSON.stringify(jsonObj, undefined, 2);
 }
 

--- a/public/configs/search_response_processors/ml_search_response_processor.ts
+++ b/public/configs/search_response_processors/ml_search_response_processor.ts
@@ -14,11 +14,15 @@ export class MLSearchResponseProcessor extends MLProcessor {
     super();
     this.id = generateId('ml_processor_search_response');
     this.optionalFields = [
+      ...(this.optionalFields || []),
       {
         id: 'one_to_one',
         type: 'boolean',
       },
-      ...(this.optionalFields || []),
+      {
+        id: 'override',
+        type: 'boolean',
+      },
     ];
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -74,6 +74,9 @@ interface InputTransformModalProps {
   onClose: () => void;
 }
 
+// the max number of input docs we use to display & test transforms with
+const MAX_INPUT_DOCS = 10;
+
 /**
  * A modal to configure advanced JSON-to-JSON transforms into a model's expected input
  */
@@ -119,6 +122,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
   // validation state utilizing the model interface, if applicable. undefined if
   // there is no model interface and/or no source input
   const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
+
+  const description =
+    props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+      ? 'Fetch an input query and see how it is transformed.'
+      : `Fetch some sample documents (up to ${MAX_INPUT_DOCS}) and see how they are transformed.`;
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {
@@ -200,9 +208,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
             <>
-              <EuiText color="subdued">
-                Fetch some sample input data and see how it is transformed.
-              </EuiText>
+              <EuiText color="subdued">{description}</EuiText>
               <EuiSpacer size="s" />
               <EuiText>Source input</EuiText>
               <EuiSmallButton
@@ -310,9 +316,9 @@ export function InputTransformModal(props: InputTransformModalProps) {
                       )
                         .unwrap()
                         .then(async (resp) => {
-                          const hits = resp.hits.hits.map(
-                            (hit: SearchHit) => hit._source
-                          );
+                          const hits = resp.hits.hits
+                            .map((hit: SearchHit) => hit._source)
+                            .slice(0, MAX_INPUT_DOCS);
                           if (hits.length > 0) {
                             setSourceInput(
                               // if one-to-one, treat the source input as a single retrieved document

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -97,8 +97,12 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const [sourceInput, setSourceInput] = useState<string>('[]');
   const [transformedInput, setTransformedInput] = useState<string>('{}');
 
-  // get the current input map
+  // get some current form values
   const map = getIn(values, props.inputMapFieldPath) as MapArrayFormValue;
+  const oneToOne = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.one_to_one`
+  );
 
   // selected transform state
   const transformOptions = map.map((_, idx) => ({
@@ -310,7 +314,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
                             (hit: SearchHit) => hit._source
                           );
                           if (hits.length > 0) {
-                            setSourceInput(customStringify(hits[0]));
+                            setSourceInput(
+                              // if one-to-one, treat the source input as a single retrieved document
+                              // else, treat it as all of the returned documents
+                              customStringify(oneToOne ? hits[0] : hits)
+                            );
                           }
                         })
                         .catch((error: any) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -79,6 +79,10 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   ) as IConfigField;
   const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.${outputMapField.id}`;
   const outputMapValue = getIn(values, outputMapFieldPath);
+  const fullResponsePath = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.full_response_path`
+  );
 
   // preview availability states
   // if there are preceding search request processors, we cannot fetch and display the interim transformed query.
@@ -228,6 +232,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         <OutputTransformModal
           uiConfig={props.uiConfig}
           config={props.config}
+          baseConfigPath={props.baseConfigPath}
           context={props.context}
           outputMapField={outputMapField}
           outputMapFieldPath={outputMapFieldPath}
@@ -345,7 +350,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : 'New document field'
             }
             valuePlaceholder="Model output field"
-            valueOptions={parseModelOutputs(modelInterface)}
+            valueOptions={
+              fullResponsePath
+                ? undefined
+                : parseModelOutputs(modelInterface, false)
+            }
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -86,7 +86,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   const [sourceOutput, setSourceOutput] = useState<string>('[]');
   const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
-  // get some current values
+  // get some current form values
   const map = getIn(values, props.outputMapFieldPath) as MapArrayFormValue;
   const fullResponsePath = getIn(
     values,

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -8,6 +8,8 @@ import jsonpath from 'jsonpath';
 import { escape, get } from 'lodash';
 import {
   JSONPATH_ROOT_SELECTOR,
+  MODEL_OUTPUT_SCHEMA_FULL_PATH,
+  MODEL_OUTPUT_SCHEMA_NESTED_PATH,
   MapFormValue,
   ModelInputFormField,
   ModelInterface,
@@ -18,10 +20,13 @@ import {
   WORKFLOW_RESOURCE_TYPE,
   WORKFLOW_STEP_TYPE,
   Workflow,
-  customStringify,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
-import { MDSQueryParams, ModelInputMap } from '../../common/interfaces';
+import {
+  MDSQueryParams,
+  ModelInputMap,
+  ModelOutputMap,
+} from '../../common/interfaces';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
 import * as pluginManifest from '../../opensearch_dashboards.json';
@@ -221,11 +226,19 @@ export function parseModelInputsObj(
   ) as ModelInputMap;
 }
 
-// Derive the collection of model outputs from the model interface JSONSchema into a form-ready list
+// Derive the collection of model outputs from the model interface JSONSchema into a form-ready list.
+// Expose the full path or nested path depending on fullResponsePath
 export function parseModelOutputs(
-  modelInterface: ModelInterface | undefined
+  modelInterface: ModelInterface | undefined,
+  fullResponsePath: boolean = false
 ): ModelOutputFormField[] {
-  const modelOutputsObj = get(modelInterface, 'output.properties', {}) as {
+  const modelOutputsObj = get(
+    modelInterface,
+    fullResponsePath
+      ? MODEL_OUTPUT_SCHEMA_FULL_PATH
+      : MODEL_OUTPUT_SCHEMA_NESTED_PATH,
+    {}
+  ) as {
     [key: string]: ModelOutput;
   };
   return Object.keys(modelOutputsObj).map(
@@ -237,6 +250,20 @@ export function parseModelOutputs(
   );
 }
 
+// Derive the collection of model outputs as an obj.
+// Expose the full path or nested path depending on fullResponsePath
+export function parseModelOutputsObj(
+  modelInterface: ModelInterface | undefined,
+  fullResponsePath: boolean = false
+): ModelOutputMap {
+  return get(
+    modelInterface,
+    fullResponsePath
+      ? MODEL_OUTPUT_SCHEMA_FULL_PATH
+      : MODEL_OUTPUT_SCHEMA_NESTED_PATH,
+    {}
+  ) as ModelOutputMap;
+}
 export const getDataSourceFromURL = (location: {
   search: string;
 }): MDSQueryParams => {


### PR DESCRIPTION
### Description

Support one-to-one / many-to-one sample inputs/outputs in ML search resp processors

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
