### PR TITLE
Move undo & save buttons in top-level header

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -480,3 +480,7 @@ export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
   'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
 export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';
 export const PROMPT_FIELD = 'prompt'; // TODO: likely expand to support a pattern and/or multiple (e.g., "prompt", "prompt_template", etc.)
+export enum CONFIG_STEP {
+  INGEST = 'Ingestion pipeline',
+  SEARCH = 'Search pipeline',
+}

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -78,8 +78,16 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   >();
 
   // workflow state
-  const [workflowName, setWorkflowName] = useState<string>('');
-  const [workflowLastUpdated, setWorkflowLastUpdated] = useState<string>('');
+  //const [workflowName, setWorkflowName] = useState<string>('');
+  const workflowName = getCharacterLimitedString(
+    props.workflow?.name,
+    MAX_WORKFLOW_NAME_TO_DISPLAY
+  );
+  const workflowLastUpdated = toFormattedDate(
+    // @ts-ignore
+    props.workflow?.lastUpdated
+  ).toString();
+  // const [workflowLastUpdated, setWorkflowLastUpdated] = useState<string>('');
 
   // export modal state
   const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);
@@ -91,27 +99,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   const {
     chrome: { setHeaderVariant },
   } = getCore();
-
-  // get some workflow details
-  useEffect(() => {
-    if (props.workflow) {
-      setWorkflowName(
-        getCharacterLimitedString(
-          props.workflow.name,
-          MAX_WORKFLOW_NAME_TO_DISPLAY
-        )
-      );
-      try {
-        const formattedDate = toFormattedDate(
-          // @ts-ignore
-          props.workflow.lastUpdated
-        ).toString();
-        setWorkflowLastUpdated(formattedDate);
-      } catch (err) {
-        setWorkflowLastUpdated('');
-      }
-    }
-  }, [props.workflow]);
 
   // When NewHomePage is enabled, use 'application' HeaderVariant; otherwise, use 'page' HeaderVariant (default).
   useEffect(() => {

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -133,23 +133,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     );
   };
 
