### PR TITLE
Add dedicated prompt configuration for ML search resp processors

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEntry, QueryPreset, WORKFLOW_STATE } from './interfaces';
+import {
+  MapEntry,
+  PromptPreset,
+  QueryPreset,
+  WORKFLOW_STATE,
+} from './interfaces';
 import { customStringify } from './utils';
 
 export const PLUGIN_ID = 'search-studio';
@@ -408,6 +413,39 @@ export const QUERY_PRESETS = [
     query: customStringify(HYBRID_SEARCH_QUERY_MATCH_NEURAL),
   },
 ] as QueryPreset[];
+
+/**
+ * PROMPT PRESETS
+ */
+export const SUMMARIZE_DOCS_PROMPT =
+  "Human: You are a professional data analyist. \
+You are given a list of document results. You will \
+analyze the data and generate a human-readable summary of the results. If you don't \
+know the answer, just say I don't know.\
+\n\n Results: <provide some results> \
+\n\n Human: Please summarize the results.\
+\n\n Assistant:";
+
+export const QA_WITH_DOCUMENTS_PROMPT =
+  "Human: You are a professional data analyist. \
+You are given a list of document results, along with a question. You will \
+analyze the results and generate a human-readable response to the question, \
+based on the results. If you don't know the answer, just say I don't know.\
+\n\n Results: <provide some results> \
+\n\n Question: <provide some question> \
+\n\n Human: Please answer the question using the provided results.\
+\n\n Assistant:";
+
+export const PROMPT_PRESETS = [
+  {
+    name: 'Summarize documents',
+    prompt: SUMMARIZE_DOCS_PROMPT,
+  },
+  {
+    name: 'QA with documents',
+    prompt: QA_WITH_DOCUMENTS_PROMPT,
+  },
+] as PromptPreset[];
 
 /**
  * MISCELLANEOUS

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -482,6 +482,11 @@ export type QueryPreset = {
   query: string;
 };
 
+export type PromptPreset = {
+  name: string;
+  prompt: string;
+};
+
 export type QuickConfigureFields = {
   modelId?: string;
   vectorField?: string;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  EuiSmallButton,
 } from '@elastic/eui';
 import {
   IProcessorConfig,
@@ -30,8 +31,11 @@ import {
   IndexMappings,
 } from '../../../../../common';
 import { MapArrayField, ModelField } from '../input_fields';
-import { InputTransformModal } from './input_transform_modal';
-import { OutputTransformModal } from './output_transform_modal';
+import {
+  ConfigurePromptModal,
+  InputTransformModal,
+  OutputTransformModal,
+} from './modals';
 import { AppState, getMappings, useAppDispatch } from '../../../../store';
 import {
   formikToPartialPipeline,
@@ -108,13 +112,14 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     }
   }, [props.uiConfig.search.enrichRequest.processors]);
 
-  // advanced transformations modal state
+  // various modal states
   const [isInputTransformModalOpen, setIsInputTransformModalOpen] = useState<
     boolean
   >(false);
   const [isOutputTransformModalOpen, setIsOutputTransformModalOpen] = useState<
     boolean
   >(false);
+  const [isPromptModalOpen, setIsPromptModalOpen] = useState<boolean>(false);
 
   // model interface state
   const [modelInterface, setModelInterface] = useState<
@@ -240,6 +245,14 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           onClose={() => setIsOutputTransformModalOpen(false)}
         />
       )}
+      {isPromptModalOpen && (
+        <ConfigurePromptModal
+          config={props.config}
+          baseConfigPath={props.baseConfigPath}
+          modelInterface={modelInterface}
+          onClose={() => setIsPromptModalOpen(false)}
+        />
+      )}
       <ModelField
         field={modelField}
         fieldPath={modelFieldPath}
@@ -249,6 +262,23 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
       {!isEmpty(getIn(values, modelFieldPath)?.id) && (
         <>
           <EuiSpacer size="s" />
+          {props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE && (
+            <>
+              <EuiText
+                size="m"
+                style={{ marginTop: '4px' }}
+              >{`Configure prompt (Optional)`}</EuiText>
+              <EuiSpacer size="s" />
+              <EuiSmallButton
+                style={{ width: '100px' }}
+                fill={false}
+                onClick={() => setIsPromptModalOpen(true)}
+              >
+                Configure
+              </EuiSmallButton>
+              <EuiSpacer size="s" />
+            </>
+          )}
           <EuiFlexGroup direction="row">
             <EuiFlexItem grow={false}>
               <EuiText

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -276,7 +276,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               >
                 Configure
               </EuiSmallButton>
-              <EuiSpacer size="s" />
+              <EuiSpacer size="l" />
             </>
           )}
           <EuiFlexGroup direction="row">
@@ -310,7 +310,6 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiSpacer size="s" />
           <EuiSpacer size="s" />
           <MapArrayField
             field={inputMapField}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useFormikContext, getIn } from 'formik';
+import { cloneDeep, isEmpty, set } from 'lodash';
+import {
+  EuiCodeEditor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiCompressedSelect,
+  EuiSelectOption,
+  EuiSmallButton,
+  EuiSpacer,
+  EuiText,
+  EuiPopover,
+  EuiSmallButtonEmpty,
+  EuiPopoverTitle,
+  EuiCodeBlock,
+  EuiCallOut,
+  EuiCode,
+} from '@elastic/eui';
+import {
+  IConfigField,
+  IProcessorConfig,
+  IngestPipelineConfig,
+  JSONPATH_ROOT_SELECTOR,
+  ML_INFERENCE_DOCS_LINK,
+  ML_INFERENCE_RESPONSE_DOCS_LINK,
+  MapArrayFormValue,
+  ModelInterface,
+  PROCESSOR_CONTEXT,
+  SearchHit,
+  SearchPipelineConfig,
+  SimulateIngestPipelineResponse,
+  WorkflowConfig,
+  WorkflowFormValues,
+  customStringify,
+} from '../../../../../../common';
+import {
+  formikToPartialPipeline,
+  generateTransform,
+  prepareDocsForSimulate,
+  unwrapTransformedDocs,
+} from '../../../../../utils';
+import {
+  searchIndex,
+  simulatePipeline,
+  useAppDispatch,
+} from '../../../../../store';
+import { getCore } from '../../../../../services';
+import { BooleanField, MapArrayField } from '../../input_fields';
+import {
+  getDataSourceId,
+  parseModelInputs,
+  parseModelInputsObj,
+  parseModelOutputs,
+  parseModelOutputsObj,
+} from '../../../../../utils/utils';
+
+interface ConfigurePromptModalProps {
+  config: IProcessorConfig;
+  baseConfigPath: string;
+  modelInterface: ModelInterface | undefined;
+  onClose: () => void;
+}
+
+/**
+ * A modal to configure advanced JSON-to-JSON transforms from a model's expected output
+ */
+export function ConfigurePromptModal(props: ConfigurePromptModalProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+  const { values } = useFormikContext<WorkflowFormValues>();
+
+  // get some current form values
+  const modelConfigPath = `${props.baseConfigPath}.${props.config.id}.model_config`;
+  const modelConfig = getIn(values, modelConfigPath) as string;
+  const modelInputs = parseModelInputs(props.modelInterface);
+
+  // prompt state
+  const [prompt, setPrompt] = useState<string>('');
+
+  // hook to set the prompt if found in the model config
+  useEffect(() => {
+    const modelConfigString = getIn(
+      values,
+      `${props.baseConfigPath}.${props.config.id}.model_config`
+    ) as string;
+    try {
+      const prompt = JSON.parse(modelConfigString)?.prompt;
+      if (!isEmpty(prompt)) {
+        setPrompt(prompt);
+      } else {
+        setPrompt('');
+      }
+    } catch {}
+  }, [
+    getIn(values, `${props.baseConfigPath}.${props.config.id}.model_config`),
+  ]);
+
+  return (
+    <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Configure prompt`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody style={{ height: '40vh' }}>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <>
+              <EuiText color="subdued">
+                Configure a custom prompt template. Optionally use model input
+                values in the prompt template with placeholders.
+              </EuiText>
+              <EuiSpacer size="s" />
+              <EuiText>Model inputs</EuiText>
+              <EuiSpacer size="s" />
+              {modelInputs.length > 0 ? (
+                <>
+                  <EuiCodeBlock language="json" fontSize="s" isCopyable={false}>
+                    {customStringify({
+                      parameters: parseModelInputsObj(props.modelInterface),
+                    })}
+                  </EuiCodeBlock>
+                </>
+              ) : (
+                <EuiCallOut color="warning" title="No defined model inputs" />
+              )}
+              <EuiSpacer size="s" />
+              {modelInputs.length > 0 && (
+                <>
+                  <EuiText>Model input placeholders</EuiText>
+                  {modelInputs.map((modelInput) => {
+                    return (
+                      <EuiCode
+                        language="json"
+                        transparentBackground={true}
+                      >{`parameters.${modelInput.label}`}</EuiCode>
+                    );
+                  })}
+                  <EuiSpacer size="m" />
+                </>
+              )}
+              <EuiText>Prompt</EuiText>
+              <EuiSpacer size="s" />
+              <EuiCodeEditor
+                mode="json"
+                theme="textmate"
+                width="100%"
+                height="15vh"
+                value={prompt}
+                readOnly={false}
+                setOptions={{
+                  fontSize: '12px',
+                  autoScrollEditorIntoView: true,
+                  showLineNumbers: false,
+                  showGutter: false,
+                  showPrintMargin: false,
+                  wrap: true,
+                }}
+                tabSize={2}
+                onChange={(value) => console.log('value now: ', value)}
+              />
+            </>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
+          Close
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
@@ -243,7 +243,7 @@ const columns = [
   {
     name: 'Name',
     field: 'label',
-    width: '30%',
+    width: '25%',
   },
   {
     name: 'Type',
@@ -253,7 +253,7 @@ const columns = [
   {
     name: 'Placeholder string',
     field: 'label',
-    width: '55%',
+    width: '50%',
     render: (label: string, modelInput: ModelInputFormField) => (
       <EuiCode
         style={{
@@ -262,9 +262,7 @@ const columns = [
         language="json"
         transparentBackground={true}
       >
-        {modelInput.type === 'array'
-          ? `\$\{parameters.${label}.toString()\}`
-          : `\$\\{parameters.${label}\\}`}
+        {getPlaceholderString(modelInput.type, label)}
       </EuiCode>
     ),
   },
@@ -273,13 +271,7 @@ const columns = [
     field: 'label',
     width: '10%',
     render: (label: string, modelInput: ModelInputFormField) => (
-      <EuiCopy
-        textToCopy={
-          modelInput.type === 'array'
-            ? `\$\{parameters.${label}.toString()\}`
-            : `\$\\{parameters.${label}\\}`
-        }
-      >
+      <EuiCopy textToCopy={getPlaceholderString(modelInput.type, label)}>
         {(copy) => (
           <EuiButtonIcon
             aria-label="Copy"
@@ -291,3 +283,14 @@ const columns = [
     ),
   },
 ];
+
+// small util fn to get the full placeholder string to be
+// inserted into the template. String conversion is required
+// if the input is an array, for example. Also, all values
+// should be prepended with "parameters.", as all inputs
+// will be nested under a base parameters obj.
+function getPlaceholderString(type: string, label: string) {
+  return type === 'array'
+    ? `\$\{parameters.${label}.toString()\}`
+    : `\$\\{parameters.${label}\\}`;
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './input_transform_modal';
+export * from './output_transform_modal';
+export * from './configure_prompt_modal';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -43,25 +43,25 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
   customStringify,
-} from '../../../../../common';
+} from '../../../../../../common';
 import {
   formikToPartialPipeline,
   generateTransform,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
-} from '../../../../utils';
+} from '../../../../../utils';
 import {
   searchIndex,
   simulatePipeline,
   useAppDispatch,
-} from '../../../../store';
-import { getCore } from '../../../../services';
+} from '../../../../../store';
+import { getCore } from '../../../../../services';
 import {
   getDataSourceId,
   parseModelInputs,
   parseModelInputsObj,
-} from '../../../../utils/utils';
-import { BooleanField, MapArrayField } from '../input_fields';
+} from '../../../../../utils/utils';
+import { BooleanField, MapArrayField } from '../../input_fields';
 
 interface InputTransformModalProps {
   uiConfig: WorkflowConfig;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -41,25 +41,25 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
   customStringify,
-} from '../../../../../common';
+} from '../../../../../../common';
 import {
   formikToPartialPipeline,
   generateTransform,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
-} from '../../../../utils';
+} from '../../../../../utils';
 import {
   searchIndex,
   simulatePipeline,
   useAppDispatch,
-} from '../../../../store';
-import { getCore } from '../../../../services';
-import { BooleanField, MapArrayField } from '../input_fields';
+} from '../../../../../store';
+import { getCore } from '../../../../../services';
+import { BooleanField, MapArrayField } from '../../input_fields';
 import {
   getDataSourceId,
   parseModelOutputs,
   parseModelOutputsObj,
-} from '../../../../utils/utils';
+} from '../../../../../utils/utils';
 
 interface OutputTransformModalProps {
   uiConfig: WorkflowConfig;

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -34,7 +34,9 @@ interface EditQueryModalProps {
  */
 export function EditQueryModal(props: EditQueryModalProps) {
   // Form state
-  const { setFieldValue } = useFormikContext<WorkflowFormValues>();
+  const { setFieldValue, setFieldTouched } = useFormikContext<
+    WorkflowFormValues
+  >();
 
   // popover state
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false);
@@ -69,9 +71,9 @@ export function EditQueryModal(props: EditQueryModalProps) {
                   name: preset.name,
                   onClick: () => {
                     setFieldValue(props.queryFieldPath, preset.query);
+                    setFieldTouched(props.queryFieldPath, true);
                     setPopoverOpen(false);
                   },
-                  size: 'full',
                 })),
               },
             ]}

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -214,6 +214,10 @@ function injectQuickConfigureFields(
       }
       case WORKFLOW_TYPE.RAG: {
         if (!isEmpty(quickConfigureFields) && workflow.ui_metadata?.config) {
+          workflow.ui_metadata.config = updateIndexConfig(
+            workflow.ui_metadata.config,
+            quickConfigureFields
+          );
           workflow.ui_metadata.config = updateSearchResponseProcessors(
             workflow.ui_metadata.config,
             quickConfigureFields,


### PR DESCRIPTION
### Description

Adds a dedicated section and modal for optionally configuring a prompt. Only exposing in the search response context, as that is the most likely place users will be setting it up. Can easily be enabled for other contexts if wanted later on. The dedicated modal has 3 main parts: 1/ dropdown with prompt template presets for users to select from, 2/ the user-editable text editor that displays the prompt, and 3/ the list of model inputs (and corresponding placeholder strings) that users can copy/paste, in order to insert these dynamic values into the template at runtime (this part is omitted if no input interface found). A common example of this, is passing returned documents as context in the prompt template for some LLM to answer a question with / summarize/ etc.

Implementation details:
- adds prompt presets in constants. just 2 very basic ones for now
- updates `MLProcessorInputs` to include a new section to configure the prompt and render the modal if clicked
- new `ConfigurePromptModal` component to handle the user interactions and configuration as described above. any updates to the prompt will be reflected in the form, by updating the `prompt` sub-field under the model config form field.
- minor: refactors the new modal and existing input/output modals into a standalone `modals` module
- minor: adds a `touched` check when selecting a new query, so the save button is enabled immediately when changed (if nothing else is dirty)
- minor: adds index config injection in the quick configure modal for RAG use case, so any configured text field, is set as a `text` field index mapping by default

Demo video, showing a new RAG use case with no prompt template. Shows configuration of the template using a preset, also including the dynamic `context` input to be injected into the template. The full example with injected inputs is available to view when configuring the input transform. When running, the results are as expected, containing a readable summary of the results found.

[screen-capture (1).webm](https://github.com/user-attachments/assets/ad547aed-2a11-4e0b-b137-8fe188f3b8c4)

### Issues Resolved
Resolves #380 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
