### PR TITLE
Misc bug fixes and minor UX improvements II

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -456,7 +456,6 @@ export enum PROCESSOR_CONTEXT {
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
-export const DEFAULT_NEW_WORKFLOW_STATE = WORKFLOW_STATE.NOT_STARTED;
 export const DEFAULT_NEW_WORKFLOW_STATE_TYPE = ('NOT_STARTED' as any) as typeof WORKFLOW_STATE;
 export const DATE_FORMAT_PATTERN = 'MM/DD/YY hh:mm A';
 export const EMPTY_FIELD_STRING = '--';

--- a/public/general_components/processors_title.tsx
+++ b/public/general_components/processors_title.tsx
@@ -16,9 +16,12 @@ interface ProcessorsTitleProps {
  */
 export function ProcessorsTitle(props: ProcessorsTitleProps) {
   return (
-    <EuiFlexItem grow={false}>
+    <EuiFlexItem
+      grow={false}
+      style={{ marginTop: '-24px', marginBottom: '-8px' }}
+    >
       <EuiText size="s">
-        <div>
+        <>
           <h3
             style={{ display: 'inline-block' }}
           >{`${props.title} (${props.processorCount}) -`}</h3>
@@ -26,7 +29,7 @@ export function ProcessorsTitle(props: ProcessorsTitleProps) {
           <h3 style={{ display: 'inline-block', fontStyle: 'italic' }}>
             optional
           </h3>
-        </div>
+        </>
       </EuiText>
     </EuiFlexItem>
   );

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -14,10 +14,8 @@ import {
   EuiSmallButton,
 } from '@elastic/eui';
 import {
-  DEFAULT_NEW_WORKFLOW_STATE,
   PLUGIN_ID,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
-  WORKFLOW_STATE,
   Workflow,
   getCharacterLimitedString,
   toFormattedDate,
@@ -58,7 +56,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   const history = useHistory();
   // workflow state
   const [workflowName, setWorkflowName] = useState<string>('');
-  const [workflowState, setWorkflowState] = useState<WORKFLOW_STATE>('');
   const [workflowLastUpdated, setWorkflowLastUpdated] = useState<string>('');
 
   // export modal state
@@ -80,7 +77,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
           MAX_WORKFLOW_NAME_TO_DISPLAY
         )
       );
-      setWorkflowState(props.workflow.state || DEFAULT_NEW_WORKFLOW_STATE);
       try {
         const formattedDate = toFormattedDate(
           // @ts-ignore
@@ -206,9 +202,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
             pageTitle={
               <EuiFlexGroup direction="row" alignItems="flexEnd" gutterSize="m">
                 <EuiFlexItem grow={false}>{workflowName}</EuiFlexItem>
-                <EuiFlexItem grow={false} style={{ marginBottom: '10px' }}>
-                  <EuiText size="m">{workflowState}</EuiText>
-                </EuiFlexItem>
               </EuiFlexGroup>
             }
             rightSideItems={[

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -41,6 +41,7 @@ interface ResizableWorkspaceProps {
 }
 
 const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
+const PREVIEW_PANEL_ID = 'preview_panel_id';
 const TOOLS_PANEL_ID = 'tools_panel_id';
 
 /**
@@ -69,18 +70,16 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     undefined
   );
 
-  // Workflow inputs side panel state
-  const [isWorkflowInputsPanelOpen, setIsWorkflowInputsPanelOpen] = useState<
-    boolean
-  >(true);
+  // Preview side panel state. This panel encapsulates the tools panel as a child resizable panel.
+  const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(true);
   const collapseFnHorizontal = useRef(
     (id: string, options: { direction: 'left' | 'right' }) => {}
   );
-  const onToggleWorkflowInputsChange = () => {
-    collapseFnHorizontal.current(WORKFLOW_INPUTS_PANEL_ID, {
-      direction: 'left',
+  const onTogglePreviewChange = () => {
+    collapseFnHorizontal.current(PREVIEW_PANEL_ID, {
+      direction: 'right',
     });
-    setIsWorkflowInputsPanelOpen(!isWorkflowInputsPanelOpen);
+    setIsPreviewPanelOpen(!isPreviewPanelOpen);
   };
 
   // ingest state
@@ -143,7 +142,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             direction="horizontal"
             className="stretch-absolute"
             style={{
-              marginLeft: isWorkflowInputsPanelOpen ? '-8px' : '0px',
+              marginLeft: '-8px',
               marginTop: '-8px',
             }}
           >
@@ -159,13 +158,10 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                 <>
                   <EuiResizablePanel
                     id={WORKFLOW_INPUTS_PANEL_ID}
-                    mode="collapsible"
-                    initialSize={50}
+                    mode="main"
+                    initialSize={60}
                     minSize="25%"
                     paddingSize="s"
-                    onToggleCollapsedInternal={() =>
-                      onToggleWorkflowInputsChange()
-                    }
                   >
                     <WorkflowInputs
                       workflow={props.workflow}
@@ -181,14 +177,16 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                   </EuiResizablePanel>
                   <EuiResizableButton />
                   <EuiResizablePanel
+                    id={PREVIEW_PANEL_ID}
                     style={{
-                      marginRight: '-32px',
+                      marginRight: isPreviewPanelOpen ? '-32px' : '0px',
                       marginBottom: isToolsPanelOpen ? '0px' : '24px',
                     }}
-                    mode="main"
+                    mode="collapsible"
                     initialSize={60}
                     minSize="25%"
                     paddingSize="s"
+                    onToggleCollapsedInternal={() => onTogglePreviewChange()}
                   >
                     <EuiResizableContainer
                       className="workspace-panel"

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -57,6 +57,9 @@ const inputTabs = [
   },
 ];
 
+// TODO: this may change in the future
+const PANEL_TITLE = 'Inspector';
+
 /**
  * The base Tools component for performing ingest and search, viewing resources, and debugging.
  */
@@ -116,9 +119,9 @@ export function Tools(props: ToolsProps) {
           height: '100%',
         }}
       >
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>
           <EuiText size="s">
-            <h2>Tools</h2>
+            <h2>{PANEL_TITLE}</h2>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -83,9 +83,8 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       );
       expect(getAllByText('Skip ingestion pipeline').length).toBeGreaterThan(0);
       expect(getAllByText('Define ingest pipeline').length).toBeGreaterThan(0);
-      expect(getAllByText('Tools').length).toBeGreaterThan(0);
+      expect(getAllByText('Inspector').length).toBeGreaterThan(0);
       expect(getAllByText('Preview').length).toBeGreaterThan(0);
-      expect(getAllByText('Not started').length).toBeGreaterThan(0);
       expect(
         getAllByText((content) => content.startsWith('Last updated:')).length
       ).toBeGreaterThan(0);
@@ -240,14 +239,14 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
     );
     userEvent.click(addRequestProcessorButton);
     await waitFor(() => {
-      expect(getAllByText('Processors').length).toBeGreaterThan(0);
+      expect(getAllByText('PROCESSORS').length).toBeGreaterThan(0);
     });
 
     // Add response processor
     const addResponseProcessorButton = getAllByTestId('addProcessorButton')[1];
     userEvent.click(addResponseProcessorButton);
     await waitFor(() => {
-      expect(getAllByText('Processors').length).toBeGreaterThan(0);
+      expect(getAllByText('PROCESSORS').length).toBeGreaterThan(0);
     });
 
     // Save, Build and Run query, Back buttons

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -23,6 +23,7 @@ import {
   EuiSuperSelectOption,
   EuiCompressedSuperSelect,
   EuiCodeBlock,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -294,9 +295,25 @@ export function SourceData(props: SourceDataProps) {
       )}
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiText size="s">
-            <h3>Source data</h3>
-          </EuiText>
+          <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <h3>Import data</h3>
+              </EuiText>
+            </EuiFlexItem>
+            {docsPopulated && (
+              <EuiFlexItem grow={false}>
+                <EuiSmallButtonEmpty
+                  onClick={() => setIsEditModalOpen(true)}
+                  data-testid="editSourceDataButton"
+                  iconType="pencil"
+                  iconSide="left"
+                >
+                  Edit
+                </EuiSmallButtonEmpty>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
         </EuiFlexItem>
         {props.lastIngested !== undefined && (
           <EuiFlexItem grow={false}>
@@ -306,16 +323,19 @@ export function SourceData(props: SourceDataProps) {
           </EuiFlexItem>
         )}
 
-        <EuiFlexItem grow={false}>
-          <EuiSmallButton
-            fill={false}
-            style={{ width: '100px' }}
-            onClick={() => setIsEditModalOpen(true)}
-            data-testid="editSourceDataButton"
-          >
-            {docsPopulated ? `Edit` : `Select data`}
-          </EuiSmallButton>
-        </EuiFlexItem>
+        {!docsPopulated && (
+          <EuiFlexItem grow={false}>
+            <EuiSmallButton
+              fill={false}
+              style={{ width: '100px' }}
+              onClick={() => setIsEditModalOpen(true)}
+              data-testid="selectDataToImportButton"
+            >
+              {`Select data`}
+            </EuiSmallButton>
+          </EuiFlexItem>
+        )}
+
         {docsPopulated && (
           <>
             <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -22,6 +22,7 @@ import {
   EuiSmallFilterButton,
   EuiSuperSelectOption,
   EuiCompressedSuperSelect,
+  EuiCodeBlock,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -316,15 +317,21 @@ export function SourceData(props: SourceDataProps) {
           </EuiSmallButton>
         </EuiFlexItem>
         {docsPopulated && (
-          <EuiFlexItem grow={false}>
-            <JsonField
-              label="Documents to be imported"
-              fieldPath={'ingest.docs'}
-              helpText="Documents should be formatted as a valid JSON array."
-              editorHeight="25vh"
-              readOnly={true}
-            />
-          </EuiFlexItem>
+          <>
+            <EuiSpacer size="s" />
+            <EuiFlexItem grow={true}>
+              <EuiCodeBlock
+                fontSize="s"
+                language="json"
+                overflowHeight={300}
+                isCopyable={false}
+                whiteSpace="pre"
+                paddingSize="none"
+              >
+                {getIn(values, 'ingest.docs')}
+              </EuiCodeBlock>
+            </EuiFlexItem>
+          </>
         )}
       </EuiFlexGroup>
     </>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -10,12 +10,10 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiLink,
   EuiPanel,
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiSpacer,
-  EuiText,
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import {
@@ -30,15 +28,17 @@ import { MapField } from './map_field';
 interface MapArrayFieldProps {
   field: IConfigField;
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
-  label?: string;
-  helpLink?: string;
   helpText?: string;
+  keyTitle?: string;
   keyPlaceholder?: string;
+  valueTitle?: string;
   valuePlaceholder?: string;
   onMapAdd?: (curArray: MapArrayFormValue) => void;
   onMapDelete?: (idxToDelete: number) => void;
   keyOptions?: { label: string }[];
   valueOptions?: { label: string }[];
+  addMapEntryButtonText?: string;
+  addMapButtonText?: string;
 }
 
 /**
@@ -90,17 +90,6 @@ export function MapArrayField(props: MapArrayFieldProps) {
           <EuiCompressedFormRow
             fullWidth={true}
             key={props.fieldPath}
-            label={props.label}
-            labelAppend={
-              props.helpLink ? (
-                <EuiText size="xs">
-                  <EuiLink href={props.helpLink} target="_blank">
-                    Learn more
-                  </EuiLink>
-                </EuiText>
-              ) : undefined
-            }
-            helpText={props.helpText || undefined}
             isInvalid={
               getIn(errors, field.name) !== undefined &&
               getIn(errors, field.name).length > 0 &&
@@ -135,10 +124,14 @@ export function MapArrayField(props: MapArrayFieldProps) {
                           <EuiPanel grow={true}>
                             <MapField
                               fieldPath={`${props.fieldPath}.${idx}`}
+                              helpText={props.helpText}
+                              keyTitle={props.keyTitle}
                               keyPlaceholder={props.keyPlaceholder}
+                              valueTitle={props.valueTitle}
                               valuePlaceholder={props.valuePlaceholder}
                               keyOptions={props.keyOptions}
                               valueOptions={props.valueOptions}
+                              addEntryButtonText={props.addMapEntryButtonText}
                             />
                           </EuiPanel>
                         </EuiAccordion>
@@ -151,10 +144,14 @@ export function MapArrayField(props: MapArrayFieldProps) {
                   <EuiPanel grow={true}>
                     <MapField
                       fieldPath={`${props.fieldPath}.0`}
+                      helpText={props.helpText}
+                      keyTitle={props.keyTitle}
                       keyPlaceholder={props.keyPlaceholder}
+                      valueTitle={props.valueTitle}
                       valuePlaceholder={props.valuePlaceholder}
                       keyOptions={props.keyOptions}
                       valueOptions={props.valueOptions}
+                      addEntryButtonText={props.addMapEntryButtonText}
                     />
                   </EuiPanel>
                   <EuiSpacer size="s" />
@@ -182,7 +179,9 @@ export function MapArrayField(props: MapArrayFieldProps) {
                         onClick={() => {
                           addMap(field.value);
                         }}
-                      >{`(Advanced) Add another prediction`}</EuiSmallButtonEmpty>
+                      >
+                        {props.addMapButtonText || `(Advanced) Add another map`}
+                      </EuiSmallButtonEmpty>
                     )}
                   </>
                 </div>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -13,6 +13,7 @@ import {
   EuiLink,
   EuiText,
   EuiSmallButton,
+  EuiIconTip,
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
@@ -29,11 +30,19 @@ interface MapFieldProps {
   label?: string;
   helpLink?: string;
   helpText?: string;
+  keyTitle?: string;
   keyPlaceholder?: string;
+  valueTitle?: string;
   valuePlaceholder?: string;
   keyOptions?: { label: string }[];
   valueOptions?: { label: string }[];
+  addEntryButtonText?: string;
 }
+
+// The keys will be more static in general. Give more space for values where users
+// will typically be writing out more complex transforms/configuration (in the case of ML inference processors).
+const KEY_FLEX_RATIO = 4;
+const VALUE_FLEX_RATIO = 6;
 
 /**
  * Input component for configuring field mappings. Input forms are defaulted to text fields. If
@@ -80,7 +89,6 @@ export function MapField(props: MapFieldProps) {
                 </EuiText>
               ) : undefined
             }
-            helpText={props.helpText || undefined}
             error={
               getIn(errors, field.name) !== undefined &&
               getIn(errors, field.name).length > 0
@@ -95,69 +103,108 @@ export function MapField(props: MapFieldProps) {
             }
           >
             <EuiFlexGroup direction="column">
+              <EuiFlexItem style={{ marginBottom: '0px' }}>
+                <EuiFlexGroup direction="row" gutterSize="xs">
+                  <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                    <EuiText size="s" color="subdued">
+                      {props.keyTitle || 'Key'}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                    <EuiFlexGroup direction="row" gutterSize="xs">
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="s" color="subdued">
+                          {props.valueTitle || 'Value'}
+                        </EuiText>
+                      </EuiFlexItem>
+                      {props.helpText && (
+                        <EuiFlexItem grow={false}>
+                          <EuiIconTip
+                            content={props.helpText}
+                            position="right"
+                          />
+                        </EuiFlexItem>
+                      )}
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+
               {field.value?.map((mapping: MapEntry, idx: number) => {
                 return (
                   <EuiFlexItem key={idx}>
-                    <EuiFlexGroup direction="row">
-                      <EuiFlexItem grow={true}>
+                    <EuiFlexGroup direction="row" gutterSize="xs">
+                      <EuiFlexItem grow={KEY_FLEX_RATIO}>
                         <EuiFlexGroup direction="row" gutterSize="xs">
-                          <EuiFlexItem>
-                            <>
-                              {!isEmpty(props.keyOptions) ? (
-                                <SelectWithCustomOptions
-                                  fieldPath={`${props.fieldPath}.${idx}.key`}
-                                  options={props.keyOptions as any[]}
-                                  placeholder={props.keyPlaceholder || 'Input'}
-                                />
-                              ) : (
-                                <TextField
-                                  fullWidth={true}
-                                  fieldPath={`${props.fieldPath}.${idx}.key`}
-                                  placeholder={props.keyPlaceholder || 'Input'}
-                                  showError={false}
-                                />
-                              )}
-                            </>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                            style={{ marginTop: '10px' }}
-                          >
-                            <EuiIcon type="sortRight" />
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <>
-                              {!isEmpty(props.valueOptions) ? (
-                                <SelectWithCustomOptions
-                                  fieldPath={`${props.fieldPath}.${idx}.value`}
-                                  options={props.valueOptions || []}
-                                  placeholder={
-                                    props.valuePlaceholder || 'Output'
-                                  }
-                                />
-                              ) : (
-                                <TextField
-                                  fullWidth={true}
-                                  fieldPath={`${props.fieldPath}.${idx}.value`}
-                                  placeholder={
-                                    props.valuePlaceholder || 'Output'
-                                  }
-                                  showError={false}
-                                />
-                              )}
-                            </>
-                          </EuiFlexItem>
+                          <>
+                            <EuiFlexItem>
+                              <>
+                                {!isEmpty(props.keyOptions) ? (
+                                  <SelectWithCustomOptions
+                                    fieldPath={`${props.fieldPath}.${idx}.key`}
+                                    options={props.keyOptions as any[]}
+                                    placeholder={
+                                      props.keyPlaceholder || 'Input'
+                                    }
+                                  />
+                                ) : (
+                                  <TextField
+                                    fullWidth={true}
+                                    fieldPath={`${props.fieldPath}.${idx}.key`}
+                                    placeholder={
+                                      props.keyPlaceholder || 'Input'
+                                    }
+                                    showError={false}
+                                  />
+                                )}
+                              </>
+                            </EuiFlexItem>
+                            <EuiFlexItem
+                              grow={false}
+                              style={{ marginTop: '10px' }}
+                            >
+                              <EuiIcon type="sortRight" />
+                            </EuiFlexItem>
+                          </>
                         </EuiFlexGroup>
                       </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiSmallButtonIcon
-                          iconType={'trash'}
-                          color="danger"
-                          aria-label="Delete"
-                          onClick={() => {
-                            deleteMapEntry(field.value, idx);
-                          }}
-                        />
+                      <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                        <EuiFlexGroup direction="row" gutterSize="xs">
+                          <>
+                            <EuiFlexItem>
+                              <>
+                                {!isEmpty(props.valueOptions) ? (
+                                  <SelectWithCustomOptions
+                                    fieldPath={`${props.fieldPath}.${idx}.value`}
+                                    options={props.valueOptions || []}
+                                    placeholder={
+                                      props.valuePlaceholder || 'Output'
+                                    }
+                                  />
+                                ) : (
+                                  <TextField
+                                    fullWidth={true}
+                                    fieldPath={`${props.fieldPath}.${idx}.value`}
+                                    placeholder={
+                                      props.valuePlaceholder || 'Output'
+                                    }
+                                    showError={false}
+                                  />
+                                )}
+                              </>
+                            </EuiFlexItem>
+                            <EuiFlexItem grow={false}>
+                              <EuiSmallButtonIcon
+                                iconType={'trash'}
+                                color="danger"
+                                aria-label="Delete"
+                                onClick={() => {
+                                  deleteMapEntry(field.value, idx);
+                                }}
+                              />
+                            </EuiFlexItem>
+                          </>
+                        </EuiFlexGroup>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   </EuiFlexItem>
@@ -170,7 +217,7 @@ export function MapField(props: MapFieldProps) {
                       addMapEntry(field.value);
                     }}
                   >
-                    {field.value?.length > 0 ? 'Add more' : 'Add field mapping'}
+                    {props.addEntryButtonText || 'Add more'}
                   </EuiSmallButton>
                 </div>
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -336,16 +336,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <EuiSpacer size="l" />
             </>
           )}
-          <EuiFlexGroup direction="row">
+          <EuiFlexGroup direction="row" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <EuiText
                 size="m"
                 style={{ marginTop: '4px' }}
-              >{`Configure input transformations (${
-                props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                  ? 'Required'
-                  : 'Optional'
-              })`}</EuiText>
+              >{`Inputs`}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip
@@ -357,12 +353,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               >
                 <EuiSmallButtonEmpty
                   disabled={!isInputPreviewAvailable}
-                  style={{ width: '100px', paddingTop: '8px' }}
+                  style={{ paddingTop: '8px' }}
                   onClick={() => {
                     setIsInputTransformModalOpen(true);
                   }}
                 >
-                  Preview
+                  Preview inputs
                 </EuiSmallButtonEmpty>
               </EuiToolTip>
             </EuiFlexItem>
@@ -371,16 +367,20 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           <MapArrayField
             field={inputMapField}
             fieldPath={inputMapFieldPath}
-            label="Input Map"
             helpText={`An array specifying how to map fields from the ingested document to the model’s input. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
             root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-            helpLink={ML_INFERENCE_DOCS_LINK}
-            keyPlaceholder="Model input field"
+            keyTitle="Name"
+            keyPlaceholder="Name"
             keyOptions={parseModelInputs(modelInterface)}
-            valuePlaceholder={
+            valueTitle={
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'Query field'
                 : 'Document field'
+            }
+            valuePlaceholder={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Specify a query field'
+                : 'Define a document field'
             }
             valueOptions={
               props.context === PROCESSOR_CONTEXT.INGEST
@@ -389,18 +389,16 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 ? queryFields
                 : indexMappingFields
             }
+            addMapEntryButtonText="Add input"
+            addMapButtonText="(Advanced) Add input group"
           />
           <EuiSpacer size="l" />
-          <EuiFlexGroup direction="row">
+          <EuiFlexGroup direction="row" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <EuiText
                 size="m"
                 style={{ marginTop: '4px' }}
-              >{`Configure output transformations (${
-                props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                  ? 'Required'
-                  : 'Optional'
-              })`}</EuiText>
+              >{`Outputs`}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip
@@ -412,12 +410,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               >
                 <EuiSmallButtonEmpty
                   disabled={!isOutputPreviewAvailable}
-                  style={{ width: '100px', paddingTop: '8px' }}
+                  style={{ paddingTop: '8px' }}
                   onClick={() => {
                     setIsOutputTransformModalOpen(true);
                   }}
                 >
-                  Preview
+                  Preview outputs
                 </EuiSmallButtonEmpty>
               </EuiToolTip>
             </EuiFlexItem>
@@ -426,21 +424,27 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           <MapArrayField
             field={outputMapField}
             fieldPath={outputMapFieldPath}
-            label="Output Map"
             helpText={`An array specifying how to map the model’s output to new document fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
             root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-            helpLink={ML_INFERENCE_DOCS_LINK}
-            keyPlaceholder={
+            keyTitle={
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'Query field'
                 : 'New document field'
             }
-            valuePlaceholder="Model output field"
+            keyPlaceholder={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Specify a query field'
+                : 'Define a document field'
+            }
+            valueTitle="Name"
+            valuePlaceholder="Name"
             valueOptions={
               fullResponsePath
                 ? undefined
                 : parseModelOutputs(modelInterface, false)
             }
+            addMapEntryButtonText="Add output"
+            addMapButtonText="(Advanced) Add output group"
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -34,7 +34,6 @@ import {
   IProcessorConfig,
   IngestPipelineConfig,
   JSONPATH_ROOT_SELECTOR,
-  ML_INFERENCE_DOCS_LINK,
   ML_INFERENCE_RESPONSE_DOCS_LINK,
   MapArrayFormValue,
   ModelInterface,
@@ -441,16 +440,20 @@ export function InputTransformModal(props: InputTransformModalProps) {
               <MapArrayField
                 field={props.inputMapField}
                 fieldPath={props.inputMapFieldPath}
-                label="Input Map"
                 helpText={`An array specifying how to map fields from the ingested document to the model’s input. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-                helpLink={ML_INFERENCE_DOCS_LINK}
-                keyPlaceholder="Model input field"
+                keyTitle="Name"
+                keyPlaceholder="Name"
                 keyOptions={parseModelInputs(props.modelInterface)}
-                valuePlaceholder={
+                valueTitle={
                   props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                     ? 'Query field'
                     : 'Document field'
+                }
+                valuePlaceholder={
+                  props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                    ? 'Specify a query field'
+                    : 'Define a document field'
                 }
                 valueOptions={props.valueOptions}
                 // If the map we are adding is the first one, populate the selected option to index 0
@@ -467,6 +470,8 @@ export function InputTransformModal(props: InputTransformModalProps) {
                     setTransformedInput('{}');
                   }
                 }}
+                addMapEntryButtonText="Add input"
+                addMapButtonText="(Advanced) Add input group"
               />
             </>
           </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -388,12 +388,20 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
               <MapArrayField
                 field={props.outputMapField}
                 fieldPath={props.outputMapFieldPath}
-                label="Output Map"
                 helpText={`An array specifying how to map the model’s output to new fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
                 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-                helpLink={ML_INFERENCE_DOCS_LINK}
-                keyPlaceholder="Document field"
-                valuePlaceholder="Model output field"
+                keyTitle={
+                  props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                    ? 'Query field'
+                    : 'New document field'
+                }
+                keyPlaceholder={
+                  props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                    ? 'Specify a query field'
+                    : 'Define a document field'
+                }
+                valueTitle="Name"
+                valuePlaceholder="Name"
                 valueOptions={
                   fullResponsePath
                     ? undefined
@@ -413,6 +421,8 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
                     setTransformedOutput('{}');
                   }
                 }}
+                addMapEntryButtonText="Add output"
+                addMapButtonText="(Advanced) Add output group"
               />
             </>
           </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -209,7 +209,7 @@ export function ProcessorsList(props: ProcessorsListProps) {
               panels={[
                 {
                   id: PANEL_ID,
-                  title: 'Processors',
+                  title: 'PROCESSORS',
                   items:
                     props.context === PROCESSOR_CONTEXT.INGEST
                       ? [

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useFormikContext } from 'formik';
+import { getIn, useFormikContext } from 'formik';
 import {
   EuiSmallButton,
   EuiCompressedFieldText,
@@ -16,13 +16,13 @@ import {
   EuiSuperSelectOption,
   EuiText,
   EuiSpacer,
+  EuiCodeBlock,
 } from '@elastic/eui';
 import {
   SearchHit,
   WorkflowFormValues,
   customStringify,
 } from '../../../../../common';
-import { JsonField } from '../input_fields';
 import { AppState, searchIndex, useAppDispatch } from '../../../../store';
 import { getDataSourceId } from '../../../../utils/utils';
 import { EditQueryModal } from './edit_query_modal';
@@ -124,13 +124,17 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
             Edit
           </EuiSmallButton>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <JsonField
-            label="Query"
-            fieldPath={'search.request'}
-            editorHeight="25vh"
-            readOnly={true}
-          />
+        <EuiFlexItem grow={true}>
+          <EuiCodeBlock
+            fontSize="s"
+            language="json"
+            overflowHeight={300}
+            isCopyable={false}
+            whiteSpace="pre"
+            paddingSize="none"
+          >
+            {getIn(values, 'search.request')}
+          </EuiCodeBlock>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -121,7 +121,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiFlexGroup>
+              <EuiFlexGroup direction="row" gutterSize="none">
                 <EuiFlexItem>
                   <EuiSmallButtonEmpty
                     style={{ width: '100px' }}


### PR DESCRIPTION
### Description

Continuation of #427 . Changes:

- [x] readonly views of the docs & query inputs are `EuiCodeBlock`
- [x] rename "Tools" to "Inspector"
- [x] remove workflow state in header of details page
- [x] make the right-side panel (the preview + tools panels) collapsible, instead of the workflow inputs, since workflow inputs is the primary space users will be interacting with
- [x] capitalize "PROCESSORS" when selecting a processor in ingest/search pipeline form inputs
- [x] cleans up some spacing issue due to #428 
- [x] moves edit import data into header
- [x] moves edit query / test query into header
- [x] tune wording & simplify layout of the input/output transform form components (MapArrayField / MapField)

Demo video highlighting changes:

[screen-capture (11).webm](https://github.com/user-attachments/assets/95fa6e01-2e6f-4dcc-afd4-603684f67899)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