-  const topNavConfig: TopNavMenuData[] = [
-    {
-      iconType: 'exportAction',
-      tooltip: 'Export',
-      ariaLabel: 'Export',
-      run: onExportButtonClick,
-      controlType: 'icon',
-    } as TopNavMenuIconData,
-    {
-      iconType: 'exit',
-      tooltip: 'Return to projects',
-      ariaLabel: 'Exit',
-      run: onExitButtonClick,
-      controlType: 'icon',
-    } as TopNavMenuIconData,
-  ];
-
   // get & render the data source component, if applicable
   let DataSourceComponent: ReactElement | null = null;
   if (dataSourceEnabled && getDataSourceManagementPlugin()) {
@@ -219,6 +202,14 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
       ? false
       : isEmpty(touched?.search) || !dirty;
   const searchSaveButtonDisabled = searchUndoButtonDisabled;
+  const undoDisabled =
+    props.selectedStep === CONFIG_STEP.INGEST
+      ? ingestUndoButtonDisabled
+      : searchUndoButtonDisabled;
+  const saveDisabled =
+    props.selectedStep === CONFIG_STEP.INGEST
+      ? ingestSaveButtonDisabled
+      : searchSaveButtonDisabled;
 
   // Utility fn to update the workflow UI config only, based on the current form values.
   // A get workflow API call is subsequently run to fetch the updated state.
@@ -290,7 +281,38 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
         <>
           <TopNavMenu
             appName={PLUGIN_ID}
-            config={topNavConfig}
+            config={[
+              {
+                iconType: 'editorUndo',
+                tooltip: 'Revert changes',
+                ariaLabel: 'Revert',
+                run: revertUnsavedChanges,
+                controlType: 'icon',
+                disabled: undoDisabled,
+              } as TopNavMenuIconData,
+              {
+                iconType: 'save',
+                tooltip: 'Save',
+                ariaLabel: 'Save',
+                run: updateWorkflowUiConfig,
+                controlType: 'icon',
+                disabled: saveDisabled,
+              } as TopNavMenuIconData,
+              {
+                iconType: 'exportAction',
+                tooltip: 'Export',
+                ariaLabel: 'Export',
+                run: onExportButtonClick,
+                controlType: 'icon',
+              } as TopNavMenuIconData,
+              {
+                iconType: 'exit',
+                tooltip: 'Return to projects',
+                ariaLabel: 'Exit',
+                run: onExitButtonClick,
+                controlType: 'icon',
+              } as TopNavMenuIconData,
+            ]}
             screenTitle={workflowName}
             showDataSourceMenu={dataSourceEnabled}
             dataSourceMenuConfig={
@@ -364,11 +386,7 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
               </EuiSmallButtonEmpty>,
               <EuiSmallButtonEmpty
                 style={{ marginTop: '8px' }}
-                disabled={
-                  props.selectedStep === CONFIG_STEP.INGEST
-                    ? ingestSaveButtonDisabled
-                    : searchSaveButtonDisabled
-                }
+                disabled={saveDisabled}
                 isLoading={isRunningSave}
                 onClick={() => {
                   updateWorkflowUiConfig();
@@ -380,11 +398,7 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 style={{ marginTop: '8px' }}
                 iconType="editorUndo"
                 aria-label="undo changes"
-                isDisabled={
-                  props.selectedStep === CONFIG_STEP.INGEST
-                    ? ingestUndoButtonDisabled
-                    : searchUndoButtonDisabled
-                }
+                isDisabled={undoDisabled}
                 onClick={() => {
                   revertUnsavedChanges();
                 }}

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -85,7 +85,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     // @ts-ignore
     props.workflow?.lastUpdated
   ).toString();
-  // const [workflowLastUpdated, setWorkflowLastUpdated] = useState<string>('');
 
   // export modal state
   const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -48,7 +48,6 @@ import { DataSourceViewConfig } from '../../../../../../src/plugins/data_source_
 import { HeaderVariant } from '../../../../../../src/core/public';
 import {
   TopNavControlTextData,
-  TopNavMenuData,
   TopNavMenuIconData,
 } from '../../../../../../src/plugins/navigation/public';
 import { MountPoint } from '../../../../../../src/core/public';
@@ -78,7 +77,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   >();
 
   // workflow state
-  //const [workflowName, setWorkflowName] = useState<string>('');
   const workflowName = getCharacterLimitedString(
     props.workflow?.name,
     MAX_WORKFLOW_NAME_TO_DISPLAY

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useRef, useState, useEffect } from 'react';
-import { Form, Formik } from 'formik';
-import * as yup from 'yup';
+import React, { useRef, useState } from 'react';
 import {
   EuiCodeBlock,
   EuiEmptyPrompt,
@@ -14,20 +12,8 @@ import {
   EuiResizableContainer,
   EuiText,
 } from '@elastic/eui';
-
-import {
-  Workflow,
-  WorkflowConfig,
-  WorkflowFormValues,
-  WorkflowSchema,
-  customStringify,
-} from '../../../common';
-import {
-  isValidUiWorkflow,
-  reduceToTemplate,
-  uiConfigToFormik,
-  uiConfigToSchema,
-} from '../../utils';
+import { Workflow, WorkflowConfig, customStringify } from '../../../common';
+import { reduceToTemplate } from '../../utils';
 import { WorkflowInputs } from './workflow_inputs';
 import { Workspace } from './workspace';
 import { Tools } from './tools';
@@ -37,7 +23,14 @@ import './workspace/workspace-styles.scss';
 import '../../global-styles.scss';
 
 interface ResizableWorkspaceProps {
-  workflow?: Workflow;
+  workflow: Workflow | undefined;
+  isValidWorkflow: boolean;
+  uiConfig: WorkflowConfig | undefined;
+  setUiConfig: (uiConfig: WorkflowConfig) => void;
+  ingestDocs: string;
+  setIngestDocs: (docs: string) => void;
+  query: string;
+  setQuery: (query: string) => void;
 }
 
 const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
@@ -49,27 +42,6 @@ const TOOLS_PANEL_ID = 'tools_panel_id';
  * panels - the ReactFlow workspace panel and the selected component details panel.
  */
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
-  // Workflow state
-  const [workflow, setWorkflow] = useState<Workflow | undefined>(
-    props.workflow
-  );
-
-  // Formik form state
-  const [formValues, setFormValues] = useState<WorkflowFormValues>({});
-  const [formSchema, setFormSchema] = useState<WorkflowSchema>(yup.object({}));
-
-  // ingest state
-  const [ingestDocs, setIngestDocs] = useState<string>('');
-
-  // query state
-  const [query, setQuery] = useState<string>('');
-
-  // Temp UI config state. For persisting changes to the UI config that may
-  // not be saved in the backend (e.g., adding / removing an ingest processor)
-  const [uiConfig, setUiConfig] = useState<WorkflowConfig | undefined>(
-    undefined
-  );
-
   // Preview side panel state. This panel encapsulates the tools panel as a child resizable panel.
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(true);
   const collapseFnHorizontal = useRef(
@@ -82,12 +54,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsPreviewPanelOpen(!isPreviewPanelOpen);
   };
 
-  // ingest state
-  const [ingestResponse, setIngestResponse] = useState<string>('');
-
-  // query state
-  const [queryResponse, setQueryResponse] = useState<string>('');
-
   // Tools side panel state
   const [isToolsPanelOpen, setIsToolsPanelOpen] = useState<boolean>(true);
   const collapseFnVertical = useRef(
@@ -98,173 +64,125 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsToolsPanelOpen(!isToolsPanelOpen);
   };
 
-  // workflow state
-  const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
+  // ingest / search response states to be populated in the Tools panel
+  const [ingestResponse, setIngestResponse] = useState<string>('');
+  const [queryResponse, setQueryResponse] = useState<string>('');
 
-  // Hook to check if the workflow is valid or not
-  useEffect(() => {
-    const missingUiFlow = props.workflow && !isValidUiWorkflow(props.workflow);
-    if (missingUiFlow) {
-      setIsValidWorkflow(false);
-    } else {
-      setWorkflow(props.workflow);
-    }
-  }, [props.workflow]);
-
-  // Initialize the form state based on the workflow's config, if applicable.
-  useEffect(() => {
-    if (workflow?.ui_metadata?.config) {
-      setUiConfig(workflow.ui_metadata.config);
-    }
-  }, [workflow]);
-
-  // Initialize the form state based on the current UI config
-  useEffect(() => {
-    if (uiConfig) {
-      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs);
-      const initFormSchema = uiConfigToSchema(uiConfig);
-      setFormValues(initFormValues);
-      setFormSchema(initFormSchema);
-    }
-  }, [uiConfig]);
-
-  return isValidWorkflow ? (
-    <Formik
-      enableReinitialize={true}
-      initialValues={formValues}
-      validationSchema={formSchema}
-      onSubmit={(values) => {}}
-      validate={(values) => {}}
+  return props.isValidWorkflow ? (
+    <EuiResizableContainer
+      direction="horizontal"
+      className="stretch-absolute"
+      style={{
+        marginLeft: '-8px',
+        marginTop: '-8px',
+      }}
     >
-      {(formikProps) => (
-        <Form>
-          <EuiResizableContainer
-            direction="horizontal"
-            className="stretch-absolute"
-            style={{
-              marginLeft: '-8px',
-              marginTop: '-8px',
-            }}
-          >
-            {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-              if (togglePanel) {
-                collapseFnHorizontal.current = (
-                  panelId: string,
-                  { direction }
-                ) => togglePanel(panelId, { direction });
-              }
-
-              return (
-                <>
-                  <EuiResizablePanel
-                    id={WORKFLOW_INPUTS_PANEL_ID}
-                    mode="main"
-                    initialSize={60}
-                    minSize="25%"
-                    paddingSize="s"
-                  >
-                    <WorkflowInputs
-                      workflow={props.workflow}
-                      uiConfig={uiConfig}
-                      setUiConfig={setUiConfig}
-                      setIngestResponse={setIngestResponse}
-                      setQueryResponse={setQueryResponse}
-                      ingestDocs={ingestDocs}
-                      setIngestDocs={setIngestDocs}
-                      query={query}
-                      setQuery={setQuery}
-                    />
-                  </EuiResizablePanel>
-                  <EuiResizableButton />
-                  <EuiResizablePanel
-                    id={PREVIEW_PANEL_ID}
-                    style={{
-                      marginRight: isPreviewPanelOpen ? '-32px' : '0px',
-                      marginBottom: isToolsPanelOpen ? '0px' : '24px',
-                    }}
-                    mode="collapsible"
-                    initialSize={60}
-                    minSize="25%"
-                    paddingSize="s"
-                    onToggleCollapsedInternal={() => onTogglePreviewChange()}
-                  >
-                    <EuiResizableContainer
-                      className="workspace-panel"
-                      direction="vertical"
-                      style={{
-                        marginLeft: '-8px',
-                        marginTop: '-8px',
-                        padding: 'none',
-                      }}
-                    >
-                      {(
-                        EuiResizablePanel,
-                        EuiResizableButton,
-                        { togglePanel }
-                      ) => {
-                        if (togglePanel) {
-                          collapseFnVertical.current = (
-                            panelId: string,
-                            { direction }
-                          ) =>
-                            // ignore is added since docs are incorrectly missing "top" and "bottom"
-                            // as valid direction options for vertically-configured resizable panels.
-                            // @ts-ignore
-                            togglePanel(panelId, { direction });
-                        }
-
-                        return (
-                          <>
-                            <EuiResizablePanel
-                              mode="main"
-                              initialSize={60}
-                              minSize="25%"
-                              paddingSize="s"
-                              style={{ marginBottom: '-8px' }}
-                            >
-                              <EuiFlexGroup
-                                direction="column"
-                                gutterSize="s"
-                                style={{ height: '100%' }}
-                              >
-                                <EuiFlexItem>
-                                  <Workspace
-                                    workflow={props.workflow}
-                                    uiConfig={uiConfig}
-                                  />
-                                </EuiFlexItem>
-                              </EuiFlexGroup>
-                            </EuiResizablePanel>
-                            <EuiResizableButton />
-                            <EuiResizablePanel
-                              id={TOOLS_PANEL_ID}
-                              mode="collapsible"
-                              initialSize={50}
-                              minSize="25%"
-                              paddingSize="s"
-                              onToggleCollapsedInternal={() =>
-                                onToggleToolsChange()
-                              }
-                              style={{ marginBottom: '-16px' }}
-                            >
-                              <Tools
-                                workflow={workflow}
-                                ingestResponse={ingestResponse}
-                                queryResponse={queryResponse}
-                              />
-                            </EuiResizablePanel>
-                          </>
-                        );
-                      }}
-                    </EuiResizableContainer>
-                  </EuiResizablePanel>
-                </>
-              );
-            }}
-          </EuiResizableContainer>
-        </Form>
-      )}
-    </Formik>
+      {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
+        if (togglePanel) {
+          collapseFnHorizontal.current = (panelId: string, { direction }) =>
+            togglePanel(panelId, { direction });
+        }
+        return (
+          <>
+            <EuiResizablePanel
+              id={WORKFLOW_INPUTS_PANEL_ID}
+              mode="main"
+              initialSize={60}
+              minSize="25%"
+              paddingSize="s"
+            >
+              <WorkflowInputs
+                workflow={props.workflow}
+                uiConfig={props.uiConfig}
+                setUiConfig={props.setUiConfig}
+                setIngestResponse={setIngestResponse}
+                setQueryResponse={setQueryResponse}
+                ingestDocs={props.ingestDocs}
+                setIngestDocs={props.setIngestDocs}
+                query={props.query}
+                setQuery={props.setQuery}
+              />
+            </EuiResizablePanel>
+            <EuiResizableButton />
+            <EuiResizablePanel
+              id={PREVIEW_PANEL_ID}
+              style={{
+                marginRight: isPreviewPanelOpen ? '-32px' : '0px',
+                marginBottom: isToolsPanelOpen ? '0px' : '24px',
+              }}
+              mode="collapsible"
+              initialSize={60}
+              minSize="25%"
+              paddingSize="s"
+              onToggleCollapsedInternal={() => onTogglePreviewChange()}
+            >
+              <EuiResizableContainer
+                className="workspace-panel"
+                direction="vertical"
+                style={{
+                  marginLeft: '-8px',
+                  marginTop: '-8px',
+                  padding: 'none',
+                }}
+              >
+                {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
+                  if (togglePanel) {
+                    collapseFnVertical.current = (
+                      panelId: string,
+                      { direction }
+                    ) =>
+                      // ignore is added since docs are incorrectly missing "top" and "bottom"
+                      // as valid direction options for vertically-configured resizable panels.
+                      // @ts-ignore
+                      togglePanel(panelId, { direction });
+                  }
+                  return (
+                    <>
+                      <EuiResizablePanel
+                        mode="main"
+                        initialSize={60}
+                        minSize="25%"
+                        paddingSize="s"
+                        style={{ marginBottom: '-8px' }}
+                      >
+                        <EuiFlexGroup
+                          direction="column"
+                          gutterSize="s"
+                          style={{ height: '100%' }}
+                        >
+                          <EuiFlexItem>
+                            <Workspace
+                              workflow={props.workflow}
+                              uiConfig={props.uiConfig}
+                            />
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiResizablePanel>
+                      <EuiResizableButton />
+                      <EuiResizablePanel
+                        id={TOOLS_PANEL_ID}
+                        mode="collapsible"
+                        initialSize={50}
+                        minSize="25%"
+                        paddingSize="s"
+                        onToggleCollapsedInternal={() => onToggleToolsChange()}
+                        style={{ marginBottom: '-16px' }}
+                      >
+                        <Tools
+                          workflow={props.workflow}
+                          ingestResponse={ingestResponse}
+                          queryResponse={queryResponse}
+                        />
+                      </EuiResizablePanel>
+                    </>
+                  );
+                }}
+              </EuiResizableContainer>
+            </EuiResizablePanel>
+          </>
+        );
+      }}
+    </EuiResizableContainer>
   ) : (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={3}>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -12,7 +12,12 @@ import {
   EuiResizableContainer,
   EuiText,
 } from '@elastic/eui';
-import { Workflow, WorkflowConfig, customStringify } from '../../../common';
+import {
+  CONFIG_STEP,
+  Workflow,
+  WorkflowConfig,
+  customStringify,
+} from '../../../common';
 import { isValidUiWorkflow, reduceToTemplate } from '../../utils';
 import { WorkflowInputs } from './workflow_inputs';
 import { Workspace } from './workspace';
@@ -28,6 +33,14 @@ interface ResizableWorkspaceProps {
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   ingestDocs: string;
   setIngestDocs: (docs: string) => void;
+  isRunningIngest: boolean;
+  setIsRunningIngest: (isRunningIngest: boolean) => void;
+  isRunningSearch: boolean;
+  setIsRunningSearch: (isRunningSearch: boolean) => void;
+  selectedStep: CONFIG_STEP;
+  setSelectedStep: (step: CONFIG_STEP) => void;
+  setUnsavedIngestProcessors: (unsavedIngestProcessors: boolean) => void;
+  setUnsavedSearchProcessors: (unsavedSearchProcessors: boolean) => void;
 }
 
 const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
@@ -80,7 +93,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       className="stretch-absolute"
       style={{
         marginLeft: '-8px',
-        marginTop: '-8px',
+        marginTop: '40px',
       }}
     >
       {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
@@ -105,6 +118,14 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                 setQueryResponse={setQueryResponse}
                 ingestDocs={props.ingestDocs}
                 setIngestDocs={props.setIngestDocs}
+                isRunningIngest={props.isRunningIngest}
+                setIsRunningIngest={props.setIsRunningIngest}
+                isRunningSearch={props.isRunningSearch}
+                setIsRunningSearch={props.setIsRunningSearch}
+                selectedStep={props.selectedStep}
+                setSelectedStep={props.setSelectedStep}
+                setUnsavedIngestProcessors={props.setUnsavedIngestProcessors}
+                setUnsavedSearchProcessors={props.setUnsavedSearchProcessors}
               />
             </EuiResizablePanel>
             <EuiResizableButton />

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiCodeBlock,
   EuiEmptyPrompt,
@@ -13,7 +13,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { Workflow, WorkflowConfig, customStringify } from '../../../common';
-import { reduceToTemplate } from '../../utils';
+import { isValidUiWorkflow, reduceToTemplate } from '../../utils';
 import { WorkflowInputs } from './workflow_inputs';
 import { Workspace } from './workspace';
 import { Tools } from './tools';
@@ -24,13 +24,10 @@ import '../../global-styles.scss';
 
 interface ResizableWorkspaceProps {
   workflow: Workflow | undefined;
-  isValidWorkflow: boolean;
   uiConfig: WorkflowConfig | undefined;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   ingestDocs: string;
   setIngestDocs: (docs: string) => void;
-  query: string;
-  setQuery: (query: string) => void;
 }
 
 const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
@@ -68,7 +65,16 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   const [ingestResponse, setIngestResponse] = useState<string>('');
   const [queryResponse, setQueryResponse] = useState<string>('');
 
-  return props.isValidWorkflow ? (
+  // is valid workflow state, + associated hook to set it as such
+  const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
+  useEffect(() => {
+    const missingUiFlow = props.workflow && !isValidUiWorkflow(props.workflow);
+    if (missingUiFlow) {
+      setIsValidWorkflow(false);
+    }
+  }, [props.workflow]);
+
+  return isValidWorkflow ? (
     <EuiResizableContainer
       direction="horizontal"
       className="stretch-absolute"
@@ -99,8 +105,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                 setQueryResponse={setQueryResponse}
                 ingestDocs={props.ingestDocs}
                 setIngestDocs={props.setIngestDocs}
-                query={props.query}
-                setQuery={props.setQuery}
               />
             </EuiResizablePanel>
             <EuiResizableButton />

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -18,7 +18,11 @@ import {
   WorkflowConfig,
   customStringify,
 } from '../../../common';
-import { isValidUiWorkflow, reduceToTemplate } from '../../utils';
+import {
+  isValidUiWorkflow,
+  reduceToTemplate,
+  SHOW_ACTIONS_IN_HEADER,
+} from '../../utils';
 import { WorkflowInputs } from './workflow_inputs';
 import { Workspace } from './workspace';
 import { Tools } from './tools';
@@ -93,7 +97,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       className="stretch-absolute"
       style={{
         marginLeft: '-8px',
-        marginTop: '40px',
+        marginTop: SHOW_ACTIONS_IN_HEADER ? '-8px' : '40px',
       }}
     >
       {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -249,8 +249,7 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
       expect(getAllByText('PROCESSORS').length).toBeGreaterThan(0);
     });
 
-    // Save, Build and Run query, Back buttons
-    expect(getByTestId('saveSearchPipelineButton')).toBeInTheDocument();
+    // Build and Run query, Back buttons are present
     expect(getByTestId('runQueryButton')).toBeInTheDocument();
     const searchPipelineBackButton = getByTestId('searchPipelineBackButton');
     userEvent.click(searchPipelineBackButton);

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { ReactFlowProvider } from 'reactflow';
 import { escape } from 'lodash';
+import { Formik } from 'formik';
+import * as yup from 'yup';
 import {
   EuiSmallButton,
   EuiEmptyPrompt,
@@ -16,7 +18,13 @@ import {
   EuiPage,
   EuiPageBody,
 } from '@elastic/eui';
-import { APP_PATH, BREADCRUMBS, SHOW_ACTIONS_IN_HEADER } from '../../utils';
+import {
+  APP_PATH,
+  BREADCRUMBS,
+  SHOW_ACTIONS_IN_HEADER,
+  uiConfigToFormik,
+  uiConfigToSchema,
+} from '../../utils';
 import { getCore } from '../../services';
 import { WorkflowDetailHeader } from './components';
 import {
@@ -34,20 +42,22 @@ import {
   MAX_WORKFLOW_NAME_TO_DISPLAY,
   NO_TEMPLATES_FOUND_MSG,
   OMIT_SYSTEM_INDEX_PATTERN,
+  WorkflowConfig,
+  WorkflowFormValues,
+  WorkflowSchema,
   getCharacterLimitedString,
 } from '../../../common';
 import { MountPoint } from '../../../../../src/core/public';
+import {
+  constructHrefWithDataSourceId,
+  getDataSourceId,
+  isValidUiWorkflow,
+} from '../../utils/utils';
+import { getDataSourceEnabled } from '../../services';
 
 // styling
 import './workflow-detail-styles.scss';
 import '../../global-styles.scss';
-
-import {
-  constructHrefWithDataSourceId,
-  getDataSourceId,
-} from '../../utils/utils';
-
-import { getDataSourceEnabled } from '../../services';
 
 export interface WorkflowDetailRouterProps {
   workflowId: string;
@@ -66,6 +76,19 @@ interface WorkflowDetailProps
 
 export function WorkflowDetail(props: WorkflowDetailProps) {
   const dispatch = useAppDispatch();
+
+  // On initial load:
+  // - fetch workflow
+  // - fetch available models & connectors as their IDs may be used when building flows
+  // - fetch all indices
+  useEffect(() => {
+    dispatch(getWorkflow({ workflowId, dataSourceId }));
+    dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
+    dispatch(searchConnectors({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
+    dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
+  }, []);
+
+  // data-source-related states
   const dataSourceEnabled = getDataSourceEnabled().enabled;
   const dataSourceId = getDataSourceId();
   const { workflows, errorMessage } = useSelector(
@@ -80,6 +103,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     MAX_WORKFLOW_NAME_TO_DISPLAY
   );
 
+  // setting breadcrumbs based on data source enabled
   const {
     chrome: { setBreadcrumbs },
   } = getCore();
@@ -101,16 +125,45 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     );
   }, [SHOW_ACTIONS_IN_HEADER, dataSourceEnabled, dataSourceId, workflowName]);
 
-  // On initial load:
-  // - fetch workflow
-  // - fetch available models & connectors as their IDs may be used when building flows
-  // - fetch all indices
+  // form state
+  const [formValues, setFormValues] = useState<WorkflowFormValues>({});
+  const [formSchema, setFormSchema] = useState<WorkflowSchema>(yup.object({}));
+
+  // ingest / query states
+  const [ingestDocs, setIngestDocs] = useState<string>('');
+  const [query, setQuery] = useState<string>('');
+
+  // Temp UI config state. For persisting changes to the UI config that may
+  // not be saved in the backend (e.g., adding / removing an ingest processor)
+  const [uiConfig, setUiConfig] = useState<WorkflowConfig | undefined>(
+    undefined
+  );
+
+  // is valid workflow state, + associated hook to set it as such
+  const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
   useEffect(() => {
-    dispatch(getWorkflow({ workflowId, dataSourceId }));
-    dispatch(searchModels({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
-    dispatch(searchConnectors({ apiBody: FETCH_ALL_QUERY, dataSourceId }));
-    dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
-  }, []);
+    const missingUiFlow = workflow && !isValidUiWorkflow(workflow);
+    if (missingUiFlow) {
+      setIsValidWorkflow(false);
+    }
+  }, [workflow]);
+
+  // Initialize the UI config based on the workflow's config, if applicable.
+  useEffect(() => {
+    if (workflow?.ui_metadata?.config) {
+      setUiConfig(workflow.ui_metadata.config);
+    }
+  }, [workflow]);
+
+  // Initialize the form state based on the current UI config, if applicable
+  useEffect(() => {
+    if (uiConfig) {
+      const initFormValues = uiConfigToFormik(uiConfig, ingestDocs);
+      const initFormSchema = uiConfigToSchema(uiConfig);
+      setFormValues(initFormValues);
+      setFormSchema(initFormSchema);
+    }
+  }, [uiConfig]);
 
   return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ||
     errorMessage.includes(NO_TEMPLATES_FOUND_MSG) ? (
@@ -133,18 +186,35 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
       </EuiFlexItem>
     </EuiFlexGroup>
   ) : (
-    <ReactFlowProvider>
-      <EuiPage>
-        <EuiPageBody className="workflow-detail stretch-relative">
-          <WorkflowDetailHeader
-            workflow={workflow}
-            setActionMenu={props.setActionMenu}
-          />
-          <ReactFlowProvider>
-            <ResizableWorkspace workflow={workflow} />
-          </ReactFlowProvider>
-        </EuiPageBody>
-      </EuiPage>
-    </ReactFlowProvider>
+    <Formik
+      enableReinitialize={true}
+      initialValues={formValues}
+      validationSchema={formSchema}
+      onSubmit={(values) => {}}
+      validate={(values) => {}}
+    >
+      <ReactFlowProvider>
+        <EuiPage>
+          <EuiPageBody className="workflow-detail stretch-relative">
+            <WorkflowDetailHeader
+              workflow={workflow}
+              setActionMenu={props.setActionMenu}
+            />
+            <ReactFlowProvider>
+              <ResizableWorkspace
+                workflow={workflow}
+                uiConfig={uiConfig}
+                setUiConfig={setUiConfig}
+                ingestDocs={ingestDocs}
+                setIngestDocs={setIngestDocs}
+                query={query}
+                setQuery={setQuery}
+                isValidWorkflow={isValidWorkflow}
+              />
+            </ReactFlowProvider>
+          </EuiPageBody>
+        </EuiPage>
+      </ReactFlowProvider>
+    </Formik>
   );
 }

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../store';
 import { ResizableWorkspace } from './resizable_workspace';
 import {
+  CONFIG_STEP,
   ERROR_GETTING_WORKFLOW_MSG,
   FETCH_ALL_QUERY,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
@@ -51,7 +52,6 @@ import { MountPoint } from '../../../../../src/core/public';
 import {
   constructHrefWithDataSourceId,
   getDataSourceId,
-  isValidUiWorkflow,
 } from '../../utils/utils';
 import { getDataSourceEnabled } from '../../services';
 
@@ -138,6 +138,20 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     undefined
   );
 
+  // various form-related states. persisted here to pass down to the child's form and header components, particularly
+  // to have consistency on the button states (enabled/disabled)
+  const [isRunningIngest, setIsRunningIngest] = useState<boolean>(false);
+  const [isRunningSearch, setIsRunningSearch] = useState<boolean>(false);
+  const [selectedStep, setSelectedStep] = useState<CONFIG_STEP>(
+    CONFIG_STEP.INGEST
+  );
+  const [unsavedIngestProcessors, setUnsavedIngestProcessors] = useState<
+    boolean
+  >(false);
+  const [unsavedSearchProcessors, setUnsavedSearchProcessors] = useState<
+    boolean
+  >(false);
+
   // Initialize the UI config based on the workflow's config, if applicable.
   useEffect(() => {
     if (workflow?.ui_metadata?.config) {
@@ -188,17 +202,32 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
           <EuiPageBody className="workflow-detail stretch-relative">
             <WorkflowDetailHeader
               workflow={workflow}
+              uiConfig={uiConfig}
+              setUiConfig={setUiConfig}
+              isRunningIngest={isRunningIngest}
+              isRunningSearch={isRunningSearch}
+              selectedStep={selectedStep}
+              unsavedIngestProcessors={unsavedIngestProcessors}
+              setUnsavedIngestProcessors={setUnsavedIngestProcessors}
+              unsavedSearchProcessors={unsavedSearchProcessors}
+              setUnsavedSearchProcessors={setUnsavedSearchProcessors}
               setActionMenu={props.setActionMenu}
             />
-            <ReactFlowProvider>
-              <ResizableWorkspace
-                workflow={workflow}
-                uiConfig={uiConfig}
-                setUiConfig={setUiConfig}
-                ingestDocs={ingestDocs}
-                setIngestDocs={setIngestDocs}
-              />
-            </ReactFlowProvider>
+            <ResizableWorkspace
+              workflow={workflow}
+              uiConfig={uiConfig}
+              setUiConfig={setUiConfig}
+              ingestDocs={ingestDocs}
+              setIngestDocs={setIngestDocs}
+              isRunningIngest={isRunningIngest}
+              setIsRunningIngest={setIsRunningIngest}
+              isRunningSearch={isRunningSearch}
+              setIsRunningSearch={setIsRunningSearch}
+              selectedStep={selectedStep}
+              setSelectedStep={setSelectedStep}
+              setUnsavedIngestProcessors={setUnsavedIngestProcessors}
+              setUnsavedSearchProcessors={setUnsavedSearchProcessors}
+            />
           </EuiPageBody>
         </EuiPage>
       </ReactFlowProvider>

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -129,24 +129,14 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   const [formValues, setFormValues] = useState<WorkflowFormValues>({});
   const [formSchema, setFormSchema] = useState<WorkflowSchema>(yup.object({}));
 
-  // ingest / query states
+  // ingest docs state. we need to persist here to update the form values.
   const [ingestDocs, setIngestDocs] = useState<string>('');
-  const [query, setQuery] = useState<string>('');
 
   // Temp UI config state. For persisting changes to the UI config that may
   // not be saved in the backend (e.g., adding / removing an ingest processor)
   const [uiConfig, setUiConfig] = useState<WorkflowConfig | undefined>(
     undefined
   );
-
-  // is valid workflow state, + associated hook to set it as such
-  const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
-  useEffect(() => {
-    const missingUiFlow = workflow && !isValidUiWorkflow(workflow);
-    if (missingUiFlow) {
-      setIsValidWorkflow(false);
-    }
-  }, [workflow]);
 
   // Initialize the UI config based on the workflow's config, if applicable.
   useEffect(() => {
@@ -207,9 +197,6 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
                 setUiConfig={setUiConfig}
                 ingestDocs={ingestDocs}
                 setIngestDocs={setIngestDocs}
-                query={query}
-                setQuery={setQuery}
-                isValidWorkflow={isValidWorkflow}
               />
             </ReactFlowProvider>
           </EuiPageBody>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -72,8 +72,6 @@ interface WorkflowInputsProps {
   setQueryResponse: (queryResponse: string) => void;
   ingestDocs: string;
   setIngestDocs: (docs: string) => void;
-  query: string;
-  setQuery: (query: string) => void;
 }
 
 enum STEP {
@@ -104,6 +102,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   } = useFormikContext<WorkflowFormValues>();
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+
+  // query state
+  const [query, setQuery] = useState<string>('');
 
   // transient running states
   const [isRunningSave, setIsRunningSave] = useState<boolean>(false);
@@ -584,7 +585,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     try {
       let queryObj = {};
       try {
-        queryObj = JSON.parse(props.query);
+        queryObj = JSON.parse(query);
       } catch (e) {}
       if (!isEmpty(queryObj)) {
         if (hasProvisionedIngestResources(props.workflow)) {
@@ -597,7 +598,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           const indexName = values.search.index.name;
           dispatch(
             searchIndex({
-              apiBody: { index: indexName, body: props.query },
+              apiBody: { index: indexName, body: query },
               dataSourceId,
             })
           )
@@ -799,7 +800,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               <SearchInputs
                 uiConfig={props.uiConfig}
                 setUiConfig={props.setUiConfig}
-                setQuery={props.setQuery}
+                setQuery={setQuery}
                 setQueryResponse={props.setQueryResponse}
               />
             )}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,7 @@ import {
 } from '../public/store';
 import { WorkflowInput } from '../test/interfaces';
 import { WORKFLOW_TYPE } from '../common/constants';
-import { UIState, Workflow } from '../common/interfaces';
+import { UIState, Workflow, WorkflowDict } from '../common/interfaces';
 import {
   fetchEmptyMetadata,
   fetchHybridSearchMetadata,
@@ -22,19 +22,17 @@ import fs from 'fs';
 import path from 'path';
 
 export function mockStore(...workflowSets: WorkflowInput[]) {
+  let workflowDict = {} as WorkflowDict;
+  workflowSets?.forEach((workflowInput) => {
+    workflowDict[workflowInput.id] = generateWorkflow(workflowInput);
+  });
   return {
     getState: () => ({
       opensearch: INITIAL_OPENSEARCH_STATE,
       ml: INITIAL_ML_STATE,
       workflows: {
         ...INITIAL_WORKFLOWS_STATE,
-        workflows: workflowSets.reduce(
-          (acc, workflowInput) => ({
-            ...acc,
-            [workflowInput.id]: generateWorkflow(workflowInput),
-          }),
-          {}
-        ),
+        workflows: workflowDict,
       },
       presets: INITIAL_PRESETS_STATE,
     }),


### PR DESCRIPTION
### Description
Moves the undo & save buttons in the top-level header of the Workflow Details page. In order to do this, a lot of the state scoped within `WorkflowInputs` had to be lifted up the dependency tree, in order to be accessible in the header component, where the buttons were relocated to. The majority of this PR is just refactoring the state and related props to/from the parent/child components.

Other notable changes include:
- adding the save/undo buttons to the `TopNavMenu` so they are visible when `useNewHomePage : true`
- fixing an endless loop bug in the test utils that was throttling the tests. By moving some of this state in `WorkflowDetails`, it actually would timeout and the tests would fail. After optimizing, there is no unnecessary rendering happening
- moves `CONFIG_STEP` as a consumable global constant to be accessed by all child components

Screenshots:
![Screenshot 2024-10-28 at 5 12 07 PM](https://github.com/user-attachments/assets/6be33db9-4a99-4f3e-a103-271a1ecfb234)

![Screenshot 2024-10-28 at 5 13 07 PM](https://github.com/user-attachments/assets/efd4ef1e-0d73-4928-b6ec-bd29d808b8db)

![Screenshot 2024-10-28 at 5 13 18 PM](https://github.com/user-attachments/assets/18fff0a2-2a83-481e-ae64-b467fb396cd4)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
