### PR TITLE
Bumped minimum compatibility to 2.18.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -5,18 +5,12 @@
   "server": true,
   "ui": true,
   "requiredBundles": [],
-  "requiredPlugins": [
-    "navigation",
-    "opensearchDashboardsUtils"
-  ],
+  "requiredPlugins": ["navigation", "opensearchDashboardsUtils"],
   "optionalPlugins": [
     "dataSource",
     "dataSourceManagement",
     "contentManagement"
   ],
-  "supportedOSDataSourceVersions": ">=2.17.0 <4.0.0",
-  "requiredOSDataSourcePlugins": [
-    "opensearch-ml",
-    "opensearch-flow-framework"
-  ]
+  "supportedOSDataSourceVersions": ">=2.18.0 <4.0.0",
+  "requiredOSDataSourcePlugins": ["opensearch-ml", "opensearch-flow-framework"]
 }

--- a/server/resources/templates/custom.json
+++ b/server/resources/templates/custom.json
@@ -1,12 +1,9 @@
 {
-    "name": "Custom",
-    "description": "A blank workflow with no preset configurations",
-    "use_case": "CUSTOM",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    }
+  "name": "Custom",
+  "description": "A blank workflow with no preset configurations",
+  "use_case": "CUSTOM",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  }
 }

--- a/server/resources/templates/hybrid_search.json
+++ b/server/resources/templates/hybrid_search.json
@@ -1,14 +1,11 @@
 {
-    "name": "Hybrid Search",
-    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing hybrid search",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    },
-    "ui_metadata": {
-        "type": "Hybrid search"
-    }
+  "name": "Hybrid Search",
+  "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing hybrid search",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "ui_metadata": {
+    "type": "Hybrid search"
+  }
 }

--- a/server/resources/templates/multimodal_search.json
+++ b/server/resources/templates/multimodal_search.json
@@ -1,14 +1,11 @@
 {
-    "name": "Multimodal Search",
-    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing multimodal search",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    },
-    "ui_metadata": {
-        "type": "Multimodal search"
-    }
+  "name": "Multimodal Search",
+  "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing multimodal search",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "ui_metadata": {
+    "type": "Multimodal search"
+  }
 }

--- a/server/resources/templates/rag.json
+++ b/server/resources/templates/rag.json
@@ -1,14 +1,11 @@
 {
-    "name": "Retrieval-Augmented Generation (RAG)",
-    "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation (RAG)",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    },
-    "ui_metadata": {
-        "type": "Retrieval-augmented generation"
-    }
+  "name": "Retrieval-Augmented Generation (RAG)",
+  "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation (RAG)",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "ui_metadata": {
+    "type": "Retrieval-augmented generation"
+  }
 }

--- a/server/resources/templates/semantic_search.json
+++ b/server/resources/templates/semantic_search.json
@@ -1,14 +1,11 @@
 {
-    "name": "Semantic Search",
-    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing semantic search",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    },
-    "ui_metadata": {
-        "type": "Semantic search"
-    }
+  "name": "Semantic Search",
+  "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing semantic search",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "ui_metadata": {
+    "type": "Semantic search"
+  }
 }

--- a/server/resources/templates/sentiment_analysis.json
+++ b/server/resources/templates/sentiment_analysis.json
@@ -1,14 +1,11 @@
 {
-    "name": "Sentiment Analysis",
-    "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing sentiment analysis",
-    "version": {
-        "template": "1.0.0",
-        "compatibility": [
-            "2.17.0",
-            "3.0.0"
-        ]
-    },
-    "ui_metadata": {
-        "type": "Sentiment analysis"
-    }
+  "name": "Sentiment Analysis",
+  "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing sentiment analysis",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "ui_metadata": {
+    "type": "Sentiment analysis"
+  }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,7 +49,7 @@ function generateWorkflow({ id, name, type }: WorkflowInput): Workflow {
   return {
     id,
     name,
-    version: { template: '1.0.0', compatibility: ['2.17.0', '3.0.0'] },
+    version: { template: '1.0.0', compatibility: ['2.18.0', '3.0.0'] },
     ui_metadata: getConfig(type),
   };
 }


### PR DESCRIPTION
### Description

Bumping the version compatibility matrix to have a minimum of 2.18, since our plugin is expected to launch in 2.18, 

### Issues Resolved

closes https://github.com/opensearch-project/dashboards-flow-framework/issues/409

### Check List

- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
