### PR TITLE
Support relevant form toggling in advanced transform modals

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -155,6 +155,8 @@ export enum COMPONENT_CLASS {
  */
 export const ML_INFERENCE_DOCS_LINK =
   'https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/#configuration-parameters';
+export const ML_INFERENCE_RESPONSE_DOCS_LINK =
+  'https://opensearch.org/docs/latest/search-plugins/search-pipelines/ml-inference-search-response/#request-fields';
 export const ML_CHOOSE_MODEL_LINK =
   'https://opensearch.org/docs/latest/ml-commons-plugin/integrating-ml-models/#choosing-a-model';
 export const TEXT_CHUNKING_PROCESSOR_LINK =

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -36,7 +36,7 @@ export function getCharacterLimitedString(
     : '';
 }
 
-export function customStringify(jsonObj: {}): string {
+export function customStringify(jsonObj: {} | []): string {
   return JSON.stringify(jsonObj, undefined, 2);
 }
 

--- a/public/configs/search_response_processors/ml_search_response_processor.ts
+++ b/public/configs/search_response_processors/ml_search_response_processor.ts
@@ -14,11 +14,15 @@ export class MLSearchResponseProcessor extends MLProcessor {
     super();
     this.id = generateId('ml_processor_search_response');
     this.optionalFields = [
+      ...(this.optionalFields || []),
       {
         id: 'one_to_one',
         type: 'boolean',
       },
-      ...(this.optionalFields || []),
+      {
+        id: 'override',
+        type: 'boolean',
+      },
     ];
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -34,6 +34,7 @@ import {
   IngestPipelineConfig,
   JSONPATH_ROOT_SELECTOR,
   ML_INFERENCE_DOCS_LINK,
+  ML_INFERENCE_RESPONSE_DOCS_LINK,
   MapArrayFormValue,
   ModelInterface,
   PROCESSOR_CONTEXT,
@@ -60,7 +61,7 @@ import {
   parseModelInputs,
   parseModelInputsObj,
 } from '../../../../utils/utils';
-import { MapArrayField } from '../input_fields';
+import { BooleanField, MapArrayField } from '../input_fields';
 
 interface InputTransformModalProps {
   uiConfig: WorkflowConfig;
@@ -102,10 +103,8 @@ export function InputTransformModal(props: InputTransformModalProps) {
 
   // get some current form values
   const map = getIn(values, props.inputMapFieldPath) as MapArrayFormValue;
-  const oneToOne = getIn(
-    values,
-    `${props.baseConfigPath}.${props.config.id}.one_to_one`
-  );
+  const oneToOnePath = `${props.baseConfigPath}.${props.config.id}.one_to_one`;
+  const oneToOne = getIn(values, oneToOnePath);
 
   // selected transform state
   const transformOptions = map.map((_, idx) => ({
@@ -210,6 +209,26 @@ export function InputTransformModal(props: InputTransformModalProps) {
             <>
               <EuiText color="subdued">{description}</EuiText>
               <EuiSpacer size="s" />
+              {props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE && (
+                <>
+                  <BooleanField
+                    label={'One-to-one'}
+                    fieldPath={oneToOnePath}
+                    enabledOption={{
+                      id: `${oneToOnePath}_true`,
+                      label: 'True',
+                    }}
+                    disabledOption={{
+                      id: `${oneToOnePath}_false`,
+                      label: 'False',
+                    }}
+                    showLabel={true}
+                    helpLink={ML_INFERENCE_RESPONSE_DOCS_LINK}
+                    helpText="Run inference for each document separately"
+                  />
+                  <EuiSpacer size="s" />
+                </>
+              )}
               <EuiText>Source input</EuiText>
               <EuiSmallButton
                 style={{ width: '100px' }}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -74,6 +74,9 @@ interface InputTransformModalProps {
   onClose: () => void;
 }
 
+// the max number of input docs we use to display & test transforms with
+const MAX_INPUT_DOCS = 10;
+
 /**
  * A modal to configure advanced JSON-to-JSON transforms into a model's expected input
  */
@@ -119,6 +122,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
   // validation state utilizing the model interface, if applicable. undefined if
   // there is no model interface and/or no source input
   const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
+
+  const description =
+    props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+      ? 'Fetch an input query and see how it is transformed.'
+      : `Fetch some sample documents (up to ${MAX_INPUT_DOCS}) and see how they are transformed.`;
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {
@@ -200,9 +208,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
             <>
-              <EuiText color="subdued">
-                Fetch some sample input data and see how it is transformed.
-              </EuiText>
+              <EuiText color="subdued">{description}</EuiText>
               <EuiSpacer size="s" />
               <EuiText>Source input</EuiText>
               <EuiSmallButton
@@ -310,9 +316,9 @@ export function InputTransformModal(props: InputTransformModalProps) {
                       )
                         .unwrap()
                         .then(async (resp) => {
-                          const hits = resp.hits.hits.map(
-                            (hit: SearchHit) => hit._source
-                          );
+                          const hits = resp.hits.hits
+                            .map((hit: SearchHit) => hit._source)
+                            .slice(0, MAX_INPUT_DOCS);
                           if (hits.length > 0) {
                             setSourceInput(
                               // if one-to-one, treat the source input as a single retrieved document

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -97,8 +97,12 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const [sourceInput, setSourceInput] = useState<string>('[]');
   const [transformedInput, setTransformedInput] = useState<string>('{}');
 
-  // get the current input map
+  // get some current form values
   const map = getIn(values, props.inputMapFieldPath) as MapArrayFormValue;
+  const oneToOne = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.one_to_one`
+  );
 
   // selected transform state
   const transformOptions = map.map((_, idx) => ({
@@ -310,7 +314,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
                             (hit: SearchHit) => hit._source
                           );
                           if (hits.length > 0) {
-                            setSourceInput(customStringify(hits[0]));
+                            setSourceInput(
+                              // if one-to-one, treat the source input as a single retrieved document
+                              // else, treat it as all of the returned documents
+                              customStringify(oneToOne ? hits[0] : hits)
+                            );
                           }
                         })
                         .catch((error: any) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/input_transform_modal.tsx
@@ -98,7 +98,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const [isFetching, setIsFetching] = useState<boolean>(false);
 
   // source input / transformed input state
-  const [sourceInput, setSourceInput] = useState<string>('[]');
+  const [sourceInput, setSourceInput] = useState<string>('{}');
   const [transformedInput, setTransformedInput] = useState<string>('{}');
 
   // get some current form values
@@ -143,6 +143,8 @@ export function InputTransformModal(props: InputTransformModalProps) {
         );
         setTransformedInput(customStringify(output));
       } catch {}
+    } else {
+      setTransformedInput('{}');
     }
   }, [map, sourceInput, selectedTransformOption]);
 
@@ -195,6 +197,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
       setTransformedPrompt(originalPrompt);
     }
   }, [originalPrompt, transformedInput]);
+
+  // hook to clear the source input when one_to_one is toggled
+  useEffect(() => {
+    setSourceInput('{}');
+  }, [oneToOne]);
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/output_transform_modal.tsx
@@ -86,7 +86,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
   const [sourceOutput, setSourceOutput] = useState<string>('[]');
   const [transformedOutput, setTransformedOutput] = useState<string>('{}');
 
-  // get some current values
+  // get some current form values
   const map = getIn(values, props.outputMapFieldPath) as MapArrayFormValue;
   const fullResponsePath = getIn(
     values,


### PR DESCRIPTION
### Description

This PR adds specific, relevant forms to be exposed in the advanced transform modals, such that users can toggle and test directly within the modal, instead of navigating to/from the advanced settings fields. Specifically:
- exposes `one_to_one` toggling on INPUT transform for SEARCH RESPONSE only. This changes what the source input will be (single value vs. array of values)
- exposes `full_response_path` toggling on OUTPUT transforms for INGEST / SEARCH RESPONSE only. This changes what the source output will be (nested model response vs. full model response)

More details
- adds visual support for the default many-to-one behavior on input transform (when `one_to_one` is false). In this scenario, we collapse the values from all of the documents into a single list, to pass as a single parameter for one inference call via the ML processor
- updates `generateTransform` to support the above use case ^
- exposes `override` field for search resp processor
- limits input docs to the input transform, to be 10
- resets form inputs when form values are toggled

Demo video, showing `one_to_one` toggling on the input transform, and `full_response_path` toggling on the output transform. Note the model input selector in the output field changes from a selector when `false`, to a freeform text when `true`. This is because when it is `true`, the full model response path is passed, and users must write custom JSON path to parse out the relevant values they need.

[screen-capture (24).webm](https://github.com/user-attachments/assets/dac4547f-66d9-463e-96c5-34982b7728c8)


### Issues Resolved

Resolves #367 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
