### PR TITLE
Add dedicated UX for query template building (ML search req processors)

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -311,6 +311,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 style={{ width: '100px' }}
                 fill={false}
                 onClick={() => setIsQueryModalOpen(true)}
+                data-testid="overrideQueryButton"
               >
                 Override
               </EuiSmallButton>
@@ -328,6 +329,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 style={{ width: '100px' }}
                 fill={false}
                 onClick={() => setIsPromptModalOpen(true)}
+                data-testid="configurePromptButton"
               >
                 Configure
               </EuiSmallButton>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
@@ -94,6 +94,10 @@ export function ConfigurePromptModal(props: ConfigurePromptModalProps) {
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody style={{ height: '40vh' }}>
+        <EuiText color="subdued">
+          Configure a custom prompt template for the model. Optionally inject
+          dynamic model inputs into the template.
+        </EuiText>
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
             <>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
@@ -25,11 +25,19 @@ import {
   EuiContextMenu,
 } from '@elastic/eui';
 import {
+  IMAGE_FIELD_PATTERN,
   IProcessorConfig,
+  LABEL_FIELD_PATTERN,
   MapEntry,
+  MODEL_ID_PATTERN,
   ModelInterface,
+  QUERY_IMAGE_PATTERN,
   QUERY_PRESETS,
+  QUERY_TEXT_PATTERN,
   QueryPreset,
+  TEXT_FIELD_PATTERN,
+  VECTOR_FIELD_PATTERN,
+  VECTOR_PATTERN,
   WorkflowFormValues,
 } from '../../../../../../common';
 import { parseModelOutputs } from '../../../../../utils/utils';
@@ -43,8 +51,8 @@ interface OverrideQueryModalProps {
 }
 
 /**
- * A modal to configure a prompt template. Can manually configure, include placeholder values
- * using other model inputs, and/or select from a presets library.
+ * A modal to configure a query template & override the existing query. Can manually configure,
+ * include placeholder values using model outputs, and/or select from a presets library.
  */
 export function OverrideQueryModal(props: OverrideQueryModalProps) {
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
@@ -85,7 +93,7 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
       <EuiModalBody style={{ height: '40vh' }}>
         <EuiText color="subdued">
           Configure a custom query template to override the existing one.
-          Optionally inject dynamic model outputs into the query.
+          Optionally inject dynamic model outputs into the new query.
         </EuiText>
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
@@ -112,7 +120,45 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
                         name: preset.name,
                         onClick: () => {
                           try {
-                            setFieldValue(queryFieldPath, preset.query);
+                            setFieldValue(
+                              queryFieldPath,
+                              preset.query
+                                // sanitize the query preset string into valid template placeholder format, for
+                                // any placeholder values in the query.
+                                // for example, replacing `"{{vector}}"` with `${vector}`
+                                .replace(
+                                  new RegExp(`"${VECTOR_FIELD_PATTERN}"`, 'g'),
+                                  `\$\{vector_field\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
+                                  `\$\{vector\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${TEXT_FIELD_PATTERN}"`, 'g'),
+                                  `\$\{text_field\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${IMAGE_FIELD_PATTERN}"`, 'g'),
+                                  `\$\{image_field\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${LABEL_FIELD_PATTERN}"`, 'g'),
+                                  `\$\{label_field\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${QUERY_TEXT_PATTERN}"`, 'g'),
+                                  `\$\{query_text\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${QUERY_IMAGE_PATTERN}"`, 'g'),
+                                  `\$\{query_image\}`
+                                )
+                                .replace(
+                                  new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'),
+                                  `\$\{model_id\}`
+                                )
+                            );
                           } catch {}
                           setFieldTouched(queryFieldPath, true);
                           setPresetsPopoverOpen(false);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
