### PR TITLE
Fix placeholder strings in prompt template modal

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,17 @@ jobs:
       contents: write
       pull-requests: write
     name: Backport
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
       - name: GitHub App token
         id: github_app_token

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/configure_prompt_modal.tsx
@@ -297,5 +297,5 @@ const columns = [
 function getPlaceholderString(type: string, label: string) {
   return type === 'array'
     ? `\$\{parameters.${label}.toString()\}`
-    : `\$\\{parameters.${label}\\}`;
+    : `\$\{parameters.${label}\}`;
 }


### PR DESCRIPTION
### Description

Fix placeholder strings in prompt template modal. Before, the copied strings had an unnecessary `/` character which was inconsistent with the defined placeholder syntax.

Also fixes the backport action to be consistent with OSD's: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/.github/workflows/backport.yml

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
