### PR TITLE
Misc bug fixes and minor UX improvements

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -15,6 +15,7 @@ interface IngestInputsProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   workflow: Workflow | undefined;
+  lastIngested: number | undefined;
 }
 
 /**
@@ -28,6 +29,7 @@ export function IngestInputs(props: IngestInputsProps) {
           workflow={props.workflow}
           uiConfig={props.uiConfig}
           setIngestDocs={props.setIngestDocs}
+          lastIngested={props.lastIngested}
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -184,7 +184,7 @@ export function SourceData(props: SourceDataProps) {
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <p>{`Edit source data`}</p>
+              <p>{`Import data`}</p>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
@@ -258,7 +258,7 @@ export function SourceData(props: SourceDataProps) {
                 </>
               )}
               <JsonField
-                label="Documents"
+                label="Documents to be imported"
                 fieldPath={'ingest.docs'}
                 helpText="Documents should be formatted as a valid JSON array."
                 editorHeight="25vh"
@@ -280,7 +280,7 @@ export function SourceData(props: SourceDataProps) {
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">
-            <h2>Source data</h2>
+            <h2>Import data</h2>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -294,7 +294,7 @@ export function SourceData(props: SourceDataProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <JsonField
-            label="Documents"
+            label="Documents to be imported"
             fieldPath={'ingest.docs'}
             helpText="Documents should be formatted as a valid JSON array."
             editorHeight="25vh"

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -77,7 +77,7 @@ interface InputTransformModalProps {
   onClose: () => void;
 }
 
-// the max number of input docs we use to display & test transforms with
+// the max number of input docs we use to display & test transforms with (search response hits)
 const MAX_INPUT_DOCS = 10;
 
 /**
@@ -143,7 +143,9 @@ export function InputTransformModal(props: InputTransformModalProps) {
   const description =
     props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
       ? 'Fetch an input query and see how it is transformed.'
-      : `Fetch some sample documents (up to ${MAX_INPUT_DOCS}) and see how they are transformed.`;
+      : props.context === PROCESSOR_CONTEXT.INGEST
+      ? 'Fetch a sample document and see how it is transformed'
+      : `Fetch some returned documents (up to ${MAX_INPUT_DOCS}) and see how they are transformed.`;
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -20,7 +20,6 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiPanel,
-  EuiSpacer,
   EuiStepsHorizontal,
   EuiText,
   EuiTitle,
@@ -711,98 +710,92 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 </EuiModalFooter>
               </EuiModal>
             )}
-            {onIngestAndUnprovisioned && (
-              <>
-                <EuiSpacer size="m" />
-                <BooleanField
-                  fieldPath="ingest.enabled"
-                  enabledOption={{
-                    id: INGEST_OPTION.CREATE,
-                    label: (
-                      <EuiFlexGroup direction="column" gutterSize="none">
-                        <EuiText color="default">
-                          Create an ingest pipeline
-                        </EuiText>
-                        <EuiText size="xs" color="subdued">
-                          Configure and ingest data into an index.
-                        </EuiText>
-                      </EuiFlexGroup>
-                    ),
-                  }}
-                  disabledOption={{
-                    id: INGEST_OPTION.SKIP,
-                    label: (
-                      <EuiFlexGroup direction="column" gutterSize="none">
-                        <EuiText color="default">
-                          Skip ingestion pipeline
-                        </EuiText>
-                        <EuiText size="xs" color="subdued">
-                          Use an existing index with data ingested.
-                        </EuiText>
-                      </EuiFlexGroup>
-                    ),
-                  }}
-                  showLabel={false}
-                />
-              </>
-            )}
           </EuiFlexItem>
-          {!onIngestAndDisabled && (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiTitle>
-                  <h2>
-                    {onIngestAndUnprovisioned ? (
-                      'Define ingest pipeline'
-                    ) : onIngestAndProvisioned ? (
-                      <EuiFlexGroup
-                        direction="row"
-                        justifyContent="spaceBetween"
+          <EuiFlexItem grow={false} style={{ marginBottom: '-8px' }}>
+            <EuiTitle>
+              <h2>
+                {onIngestAndUnprovisioned ? (
+                  'Define ingest pipeline'
+                ) : onIngestAndProvisioned ? (
+                  <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+                    <EuiFlexItem grow={false}>Edit ingest pipeline</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiSmallButtonEmpty
+                        color="danger"
+                        onClick={() => setIsModalOpen(true)}
                       >
-                        <EuiFlexItem grow={false}>
-                          Edit ingest pipeline
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiSmallButtonEmpty
-                            color="danger"
-                            onClick={() => setIsModalOpen(true)}
-                          >
-                            <EuiIcon type="trash" />
-                            {`    `}Delete resources
-                          </EuiSmallButtonEmpty>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    ) : (
-                      'Define search pipeline'
-                    )}
-                  </h2>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={true}
-                style={{
-                  overflowY: 'scroll',
-                  overflowX: 'hidden',
-                }}
-              >
-                {onIngest ? (
+                        <EuiIcon type="trash" />
+                        {`    `}Delete resources
+                      </EuiSmallButtonEmpty>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ) : (
+                  'Define search pipeline'
+                )}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={true}
+            style={{
+              overflowY: 'scroll',
+              overflowX: 'hidden',
+            }}
+          >
+            {onIngest ? (
+              <>
+                {onIngestAndUnprovisioned && (
+                  <>
+                    <BooleanField
+                      fieldPath="ingest.enabled"
+                      enabledOption={{
+                        id: INGEST_OPTION.CREATE,
+                        label: (
+                          <EuiFlexGroup direction="column" gutterSize="none">
+                            <EuiText color="default">
+                              Create an ingest pipeline
+                            </EuiText>
+                            <EuiText size="xs" color="subdued">
+                              Configure and ingest data into an index.
+                            </EuiText>
+                          </EuiFlexGroup>
+                        ),
+                      }}
+                      disabledOption={{
+                        id: INGEST_OPTION.SKIP,
+                        label: (
+                          <EuiFlexGroup direction="column" gutterSize="none">
+                            <EuiText color="default">
+                              Skip ingestion pipeline
+                            </EuiText>
+                            <EuiText size="xs" color="subdued">
+                              Use an existing index with data ingested.
+                            </EuiText>
+                          </EuiFlexGroup>
+                        ),
+                      }}
+                      showLabel={false}
+                    />
+                  </>
+                )}
+                {!onIngestAndDisabled && (
                   <IngestInputs
                     setIngestDocs={props.setIngestDocs}
                     uiConfig={props.uiConfig}
                     setUiConfig={props.setUiConfig}
                     workflow={props.workflow}
                   />
-                ) : (
-                  <SearchInputs
-                    uiConfig={props.uiConfig}
-                    setUiConfig={props.setUiConfig}
-                    setQuery={props.setQuery}
-                    setQueryResponse={props.setQueryResponse}
-                  />
                 )}
-              </EuiFlexItem>
-            </>
-          )}
+              </>
+            ) : (
+              <SearchInputs
+                uiConfig={props.uiConfig}
+                setUiConfig={props.setUiConfig}
+                setQuery={props.setQuery}
+                setQueryResponse={props.setQueryResponse}
+              />
+            )}
+          </EuiFlexItem>
           <EuiFlexItem grow={false} style={{ marginBottom: '-10px' }}>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -631,7 +631,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             height: '100%',
           }}
         >
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem grow={false} style={{ marginBottom: '-8px' }}>
             <EuiStepsHorizontal
               steps={[
                 {
@@ -798,7 +798,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               />
             )}
           </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ marginBottom: '-10px' }}>
+          <EuiFlexItem
+            grow={false}
+            style={{ marginBottom: '-10px', marginTop: '-24px' }}
+          >
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
                 <EuiHorizontalRule margin="m" />

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -711,30 +711,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               </EuiModal>
             )}
           </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ marginBottom: '-8px' }}>
-            <EuiTitle>
-              <h2>
-                {onIngestAndUnprovisioned ? (
-                  'Define ingest pipeline'
-                ) : onIngestAndProvisioned ? (
-                  <EuiFlexGroup direction="row" justifyContent="spaceBetween">
-                    <EuiFlexItem grow={false}>Edit ingest pipeline</EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiSmallButtonEmpty
-                        color="danger"
-                        onClick={() => setIsModalOpen(true)}
-                      >
-                        <EuiIcon type="trash" />
-                        {`    `}Delete resources
-                      </EuiSmallButtonEmpty>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                ) : (
-                  'Define search pipeline'
-                )}
-              </h2>
-            </EuiTitle>
-          </EuiFlexItem>
           <EuiFlexItem
             grow={true}
             style={{
@@ -742,6 +718,32 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               overflowX: 'hidden',
             }}
           >
+            <EuiFlexItem grow={false}>
+              <EuiTitle>
+                <h2>
+                  {onIngestAndUnprovisioned ? (
+                    'Define ingest pipeline'
+                  ) : onIngestAndProvisioned ? (
+                    <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+                      <EuiFlexItem grow={false}>
+                        Edit ingest pipeline
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiSmallButtonEmpty
+                          color="danger"
+                          onClick={() => setIsModalOpen(true)}
+                        >
+                          <EuiIcon type="trash" />
+                          {`    `}Delete resources
+                        </EuiSmallButtonEmpty>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  ) : (
+                    'Define search pipeline'
+                  )}
+                </h2>
+              </EuiTitle>
+            </EuiFlexItem>
             {onIngest ? (
               <>
                 {onIngestAndUnprovisioned && (

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -121,6 +121,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   // confirm modal state
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
+  // last ingested state
+  const [lastIngested, setLastIngested] = useState<number | undefined>(
+    undefined
+  );
+
   // maintain global states
   const onIngest = selectedStep === STEP.INGEST;
   const onSearch = selectedStep === STEP.SEARCH;
@@ -548,6 +553,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             .unwrap()
             .then(async (resp) => {
               props.setIngestResponse(customStringify(resp));
+              setLastIngested(Date.now());
             })
             .catch((error: any) => {
               props.setIngestResponse('');
@@ -786,6 +792,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     uiConfig={props.uiConfig}
                     setUiConfig={props.setUiConfig}
                     workflow={props.workflow}
+                    lastIngested={lastIngested}
                   />
                 )}
               </>

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -85,11 +85,7 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        <EuiFlexGroup
-          direction="column"
-          justifyContent="center"
-          alignItems="center"
-        >
+        <EuiFlexGroup direction="column">
           {fileContents !== undefined && !isValidWorkflow(fileObj) && (
             <>
               <EuiFlexItem>
@@ -116,11 +112,15 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
           )}
           <EuiFlexItem grow={false}>
             <EuiCompressedFilePicker
+              fullWidth={true}
+              compressed={false}
               multiple={false}
               initialPromptText="Select or drag and drop a file"
               onChange={(files) => {
                 if (files && files.length > 0) {
                   fileReader.readAsText(files[0]);
+                } else {
+                  setFileContents(undefined);
                 }
               }}
               display="large"


### PR DESCRIPTION
### Description

General PR with a variety of bug fixes and minor UX improvements.

- [x] tunes wording on input transform (ingest)
- [x] fixes bug of error modal persisting even when removing the JSON file on import
- [x] stretches filepicker to span across modal body on import
- [x] rearrange create/skip ingest pipeline radio group
- [x] make entire form scrollable
- [x] increase scrollable form margins
- [x] tune wording related to the source/input data
- [x] only show the docs if there is valid/populated values. Show last ingested timestamp after successful ingestion on-the-fly. _Note we don't persist this such that a page refresh will show this still, as we have no way to track when the last ingestion occurred. The workflow timestamps only persist last updated, but users can later only edit the search-related components, which would update this timestamp, but not be related to the last time of ingestion._

Demo video highlighting changes:

[screen-capture (9).webm](https://github.com/user-attachments/assets/e12a0c97-51e8-4dad-b1c4-ff433d1cc14e)

### Issues Resolved
--

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