@@ -1,0 +1,217 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { useFormikContext, getIn } from 'formik';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSmallButton,
+  EuiSpacer,
+  EuiText,
+  EuiPopover,
+  EuiCode,
+  EuiBasicTable,
+  EuiAccordion,
+  EuiCopy,
+  EuiButtonIcon,
+  EuiContextMenu,
+} from '@elastic/eui';
+import {
+  IProcessorConfig,
+  MapEntry,
+  ModelInterface,
+  QUERY_PRESETS,
+  QueryPreset,
+  WorkflowFormValues,
+} from '../../../../../../common';
+import { parseModelOutputs } from '../../../../../utils/utils';
+import { JsonField } from '../../input_fields';
+
+interface OverrideQueryModalProps {
+  config: IProcessorConfig;
+  baseConfigPath: string;
+  modelInterface: ModelInterface | undefined;
+  onClose: () => void;
+}
+
+/**
+ * A modal to configure a prompt template. Can manually configure, include placeholder values
+ * using other model inputs, and/or select from a presets library.
+ */
+export function OverrideQueryModal(props: OverrideQueryModalProps) {
+  const { values, setFieldValue, setFieldTouched } = useFormikContext<
+    WorkflowFormValues
+  >();
+
+  // get some current form values
+  const modelOutputs = parseModelOutputs(props.modelInterface);
+  const queryFieldPath = `${props.baseConfigPath}.${props.config.id}.query_template`;
+  const outputMap = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.output_map`
+  );
+  // TODO: should handle edge case of multiple output maps configured. Currently
+  // defaulting to prediction 0 / assuming not multiple predictions to track.
+  const outputMapKeys = getIn(outputMap, '0', []).map(
+    (mapEntry: MapEntry) => mapEntry.key
+  ) as string[];
+  const finalModelOutputs =
+    outputMapKeys.length > 0
+      ? outputMapKeys.map((outputMapKey) => {
+          return { label: outputMapKey };
+        })
+      : modelOutputs.map((modelOutput) => {
+          return { label: modelOutput.label };
+        });
+
+  // popover states
+  const [presetsPopoverOpen, setPresetsPopoverOpen] = useState<boolean>(false);
+
+  return (
+    <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Override query`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody style={{ height: '40vh' }}>
+        <EuiText color="subdued">
+          Configure a custom query template to override the existing one.
+          Optionally inject dynamic model outputs into the query.
+        </EuiText>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <>
+              <EuiSpacer size="s" />
+              <EuiPopover
+                button={
+                  <EuiSmallButton
+                    onClick={() => setPresetsPopoverOpen(!presetsPopoverOpen)}
+                  >
+                    Choose from a preset
+                  </EuiSmallButton>
+                }
+                isOpen={presetsPopoverOpen}
+                closePopover={() => setPresetsPopoverOpen(false)}
+                anchorPosition="downLeft"
+              >
+                <EuiContextMenu
+                  initialPanelId={0}
+                  panels={[
+                    {
+                      id: 0,
+                      items: QUERY_PRESETS.map((preset: QueryPreset) => ({
+                        name: preset.name,
+                        onClick: () => {
+                          try {
+                            setFieldValue(queryFieldPath, preset.query);
+                          } catch {}
+                          setFieldTouched(queryFieldPath, true);
+                          setPresetsPopoverOpen(false);
+                        },
+                      })),
+                    },
+                  ]}
+                />
+              </EuiPopover>
+              <EuiSpacer size="m" />
+              <JsonField
+                validate={false}
+                label={'Query template'}
+                fieldPath={queryFieldPath}
+              />
+              {finalModelOutputs.length > 0 && (
+                <>
+                  <EuiSpacer size="m" />
+                  <EuiAccordion
+                    id={`modelOutputsAccordion`}
+                    buttonContent="Model outputs"
+                    style={{ marginLeft: '-8px' }}
+                  >
+                    <>
+                      <EuiSpacer size="s" />
+                      <EuiText
+                        style={{ paddingLeft: '8px' }}
+                        size="s"
+                        color="subdued"
+                      >
+                        To use any model outputs in the query template, copy the
+                        placeholder string directly.
+                      </EuiText>
+                      <EuiSpacer size="s" />
+                      <EuiBasicTable
+                        // @ts-ignore
+                        items={finalModelOutputs}
+                        columns={columns}
+                      />
+                    </>
+                  </EuiAccordion>
+                  <EuiSpacer size="m" />
+                </>
+              )}
+            </>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
+          Close
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}
+
+const columns = [
+  {
+    name: 'Name',
+    field: 'label',
+    width: '40%',
+  },
+  {
+    name: 'Placeholder string',
+    field: 'label',
+    width: '50%',
+    render: (label: string) => (
+      <EuiCode
+        style={{
+          marginLeft: '-10px',
+        }}
+        language="json"
+        transparentBackground={true}
+      >
+        {getPlaceholderString(label)}
+      </EuiCode>
+    ),
+  },
+  {
+    name: 'Actions',
+    field: 'label',
+    width: '10%',
+    render: (label: string) => (
+      <EuiCopy textToCopy={getPlaceholderString(label)}>
+        {(copy) => (
+          <EuiButtonIcon
+            aria-label="Copy"
+            iconType="copy"
+            onClick={copy}
+          ></EuiButtonIcon>
+        )}
+      </EuiCopy>
+    ),
+  },
+];
+
+// small util fn to get the full placeholder string to be
+// inserted into the template
+function getPlaceholderString(label: string) {
+  return `\$\{${label}\}`;
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/override_query_modal.tsx
@@ -119,47 +119,45 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
                       items: QUERY_PRESETS.map((preset: QueryPreset) => ({
                         name: preset.name,
                         onClick: () => {
-                          try {
-                            setFieldValue(
-                              queryFieldPath,
-                              preset.query
-                                // sanitize the query preset string into valid template placeholder format, for
-                                // any placeholder values in the query.
-                                // for example, replacing `"{{vector}}"` with `${vector}`
-                                .replace(
-                                  new RegExp(`"${VECTOR_FIELD_PATTERN}"`, 'g'),
-                                  `\$\{vector_field\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
-                                  `\$\{vector\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${TEXT_FIELD_PATTERN}"`, 'g'),
-                                  `\$\{text_field\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${IMAGE_FIELD_PATTERN}"`, 'g'),
-                                  `\$\{image_field\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${LABEL_FIELD_PATTERN}"`, 'g'),
-                                  `\$\{label_field\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${QUERY_TEXT_PATTERN}"`, 'g'),
-                                  `\$\{query_text\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${QUERY_IMAGE_PATTERN}"`, 'g'),
-                                  `\$\{query_image\}`
-                                )
-                                .replace(
-                                  new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'),
-                                  `\$\{model_id\}`
-                                )
-                            );
-                          } catch {}
+                          setFieldValue(
+                            queryFieldPath,
+                            preset.query
+                              // sanitize the query preset string into valid template placeholder format, for
+                              // any placeholder values in the query.
+                              // for example, replacing `"{{vector}}"` with `${vector}`
+                              .replace(
+                                new RegExp(`"${VECTOR_FIELD_PATTERN}"`, 'g'),
+                                `\$\{vector_field\}`
+                              )
+                              .replace(
+                                new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
+                                `\$\{vector\}`
+                              )
+                              .replace(
+                                new RegExp(`"${TEXT_FIELD_PATTERN}"`, 'g'),
+                                `\$\{text_field\}`
+                              )
+                              .replace(
+                                new RegExp(`"${IMAGE_FIELD_PATTERN}"`, 'g'),
+                                `\$\{image_field\}`
+                              )
+                              .replace(
+                                new RegExp(`"${LABEL_FIELD_PATTERN}"`, 'g'),
+                                `\$\{label_field\}`
+                              )
+                              .replace(
+                                new RegExp(`"${QUERY_TEXT_PATTERN}"`, 'g'),
+                                `\$\{query_text\}`
+                              )
+                              .replace(
+                                new RegExp(`"${QUERY_IMAGE_PATTERN}"`, 'g'),
+                                `\$\{query_image\}`
+                              )
+                              .replace(
+                                new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'),
+                                `\$\{model_id\}`
+                              )
+                          );
                           setFieldTouched(queryFieldPath, true);
                           setPresetsPopoverOpen(false);
                         },
@@ -208,7 +206,12 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
         </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
+        <EuiSmallButton
+          onClick={props.onClose}
+          fill={false}
+          color="primary"
+          data-testid="closeModalButton"
+        >
           Close
         </EuiSmallButton>
       </EuiModalFooter>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -292,7 +292,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     ingestTemplatesDifferent || isRunningIngest;
   const searchBackButtonDisabled =
     isRunningSearch ||
-    (isProposingNoSearchResources ? false : searchTemplatesDifferent);
+    (isProposingNoSearchResources || !ingestProvisioned
+      ? false
+      : searchTemplatesDifferent);
   const searchUndoButtonDisabled =
     isRunningSave || isRunningSearch
       ? true


### PR DESCRIPTION
### Description

This PR improves the UX for query configuration/overriding the query via a `query_template` field exposed in the ML search request processors. This is a common pattern for vector search use cases, to generate a valid knn query, injecting the returned vector embedding directly into the new query. Before, this was nested under 'Advanced settings', under 'Query template'. Now, we add a dedicated modal similar to prompt-building for this particular scenario.

More details
- adds a 'Override query' option for ML search req processors only
- supports preset selection, the same as the base query configuration (one difference, is once a preset is selected, we sanitize to be in a proper templated format, since the value here is a _template_ rather than a _string_)
- similar to the prompt modal, we expose some model configuration. In this case, the model outputs. Note we dynamically generate the list based on the presence of a configured output map or not. If there is an output map, then pull the keys (the transformed/new outputs) as available options to inject in the template. If there is no output map, then pull the model outputs from the interface directly, as this implies no further transformation is needed
- minor: adds some helper text in the configure prompt modal
- bug fix of back button disabled when skipping ingest altogether

Demo video, showing the new modal, and the various options shown under "Model outputs" based on any output map configuration.

[screen-capture (7).webm](https://github.com/user-attachments/assets/7d9c787a-9bda-4f24-bd65-30a91b145001)


### Issues Resolved
Resolves #404 
Resolves #407

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
