### PR TITLE
Add standalone form state for source data

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -484,3 +484,8 @@ export enum CONFIG_STEP {
   INGEST = 'Ingestion pipeline',
   SEARCH = 'Search pipeline',
 }
+export enum SOURCE_OPTIONS {
+  MANUAL = 'manual',
+  UPLOAD = 'upload',
+  EXISTING_INDEX = 'existing_index',
+}

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -67,9 +67,6 @@ export type IndexConfig = {
   settings: IConfigField;
 };
 
-// TODO: may expand to just IndexConfig (including mappings/settings info)
-// if we want to persist this for users using some existing index,
-// and want to pass that index config around.
 export type SearchIndexConfig = {
   name: IConfigField;
 };
@@ -112,6 +109,13 @@ export type WorkflowSchemaObj = {
   [key: string]: ObjectSchema<any, any, any>;
 };
 export type WorkflowSchema = ObjectSchema<WorkflowSchemaObj>;
+
+// Form / schema interfaces for the ingest docs sub-form
+export type IngestDocsFormValues = {
+  docs: FormikValues;
+};
+export type IngestDocsSchemaObj = WorkflowSchemaObj;
+export type IngestDocsSchema = WorkflowSchema;
 
 /**
  ********** WORKSPACE TYPES/INTERFACES **********

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -22,7 +22,7 @@ import {
   SearchHit,
   Workflow,
   WorkflowConfig,
-  WorkspaceFormValues,
+  WorkflowFormValues,
   customStringify,
   isVectorSearchUseCase,
   toFormattedDate,
@@ -44,7 +44,7 @@ interface SourceDataProps {
 export function SourceData(props: SourceDataProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
-  const { values, setFieldValue } = useFormikContext<WorkspaceFormValues>();
+  const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
 
   // empty/populated docs state
   let docs = [];
@@ -236,7 +236,7 @@ export function SourceData(props: SourceDataProps) {
 // only be executed for workflows coming from preset vector search use cases.
 function getProcessorInfo(
   uiConfig: WorkflowConfig,
-  values: WorkspaceFormValues
+  values: WorkflowFormValues
 ): {
   processorId: string | undefined;
   inputMapEntry: MapEntry | undefined;

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useFormikContext } from 'formik';
+import {
+  EuiSmallButton,
+  EuiCompressedFilePicker,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+  EuiFilterGroup,
+  EuiSmallFilterButton,
+  EuiSuperSelectOption,
+  EuiCompressedSuperSelect,
+} from '@elastic/eui';
+import { JsonField } from '../input_fields';
+import { SOURCE_OPTIONS, WorkspaceFormValues } from '../../../../../common';
+import { AppState } from '../../../../store';
+
+interface SourceDataProps {
+  selectedOption: SOURCE_OPTIONS;
+  setSelectedOption: (option: SOURCE_OPTIONS) => void;
+  selectedIndex: string | undefined;
+  setSelectedIndex: (index: string) => void;
+  setIsModalOpen: (isOpen: boolean) => void;
+}
+
+/**
+ * Modal for configuring the source data for ingest.
+ */
+export function SourceDataModal(props: SourceDataProps) {
+  const { setFieldValue } = useFormikContext<WorkspaceFormValues>();
+  const indices = useSelector((state: AppState) => state.opensearch.indices);
+
+  // files state. when a file is read, update the form value.
+  const fileReader = new FileReader();
+  fileReader.onload = (e) => {
+    if (e.target) {
+      setFieldValue('ingest.docs', e.target.result);
+    }
+  };
+
+  return (
+    <EuiModal
+      onClose={() => props.setIsModalOpen(false)}
+      style={{ width: '70vw' }}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Import data`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <>
+          <EuiFilterGroup>
+            <EuiSmallFilterButton
+              id={SOURCE_OPTIONS.MANUAL}
+              hasActiveFilters={props.selectedOption === SOURCE_OPTIONS.MANUAL}
+              onClick={() => props.setSelectedOption(SOURCE_OPTIONS.MANUAL)}
+              data-testid="manualEditSourceDataButton"
+            >
+              Manual
+            </EuiSmallFilterButton>
+            <EuiSmallFilterButton
+              id={SOURCE_OPTIONS.UPLOAD}
+              hasActiveFilters={props.selectedOption === SOURCE_OPTIONS.UPLOAD}
+              onClick={() => props.setSelectedOption(SOURCE_OPTIONS.UPLOAD)}
+              data-testid="uploadSourceDataButton"
+            >
+              Upload
+            </EuiSmallFilterButton>
+            <EuiSmallFilterButton
+              id={SOURCE_OPTIONS.EXISTING_INDEX}
+              hasActiveFilters={
+                props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX
+              }
+              onClick={() =>
+                props.setSelectedOption(SOURCE_OPTIONS.EXISTING_INDEX)
+              }
+              data-testid="selectIndexSourceDataButton"
+            >
+              Existing index
+            </EuiSmallFilterButton>
+          </EuiFilterGroup>
+          <EuiSpacer size="m" />
+          {props.selectedOption === SOURCE_OPTIONS.UPLOAD && (
+            <>
+              <EuiCompressedFilePicker
+                accept="application/json"
+                multiple={false}
+                initialPromptText="Upload file"
+                onChange={(files) => {
+                  if (files && files.length > 0) {
+                    fileReader.readAsText(files[0]);
+                  }
+                }}
+                display="default"
+              />
+              <EuiSpacer size="s" />
+            </>
+          )}
+          {props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX && (
+            <>
+              <EuiText color="subdued" size="s">
+                Up to 5 sample documents will be automatically populated.
+              </EuiText>
+              <EuiSpacer size="s" />
+              <EuiCompressedSuperSelect
+                options={Object.values(indices).map(
+                  (option) =>
+                    ({
+                      value: option.name,
+                      inputDisplay: <EuiText size="s">{option.name}</EuiText>,
+                      disabled: false,
+                    } as EuiSuperSelectOption<string>)
+                )}
+                valueOfSelected={props.selectedIndex}
+                onChange={(option) => {
+                  props.setSelectedIndex(option);
+                }}
+                isInvalid={false}
+              />
+              <EuiSpacer size="xs" />
+            </>
+          )}
+          <JsonField
+            label="Documents to be imported"
+            fieldPath={'ingest.docs'}
+            helpText="Documents should be formatted as a valid JSON array."
+            editorHeight="25vh"
+            readOnly={false}
+          />
+        </>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButton
+          onClick={() => props.setIsModalOpen(false)}
+          fill={false}
+          color="primary"
+          data-testid="closeSourceDataButton"
+        >
+          Close
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useFormikContext } from 'formik';
+import { Formik, getIn, useFormikContext } from 'formik';
+import * as yup from 'yup';
 import {
   EuiSmallButton,
   EuiCompressedFilePicker,
@@ -22,8 +23,14 @@ import {
   EuiCompressedSuperSelect,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
-import { SOURCE_OPTIONS, WorkspaceFormValues } from '../../../../../common';
+import {
+  IConfigField,
+  IngestDocsFormValues,
+  SOURCE_OPTIONS,
+  WorkflowFormValues,
+} from '../../../../../common';
 import { AppState } from '../../../../store';
+import { getFieldSchema, getInitialValue } from '../../../../utils';
 
 interface SourceDataProps {
   selectedOption: SOURCE_OPTIONS;
@@ -37,119 +44,180 @@ interface SourceDataProps {
  * Modal for configuring the source data for ingest.
  */
 export function SourceDataModal(props: SourceDataProps) {
-  const { setFieldValue } = useFormikContext<WorkspaceFormValues>();
+  const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
   const indices = useSelector((state: AppState) => state.opensearch.indices);
 
-  // files state. when a file is read, update the form value.
-  const fileReader = new FileReader();
-  fileReader.onload = (e) => {
-    if (e.target) {
-      setFieldValue('ingest.docs', e.target.result);
-    }
-  };
+  // sub-form values/schema
+  const docsFormValues = {
+    docs: getInitialValue('jsonArray'),
+  } as IngestDocsFormValues;
+  const docsFormSchema = yup.object({
+    docs: getFieldSchema({
+      type: 'jsonArray',
+    } as IConfigField),
+  });
+
+  // persist standalone values. update when there is changes detected to the parent form
+  const [tempDocs, setTempDocs] = useState<string>('[]');
+  useEffect(() => {
+    setTempDocs(getIn(values, 'ingest.docs'));
+  }, [getIn(values, 'ingest.docs')]);
+
+  function onClose() {
+    props.setIsModalOpen(false);
+  }
+
+  function onUpdate() {
+    // 1. Update the form with the temp docs
+    setFieldValue('ingest.docs', tempDocs);
+
+    props.setIsModalOpen(false);
+  }
 
   return (
-    <EuiModal
-      onClose={() => props.setIsModalOpen(false)}
-      style={{ width: '70vw' }}
+    <Formik
+      enableReinitialize={false}
+      initialValues={docsFormValues}
+      validationSchema={docsFormSchema}
+      onSubmit={(values) => {}}
+      validate={(values) => {}}
     >
-      <EuiModalHeader>
-        <EuiModalHeaderTitle>
-          <p>{`Import data`}</p>
-        </EuiModalHeaderTitle>
-      </EuiModalHeader>
-      <EuiModalBody>
-        <>
-          <EuiFilterGroup>
-            <EuiSmallFilterButton
-              id={SOURCE_OPTIONS.MANUAL}
-              hasActiveFilters={props.selectedOption === SOURCE_OPTIONS.MANUAL}
-              onClick={() => props.setSelectedOption(SOURCE_OPTIONS.MANUAL)}
-              data-testid="manualEditSourceDataButton"
-            >
-              Manual
-            </EuiSmallFilterButton>
-            <EuiSmallFilterButton
-              id={SOURCE_OPTIONS.UPLOAD}
-              hasActiveFilters={props.selectedOption === SOURCE_OPTIONS.UPLOAD}
-              onClick={() => props.setSelectedOption(SOURCE_OPTIONS.UPLOAD)}
-              data-testid="uploadSourceDataButton"
-            >
-              Upload
-            </EuiSmallFilterButton>
-            <EuiSmallFilterButton
-              id={SOURCE_OPTIONS.EXISTING_INDEX}
-              hasActiveFilters={
-                props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX
-              }
-              onClick={() =>
-                props.setSelectedOption(SOURCE_OPTIONS.EXISTING_INDEX)
-              }
-              data-testid="selectIndexSourceDataButton"
-            >
-              Existing index
-            </EuiSmallFilterButton>
-          </EuiFilterGroup>
-          <EuiSpacer size="m" />
-          {props.selectedOption === SOURCE_OPTIONS.UPLOAD && (
-            <>
-              <EuiCompressedFilePicker
-                accept="application/json"
-                multiple={false}
-                initialPromptText="Upload file"
-                onChange={(files) => {
-                  if (files && files.length > 0) {
-                    fileReader.readAsText(files[0]);
-                  }
-                }}
-                display="default"
-              />
-              <EuiSpacer size="s" />
-            </>
-          )}
-          {props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX && (
-            <>
-              <EuiText color="subdued" size="s">
-                Up to 5 sample documents will be automatically populated.
-              </EuiText>
-              <EuiSpacer size="s" />
-              <EuiCompressedSuperSelect
-                options={Object.values(indices).map(
-                  (option) =>
-                    ({
-                      value: option.name,
-                      inputDisplay: <EuiText size="s">{option.name}</EuiText>,
-                      disabled: false,
-                    } as EuiSuperSelectOption<string>)
+      {(formikProps) => {
+        // internal hook to loop back and update tempDocs when form changes are detected
+        useEffect(() => {
+          setTempDocs(getIn(formikProps.values, 'docs'));
+        }, [getIn(formikProps.values, 'docs')]);
+
+        return (
+          <EuiModal onClose={() => onClose()} style={{ width: '70vw' }}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <p>{`Import data`}</p>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody>
+              <>
+                <EuiFilterGroup>
+                  <EuiSmallFilterButton
+                    id={SOURCE_OPTIONS.MANUAL}
+                    hasActiveFilters={
+                      props.selectedOption === SOURCE_OPTIONS.MANUAL
+                    }
+                    onClick={() =>
+                      props.setSelectedOption(SOURCE_OPTIONS.MANUAL)
+                    }
+                    data-testid="manualEditSourceDataButton"
+                  >
+                    Manual
+                  </EuiSmallFilterButton>
+                  <EuiSmallFilterButton
+                    id={SOURCE_OPTIONS.UPLOAD}
+                    hasActiveFilters={
+                      props.selectedOption === SOURCE_OPTIONS.UPLOAD
+                    }
+                    onClick={() =>
+                      props.setSelectedOption(SOURCE_OPTIONS.UPLOAD)
+                    }
+                    data-testid="uploadSourceDataButton"
+                  >
+                    Upload
+                  </EuiSmallFilterButton>
+                  <EuiSmallFilterButton
+                    id={SOURCE_OPTIONS.EXISTING_INDEX}
+                    hasActiveFilters={
+                      props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX
+                    }
+                    onClick={() =>
+                      props.setSelectedOption(SOURCE_OPTIONS.EXISTING_INDEX)
+                    }
+                    data-testid="selectIndexSourceDataButton"
+                  >
+                    Existing index
+                  </EuiSmallFilterButton>
+                </EuiFilterGroup>
+                <EuiSpacer size="m" />
+                {props.selectedOption === SOURCE_OPTIONS.UPLOAD && (
+                  <>
+                    <EuiCompressedFilePicker
+                      accept="application/json"
+                      multiple={false}
+                      initialPromptText="Upload file"
+                      onChange={(files) => {
+                        if (files && files.length > 0) {
+                          // create a custom filereader to update form with file values
+                          const fileReader = new FileReader();
+                          fileReader.onload = (e) => {
+                            if (e.target) {
+                              formikProps.setFieldValue(
+                                'docs',
+                                e.target.result as string
+                              );
+                            }
+                          };
+                          fileReader.readAsText(files[0]);
+                        }
+                      }}
+                      display="default"
+                    />
+                    <EuiSpacer size="s" />
+                  </>
                 )}
-                valueOfSelected={props.selectedIndex}
-                onChange={(option) => {
-                  props.setSelectedIndex(option);
-                }}
-                isInvalid={false}
-              />
-              <EuiSpacer size="xs" />
-            </>
-          )}
-          <JsonField
-            label="Documents to be imported"
-            fieldPath={'ingest.docs'}
-            helpText="Documents should be formatted as a valid JSON array."
-            editorHeight="25vh"
-            readOnly={false}
-          />
-        </>
-      </EuiModalBody>
-      <EuiModalFooter>
-        <EuiSmallButton
-          onClick={() => props.setIsModalOpen(false)}
-          fill={false}
-          color="primary"
-          data-testid="closeSourceDataButton"
-        >
-          Close
-        </EuiSmallButton>
-      </EuiModalFooter>
-    </EuiModal>
+                {props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX && (
+                  <>
+                    <EuiText color="subdued" size="s">
+                      Up to 5 sample documents will be automatically populated.
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiCompressedSuperSelect
+                      options={Object.values(indices).map(
+                        (option) =>
+                          ({
+                            value: option.name,
+                            inputDisplay: (
+                              <EuiText size="s">{option.name}</EuiText>
+                            ),
+                            disabled: false,
+                          } as EuiSuperSelectOption<string>)
+                      )}
+                      valueOfSelected={props.selectedIndex}
+                      onChange={(option) => {
+                        props.setSelectedIndex(option);
+                      }}
+                      isInvalid={false}
+                    />
+                    <EuiSpacer size="xs" />
+                  </>
+                )}
+                <JsonField
+                  label="Documents to be imported"
+                  fieldPath={'docs'}
+                  helpText="Documents should be formatted as a valid JSON array."
+                  editorHeight="25vh"
+                  readOnly={false}
+                />
+              </>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiSmallButton
+                onClick={() => onClose()}
+                fill={false}
+                color="primary"
+                data-testid="cancelSourceDataButton"
+              >
+                Cancel
+              </EuiSmallButton>
+              <EuiSmallButton
+                onClick={() => onUpdate()}
+                fill={true}
+                color="primary"
+                data-testid="updateSourceDataButton"
+              >
+                Update
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        );
+      }}
+    </Formik>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -300,7 +300,7 @@ export function SourceDataModal(props: SourceDataProps) {
                 onClick={() => onClose()}
                 fill={false}
                 color="primary"
-                data-testid="cancelSourceDataButton"
+                data-testid="closeSourceDataButton"
               >
                 Cancel
               </EuiSmallButton>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -11,7 +11,7 @@ import {
   EuiLink,
   EuiText,
 } from '@elastic/eui';
-import { WorkspaceFormValues, customStringify } from '../../../../../common';
+import { WorkflowFormValues, customStringify } from '../../../../../common';
 import { camelCaseToTitleString } from '../../../../utils';
 
 interface JsonFieldProps {
@@ -31,7 +31,7 @@ interface JsonFieldProps {
 export function JsonField(props: JsonFieldProps) {
   const validate = props.validate !== undefined ? props.validate : true;
 
-  const { errors, touched, values } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched, values } = useFormikContext<WorkflowFormValues>();
 
   // temp input state. only format when users click out of the code editor
   const [jsonStr, setJsonStr] = useState<string>('{}');

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -18,7 +18,7 @@ import {
 } from '@elastic/eui';
 import {
   MODEL_STATE,
-  WorkspaceFormValues,
+  WorkflowFormValues,
   ModelFormValue,
   IConfigField,
   ML_CHOOSE_MODEL_LINK,
@@ -46,7 +46,7 @@ export function ModelField(props: ModelFieldProps) {
   // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
   const models = useSelector((state: AppState) => state.ml.models);
 
-  const { errors, touched, values } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched, values } = useFormikContext<WorkflowFormValues>();
 
   // Deployed models state
   const [deployedModels, setDeployedModels] = useState<ModelItem[]>([]);

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/number_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/number_field.tsx
@@ -11,7 +11,7 @@ import {
   EuiText,
   EuiCompressedFieldNumber,
 } from '@elastic/eui';
-import { WorkspaceFormValues } from '../../../../../common';
+import { WorkflowFormValues } from '../../../../../common';
 import { camelCaseToTitleString, getInitialValue } from '../../../../utils';
 
 interface NumberFieldProps {
@@ -27,7 +27,7 @@ interface NumberFieldProps {
  * An input field for a component where users input numbers
  */
 export function NumberField(props: NumberFieldProps) {
-  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched } = useFormikContext<WorkflowFormValues>();
 
   return (
     <Field name={props.fieldPath}>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -11,7 +11,7 @@ import {
   EuiSuperSelectOption,
   EuiText,
 } from '@elastic/eui';
-import { WorkspaceFormValues, IConfigField } from '../../../../../common';
+import { WorkflowFormValues, IConfigField } from '../../../../../common';
 import { camelCaseToTitleString } from '../../../../utils';
 
 interface SelectFieldProps {
@@ -24,7 +24,7 @@ interface SelectFieldProps {
  * A generic select field from a list of preconfigured options
  */
 export function SelectField(props: SelectFieldProps) {
-  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched } = useFormikContext<WorkflowFormValues>();
 
   return (
     <Field name={props.fieldPath}>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
 import { get, isEmpty } from 'lodash';
 import { EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { WorkspaceFormValues } from '../../../../../common';
+import { WorkflowFormValues } from '../../../../../common';
 
 interface SelectWithCustomOptionsProps {
   fieldPath: string;
@@ -20,7 +20,7 @@ interface SelectWithCustomOptionsProps {
  */
 export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
   const { values, setFieldTouched, setFieldValue } = useFormikContext<
-    WorkspaceFormValues
+    WorkflowFormValues
   >();
 
   // selected option state

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -11,7 +11,7 @@ import {
   EuiLink,
   EuiText,
 } from '@elastic/eui';
-import { WorkspaceFormValues } from '../../../../../common';
+import { WorkflowFormValues } from '../../../../../common';
 import { getInitialValue } from '../../../../utils';
 
 interface TextFieldProps {
@@ -28,7 +28,7 @@ interface TextFieldProps {
  * An input field for a component where users input plaintext
  */
 export function TextField(props: TextFieldProps) {
-  const { errors, touched } = useFormikContext<WorkspaceFormValues>();
+  const { errors, touched } = useFormikContext<WorkflowFormValues>();
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -103,7 +103,7 @@ function processorsConfigToSchema(processorsConfig: ProcessorsConfig): Schema {
  **************** Yup (validation) utils **********************
  */
 
-function getFieldSchema(
+export function getFieldSchema(
   field: IConfigField,
   optional: boolean = false
 ): Schema {


### PR DESCRIPTION
### Description

This PR decouples the form state for configuring source data in the "Edit source data" modal. Instead of using the global, parent form, we create a new sub-form to persist interim form state. The parent form is only updated, if a user explicitly clicks "Update", and if there are no validation errors. Following PRs will follow this same pattern for other form-based modals, including input/output transforms, and query editor modals.

Details:
- moved the modal into standalone `SourceDataModal` component. Here, we create a new `Formik` component, and persist some custom hooks etc. within it, so we can listen on changes _only_ to the sub-form values.
- refactors state vars and state handling from `SourceData` -> `SourceDataModal` as much as possible
- add new types for the sub-form
- removes leftover legacy `WorkspaceFormValues` -> `WorkflowFormValues` for type safety

Demo video:

[screen-capture (9).webm](https://github.com/user-attachments/assets/b37f3609-7391-4e3f-b96d-0ea837a57f2d)

### Issues resolved
Makes progress on #446 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
