### PR TITLE
Fix URL update for 'Create workflow' button (list page)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,4 +25,6 @@ jobs:
         uses: VachaShah/backport@v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>
+          labels_template: "<%= JSON.stringify([...labels, 'autocut']) %>"
+          failure_labels: "failed backport"

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -283,6 +283,11 @@ export function Workflows(props: WorkflowsProps) {
                         fill={true}
                         onClick={() => {
                           setSelectedTabId(WORKFLOWS_TAB.CREATE);
+                          replaceActiveTab(
+                            WORKFLOWS_TAB.CREATE,
+                            props,
+                            dataSourceId
+                          );
                         }}
                         data-testid="createWorkflowButton"
                       >


### PR DESCRIPTION
### Description

The active tab update does not occur when clicking the "create workflow" button from the list page. This fixes that.

Also fixes the backport args reqd with the new version of the backport action in the workflow.

### Issues Resolved

Resolves #414 
Resolves #415 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
