### PR TITLE
Removing the SideNav within the flow framework dashboards

### DIFF
--- a/public/app.tsx
+++ b/public/app.tsx
@@ -8,15 +8,9 @@ import {
   Route,
   RouteComponentProps,
   Switch,
-  useLocation,
 } from 'react-router-dom';
-import {
-  EuiPageSideBar,
-  EuiSideNav,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
-import { Navigation, APP_PATH } from './utils';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { APP_PATH } from './utils';
 import {
   Workflows,
   WorkflowDetail,
@@ -24,52 +18,17 @@ import {
   WorkflowsRouterProps,
 } from './pages';
 import { MountPoint } from '../../../src/core/public';
-import {
-  constructHrefWithDataSourceId,
-  getDataSourceFromURL,
-} from './utils/utils';
 
 // styling
 import './global-styles.scss';
 
 interface Props extends RouteComponentProps {
   setHeaderActionMenu: (menuMount?: MountPoint) => void;
-  hideInAppSideNavBar: boolean;
 }
 
 export const FlowFrameworkDashboardsApp = (props: Props) => {
-  const { setHeaderActionMenu, hideInAppSideNavBar } = props;
-  const location = useLocation();
-  const queryParams = getDataSourceFromURL(location);
-  const dataSourceId = queryParams.dataSourceId;
-  const sidebar = (
-    <EuiPageSideBar
-      style={{ minWidth: 190 }}
-      hidden={hideInAppSideNavBar}
-      paddingSize="l"
-    >
-      <EuiSideNav
-        style={{ width: 190 }}
-        items={[
-          {
-            name: Navigation.PluginName,
-            id: 0,
-            items: [
-              {
-                name: Navigation.Workflows,
-                id: 1,
-                href: constructHrefWithDataSourceId(
-                  APP_PATH.WORKFLOWS,
-                  dataSourceId
-                ),
-                isSelected: props.location.pathname === APP_PATH.WORKFLOWS,
-              },
-            ],
-          },
-        ]}
-      />
-    </EuiPageSideBar>
-  );
+  const { setHeaderActionMenu } = props;
+
 
   // Render the application DOM.
   return (
@@ -78,7 +37,6 @@ export const FlowFrameworkDashboardsApp = (props: Props) => {
       gutterSize="none"
       className="stretch-relative"
     >
-      <EuiFlexItem grow={false}>{sidebar}</EuiFlexItem>
       <EuiFlexItem>
         <Switch>
           <Route

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -42,7 +42,6 @@ export class FlowFrameworkDashboardsPlugin
     core: CoreSetup,
     plugins: any
   ): FlowFrameworkDashboardsPluginSetup {
-    const hideInAppSideNavBar = core.chrome.navGroup.getNavGroupEnabled();
     // Register the plugin in the side navigation
     core.application.register({
       id: PLUGIN_ID,
@@ -62,7 +61,7 @@ export class FlowFrameworkDashboardsPlugin
         setCore(coreStart);
         setHeaderActionMenu(params.setHeaderActionMenu);
         setRouteService(routeServices);
-        return renderApp(coreStart, params, hideInAppSideNavBar);
+        return renderApp(coreStart, params);
       },
     });
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [

--- a/public/render_app.tsx
+++ b/public/render_app.tsx
@@ -14,11 +14,7 @@ import { store } from './store';
 // styling
 import './global-styles.scss';
 
-export const renderApp = (
-  coreStart: CoreStart,
-  params: AppMountParameters,
-  hideInAppSideNavBar: boolean
-) => {
+export const renderApp = (coreStart: CoreStart, params: AppMountParameters) => {
   // This is so our base element stretches to fit the entire webpage
   params.element.className = 'stretch-absolute';
   ReactDOM.render(
@@ -28,7 +24,6 @@ export const renderApp = (
           render={(props) => (
             <FlowFrameworkDashboardsApp
               setHeaderActionMenu={params.setHeaderActionMenu}
-              hideInAppSideNavBar={hideInAppSideNavBar}
               {...props}
             />
           )}


### PR DESCRIPTION
### Description

- Removing the SideNav within the flow framework dashboards as discussed in  https://github.com/opensearch-project/dashboards-flow-framework/issues/444


**OldHomePage:**

<img width="1338" alt="Screenshot 2024-10-30 at 12 10 33 PM" src="https://github.com/user-attachments/assets/c1075d69-ffdd-48e4-a189-5922fd8e3cec">
<img width="1338" alt="Screenshot 2024-10-30 at 12 10 45 PM" src="https://github.com/user-attachments/assets/e6c9bb6b-61f9-4344-a1ef-7358c0d93a22">

**NewHomePage:**

<img width="1345" alt="Screenshot 2024-10-30 at 12 11 36 PM" src="https://github.com/user-attachments/assets/fe32d8a1-87b5-433e-916e-577505f8a72f">
<img width="1345" alt="Screenshot 2024-10-30 at 12 11 51 PM" src="https://github.com/user-attachments/assets/5585de7c-76cc-4a51-afd2-0c758a26f1b2">


### Issues Resolved

closes #444

### Check List

- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
