### PR TITLE
Improve prompt config UX; support JSONPath bug fix

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -480,3 +480,4 @@ export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
 export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
   'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
 export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';
+export const PROMPT_FIELD = 'prompt'; // TODO: likely expand to support a pattern and/or multiple (e.g., "prompt", "prompt_template", etc.)

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -6,7 +6,12 @@
 import { Node, Edge } from 'reactflow';
 import { FormikValues } from 'formik';
 import { ObjectSchema } from 'yup';
-import { COMPONENT_CLASS, PROCESSOR_TYPE, WORKFLOW_TYPE } from './constants';
+import {
+  COMPONENT_CLASS,
+  PROCESSOR_TYPE,
+  PROMPT_FIELD,
+  WORKFLOW_TYPE,
+} from './constants';
 
 export type Index = {
   name: string;
@@ -401,6 +406,7 @@ export type ModelInterface = {
 export type ConnectorParameters = {
   model?: string;
   dimensions?: number;
+  [PROMPT_FIELD]?: string;
 };
 
 export type Model = {

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -37,12 +37,12 @@ enum TAB_ID {
 const inputTabs = [
   {
     id: TAB_ID.INGEST,
-    name: 'Run ingestion',
+    name: 'Ingest response',
     disabled: false,
   },
   {
     id: TAB_ID.QUERY,
-    name: 'Run query',
+    name: 'Search response',
     disabled: false,
   },
   {

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -94,8 +94,8 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(getByText('Export')).toBeInTheDocument();
       expect(getByText('Visual')).toBeInTheDocument();
       expect(getByText('JSON')).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Run ingestion' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Run query' })).toBeInTheDocument();
+      expect(getByRole('tab', { name: 'Ingest response' })).toBeInTheDocument();
+      expect(getByRole('tab', { name: 'Search response' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
 

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -23,6 +23,7 @@ import {
   AppState,
   catIndices,
   getWorkflow,
+  searchConnectors,
   searchModels,
   useAppDispatch,
 } from '../../store';
@@ -102,11 +103,12 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
 
   // On initial load:
   // - fetch workflow
-  // - fetch available models as their IDs may be used when building flows
+  // - fetch available models & connectors as their IDs may be used when building flows
   // - fetch all indices
   useEffect(() => {
     dispatch(getWorkflow({ workflowId, dataSourceId }));
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
+    dispatch(searchConnectors({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
     dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
   }, []);
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
@@ -33,6 +33,7 @@ import {
   IProcessorConfig,
   ModelInputFormField,
   ModelInterface,
+  PROMPT_FIELD,
   PROMPT_PRESETS,
   PromptPreset,
   WorkflowFormValues,
@@ -74,21 +75,16 @@ export function ConfigurePromptModal(props: ConfigurePromptModalProps) {
 
   // hook to set the prompt if found in the model config
   useEffect(() => {
-    const modelConfigString = getIn(
-      values,
-      `${props.baseConfigPath}.${props.config.id}.model_config`
-    ) as string;
     try {
-      const prompt = JSON.parse(modelConfigString)?.prompt;
+      const modelConfigObj = JSON.parse(getIn(values, modelConfigPath));
+      const prompt = getIn(modelConfigObj, PROMPT_FIELD);
       if (!isEmpty(prompt)) {
         setPromptStr(prompt);
       } else {
         setPromptStr('');
       }
     } catch {}
-  }, [
-    getIn(values, `${props.baseConfigPath}.${props.config.id}.model_config`),
-  ]);
+  }, [getIn(values, modelConfigPath)]);
 
   return (
     <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
@@ -127,7 +123,7 @@ export function ConfigurePromptModal(props: ConfigurePromptModalProps) {
                               modelConfigPath,
                               customStringify({
                                 ...JSON.parse(modelConfig),
-                                prompt: preset.prompt,
+                                [PROMPT_FIELD]: preset.prompt,
                               })
                             );
                           } catch {}
@@ -168,9 +164,9 @@ export function ConfigurePromptModal(props: ConfigurePromptModalProps) {
                     // if the input is blank, it is assumed the user
                     // does not want any prompt. hence, remove the "prompt" field
                     // from the config altogether.
-                    delete updatedModelConfig.prompt;
+                    delete updatedModelConfig[PROMPT_FIELD];
                   } else {
-                    updatedModelConfig.prompt = promptStr;
+                    updatedModelConfig[PROMPT_FIELD] = promptStr;
                   }
                   setFieldValue(
                     modelConfigPath,

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -232,7 +232,7 @@ function getTransformedResult(
     ? input
     : mapEntry.value.startsWith(JSONPATH_ROOT_SELECTOR)
     ? // JSONPath transform
-      jsonpath.query(input, path)
+      jsonpath.value(input, path)
     : // Standard dot notation
       get(input, path);
 }

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -16,6 +16,7 @@ import {
   ModelInterface,
   ModelOutput,
   NO_MODIFICATIONS_FOUND_TEXT,
+  PROMPT_FIELD,
   SearchHit,
   WORKFLOW_RESOURCE_TYPE,
   WORKFLOW_STATE,
@@ -160,6 +161,7 @@ export function getConnectorsFromResponses(
       parameters: {
         model: connectorHit._source?.parameters?.model,
         dimensions: connectorHit._source?.parameters.dimensions,
+        [PROMPT_FIELD]: connectorHit?._source?.parameters[PROMPT_FIELD],
       },
     } as Connector;
   });


### PR DESCRIPTION
### Description

Misc improvements PR:
- improves the logic on when to expose the "Configure prompt" section in the ML processor configs. Rather than exposing by default for ML search response processors, instead only expose if there is a present 'prompt` parameters via the connector blueprint, regardless of context (ingest,search req, search resp). In general, this will require some consistency on the expected blueprints to contain such field for such use cases - ongoing discussions with ML team to sort this part out.
- supports / is consistent with the bug fix in ML ingest processors, (see [here](https://github.com/opensearch-project/ml-commons/pull/2985))such that we do not always default to an array obj. Updates the underlying `jsonpath` call from `query` -> `value`, where `value` returns the first hit in the target obj, instead of wrapping all hits in an arr.
- Minor wording improvements of the 'Tools' tabs
- changing hardcoded `prompt` field to a constant. we may have more, and/or have a regex for determining when a connector has a configurable "prompt"/"prompt template" etc. (tracked via #393)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
