### PR TITLE
Refactor processor form components

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -175,14 +175,21 @@ export function MapArrayField(props: MapArrayFieldProps) {
                         {'Configure'}
                       </EuiSmallButton>
                     ) : (
-                      <EuiSmallButtonEmpty
-                        style={{ marginLeft: '-8px', marginTop: '-4px' }}
-                        onClick={() => {
-                          addMap(field.value);
-                        }}
-                      >
-                        {props.addMapButtonText || `(Advanced) Add another map`}
-                      </EuiSmallButtonEmpty>
+                      <EuiPanel grow={true} paddingSize="none">
+                        <EuiFlexItem grow={true} style={{ margin: '0px' }}>
+                          {' '}
+                          <EuiSmallButtonEmpty
+                            iconType="plusInCircle"
+                            iconSide="left"
+                            onClick={() => {
+                              addMap(field.value);
+                            }}
+                          >
+                            {props.addMapButtonText ||
+                              `Add another map (Advanced)`}
+                          </EuiSmallButtonEmpty>
+                        </EuiFlexItem>
+                      </EuiPanel>
                     )}
                   </>
                 </div>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -177,7 +177,6 @@ export function MapArrayField(props: MapArrayFieldProps) {
                     ) : (
                       <EuiPanel grow={true} paddingSize="none">
                         <EuiFlexItem grow={true} style={{ margin: '0px' }}>
-                          {' '}
                           <EuiSmallButtonEmpty
                             iconType="plusInCircle"
                             iconSide="left"

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_array_field.tsx
@@ -37,6 +37,7 @@ interface MapArrayFieldProps {
   valueOptions?: { label: string }[];
   addMapEntryButtonText?: string;
   addMapButtonText?: string;
+  mappingDirection?: 'sortRight' | 'sortLeft' | undefined;
 }
 
 /**
@@ -130,6 +131,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
                               keyOptions={props.keyOptions}
                               valueOptions={props.valueOptions}
                               addEntryButtonText={props.addMapEntryButtonText}
+                              mappingDirection={props.mappingDirection}
                             />
                           </EuiPanel>
                         </EuiAccordion>
@@ -150,6 +152,7 @@ export function MapArrayField(props: MapArrayFieldProps) {
                       keyOptions={props.keyOptions}
                       valueOptions={props.valueOptions}
                       addEntryButtonText={props.addMapEntryButtonText}
+                      mappingDirection={props.mappingDirection}
                     />
                   </EuiPanel>
                   <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -37,6 +37,7 @@ interface MapFieldProps {
   keyOptions?: { label: string }[];
   valueOptions?: { label: string }[];
   addEntryButtonText?: string;
+  mappingDirection?: 'sortRight' | 'sortLeft' | undefined;
 }
 
 // The keys will be more static in general. Give more space for values where users
@@ -163,7 +164,9 @@ export function MapField(props: MapFieldProps) {
                               grow={false}
                               style={{ marginTop: '10px' }}
                             >
-                              <EuiIcon type="sortRight" />
+                              <EuiIcon
+                                type={props.mappingDirection || 'sortRight'}
+                              />
                             </EuiFlexItem>
                           </>
                         </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -12,8 +12,8 @@ import {
   EuiIcon,
   EuiLink,
   EuiText,
-  EuiSmallButton,
   EuiIconTip,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
@@ -240,13 +240,16 @@ export function MapField(props: MapFieldProps) {
               })}
               <EuiFlexItem grow={false}>
                 <div>
-                  <EuiSmallButton
+                  <EuiSmallButtonEmpty
+                    style={{ marginLeft: '-8px', marginTop: '0px' }}
+                    iconType={'plusInCircle'}
+                    iconSide="left"
                     onClick={() => {
                       addMapEntry(field.value);
                     }}
                   >
                     {props.addEntryButtonText || 'Add more'}
-                  </EuiSmallButton>
+                  </EuiSmallButtonEmpty>
                 </div>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -51,9 +51,13 @@ const VALUE_FLEX_RATIO = 6;
  * Allow custom options as a backup/default to ensure flexibility.
  */
 export function MapField(props: MapFieldProps) {
-  const { setFieldValue, setFieldTouched, errors, touched } = useFormikContext<
-    WorkflowFormValues
-  >();
+  const {
+    setFieldValue,
+    setFieldTouched,
+    errors,
+    touched,
+    values,
+  } = useFormikContext<WorkflowFormValues>();
 
   // Adding a map entry to the end of the existing arr
   function addMapEntry(curEntries: MapFormValue): void {
@@ -140,7 +144,28 @@ export function MapField(props: MapFieldProps) {
                           <>
                             <EuiFlexItem>
                               <>
-                                {!isEmpty(props.keyOptions) ? (
+                                {/**
+                                 * We determine if there is an interface based on if there are key options or not,
+                                 * as the options would be derived from the underlying interface.
+                                 * And if so, these values should be static.
+                                 * So, we only display the static text with no mechanism to change it's value.
+                                 * Note we still allow more entries, if a user wants to override / add custom
+                                 * keys if there is some gaps in the model interface.
+                                 */}
+                                {!isEmpty(props.keyOptions) &&
+                                !isEmpty(
+                                  getIn(values, `${props.fieldPath}.${idx}.key`)
+                                ) ? (
+                                  <EuiText
+                                    size="s"
+                                    style={{ marginTop: '4px' }}
+                                  >
+                                    {getIn(
+                                      values,
+                                      `${props.fieldPath}.${idx}.key`
+                                    )}
+                                  </EuiText>
+                                ) : !isEmpty(props.keyOptions) ? (
                                   <SelectWithCustomOptions
                                     fieldPath={`${props.fieldPath}.${idx}.key`}
                                     options={props.keyOptions as any[]}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -381,6 +381,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             }
             addMapEntryButtonText="Add input"
             addMapButtonText="(Advanced) Add input group"
+            mappingDirection="sortRight"
           />
           <EuiSpacer size="l" />
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
@@ -434,6 +435,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             }
             addMapEntryButtonText="Add output"
             addMapButtonText="(Advanced) Add output group"
+            mappingDirection="sortLeft"
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -29,6 +29,9 @@ import {
   ModelInterface,
   IndexMappings,
   PROMPT_FIELD,
+  MapArrayFormValue,
+  MapEntry,
+  MapFormValue,
 } from '../../../../../common';
 import { MapArrayField, ModelField } from '../input_fields';
 import {
@@ -132,9 +135,27 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   // 1: update model interface states
   // 2. clear out any persisted input_map/output_map form values, as those would now be invalid
   function onModelChange(modelId: string) {
-    setModelInterface(models[modelId]?.interface);
-    setFieldValue(inputMapFieldPath, []);
-    setFieldValue(outputMapFieldPath, []);
+    const newModelInterface = models[modelId]?.interface;
+    setModelInterface(newModelInterface);
+    const modelInputsAsForm = [
+      parseModelInputs(newModelInterface).map((modelInput) => {
+        return {
+          key: modelInput.label,
+          value: '',
+        } as MapEntry;
+      }) as MapFormValue,
+    ] as MapArrayFormValue;
+    const modelOutputsAsForm = [
+      parseModelOutputs(newModelInterface).map((modelOutput) => {
+        return {
+          key: modelOutput.label,
+          value: '',
+        } as MapEntry;
+      }) as MapFormValue,
+    ] as MapArrayFormValue;
+
+    setFieldValue(inputMapFieldPath, modelInputsAsForm);
+    setFieldValue(outputMapFieldPath, modelOutputsAsForm);
     setFieldTouched(inputMapFieldPath, false);
     setFieldTouched(outputMapFieldPath, false);
   }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -381,7 +381,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             }
             addMapEntryButtonText="Add input"
             addMapButtonText="(Advanced) Add input group"
-            mappingDirection="sortRight"
+            mappingDirection="sortLeft"
           />
           <EuiSpacer size="l" />
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
@@ -416,26 +416,26 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             fieldPath={outputMapFieldPath}
             helpText={`An array specifying how to map the model’s output to new document fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
             root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-            keyTitle={
-              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                ? 'Query field'
-                : 'New document field'
-            }
-            keyPlaceholder={
-              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                ? 'Specify a query field'
-                : 'Define a document field'
-            }
-            valueTitle="Name"
-            valuePlaceholder="Name"
-            valueOptions={
+            keyTitle="Name"
+            keyPlaceholder="Name"
+            keyOptions={
               fullResponsePath
                 ? undefined
                 : parseModelOutputs(modelInterface, false)
             }
+            valueTitle={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Query field'
+                : 'New document field'
+            }
+            valuePlaceholder={
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'Specify a query field'
+                : 'Define a document field'
+            }
             addMapEntryButtonText="Add output"
             addMapButtonText="(Advanced) Add output group"
-            mappingDirection="sortLeft"
+            mappingDirection="sortRight"
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -401,7 +401,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : indexMappingFields
             }
             addMapEntryButtonText="Add input"
-            addMapButtonText="(Advanced) Add input group"
+            addMapButtonText="Add input group (Advanced)"
             mappingDirection="sortLeft"
           />
           <EuiSpacer size="l" />
@@ -455,7 +455,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : 'Define a document field'
             }
             addMapEntryButtonText="Add output"
-            addMapButtonText="(Advanced) Add output group"
+            addMapButtonText="Add output group (Advanced)"
             mappingDirection="sortRight"
           />
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -323,6 +323,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
             }}
             addMapEntryButtonText="Add input"
             addMapButtonText="(Advanced) Add input group"
+            mappingDirection="sortRight"
           />
         );
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -322,7 +322,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
               }
             }}
             addMapEntryButtonText="Add input"
-            addMapButtonText="(Advanced) Add input group"
+            addMapButtonText="Add input group (Advanced)"
             mappingDirection="sortLeft"
           />
         );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -323,7 +323,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
             }}
             addMapEntryButtonText="Add input"
             addMapButtonText="(Advanced) Add input group"
-            mappingDirection="sortRight"
+            mappingDirection="sortLeft"
           />
         );
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -248,6 +248,7 @@ root object selector "${JSONPATH_ROOT_SELECTOR}"`}
             }}
             addMapEntryButtonText="Add output"
             addMapButtonText="(Advanced) Add output group"
+            mappingDirection="sortLeft"
           />
         );
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -247,7 +247,7 @@ root object selector "${JSONPATH_ROOT_SELECTOR}"`}
               }
             }}
             addMapEntryButtonText="Add output"
-            addMapButtonText="(Advanced) Add output group"
+            addMapButtonText="Add output group (Advanced)"
             mappingDirection="sortRight"
           />
         );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -215,22 +215,22 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
             fieldPath={'output_map'}
             helpText={`An array specifying how to map the model’s output to new fields. Dot notation is used by default. To explicitly use JSONPath, please ensure to prepend with the
 root object selector "${JSONPATH_ROOT_SELECTOR}"`}
-            keyTitle={
+            keyTitle="Name"
+            keyPlaceholder="Name"
+            keyOptions={
+              tempFullResponsePath
+                ? undefined
+                : parseModelOutputs(props.modelInterface, false)
+            }
+            valueTitle={
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'Query field'
                 : 'New document field'
             }
-            keyPlaceholder={
+            valuePlaceholder={
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'Specify a query field'
                 : 'Define a document field'
-            }
-            valueTitle="Name"
-            valuePlaceholder="Name"
-            valueOptions={
-              tempFullResponsePath
-                ? undefined
-                : parseModelOutputs(props.modelInterface, false)
             }
             // If the map we are adding is the first one, populate the selected option to index 0
             onMapAdd={(curArray) => {
@@ -248,7 +248,7 @@ root object selector "${JSONPATH_ROOT_SELECTOR}"`}
             }}
             addMapEntryButtonText="Add output"
             addMapButtonText="(Advanced) Add output group"
-            mappingDirection="sortLeft"
+            mappingDirection="sortRight"
           />
         );
 

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import {
-  EuiSmallButton,
+  EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiContextMenu,
   EuiFlexGroup,
@@ -184,131 +184,141 @@ export function ProcessorsList(props: ProcessorsListProps) {
         );
       })}
       <EuiSpacer size="s" />
-      <EuiFlexItem grow={false}>
-        <div>
-          <EuiPopover
-            button={
-              <EuiSmallButton
-                iconType="arrowDown"
-                iconSide="right"
-                onClick={() => {
-                  setPopover(!isPopoverOpen);
-                }}
-                data-testid="addProcessorButton"
-              >
-                {processors.length > 0
-                  ? 'Add another processor'
-                  : 'Add processor'}
-              </EuiSmallButton>
-            }
-            isOpen={isPopoverOpen}
-            closePopover={closePopover}
-            panelPaddingSize="none"
-            anchorPosition="downLeft"
+      <EuiFlexItem>
+        <EuiPanel paddingSize="s" grow={true}>
+          <EuiFlexGroup
+            gutterSize="none"
+            alignItems="center"
+            justifyContent="center"
           >
-            <EuiContextMenu
-              size="s"
-              initialPanelId={PANEL_ID}
-              panels={[
-                {
-                  id: PANEL_ID,
-                  title: 'PROCESSORS',
-                  items:
-                    props.context === PROCESSOR_CONTEXT.INGEST
-                      ? [
-                          {
-                            name: 'ML Inference Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(new MLIngestProcessor().toObj());
-                            },
-                          },
-                          {
-                            name: 'Split Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(new SplitIngestProcessor().toObj());
-                            },
-                          },
-                          {
-                            name: 'Sort Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(new SortIngestProcessor().toObj());
-                            },
-                          },
-                          {
-                            name: 'Text Chunking Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new TextChunkingIngestProcessor().toObj()
-                              );
-                            },
-                          },
-                        ]
-                      : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                      ? [
-                          {
-                            name: 'ML Inference Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new MLSearchRequestProcessor().toObj()
-                              );
-                            },
-                          },
-                        ]
-                      : [
-                          {
-                            name: 'ML Inference Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new MLSearchResponseProcessor().toObj()
-                              );
-                            },
-                          },
-                          {
-                            name: 'Split Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new SplitSearchResponseProcessor().toObj()
-                              );
-                            },
-                          },
-                          {
-                            name: 'Sort Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new SortSearchResponseProcessor().toObj()
-                              );
-                            },
-                          },
-                          {
-                            name: 'Normalization Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(
-                                new NormalizationProcessor().toObj()
-                              );
-                            },
-                          },
-                          {
-                            name: 'Collapse Processor',
-                            onClick: () => {
-                              closePopover();
-                              addProcessor(new CollapseProcessor().toObj());
-                            },
-                          },
-                        ],
-                },
-              ]}
-            />
-          </EuiPopover>
-        </div>
+            <EuiFlexItem grow={false}>
+              <EuiPopover
+                button={
+                  <EuiSmallButtonEmpty
+                    iconType="plusInCircle"
+                    iconSide="left"
+                    onClick={() => {
+                      setPopover(!isPopoverOpen);
+                    }}
+                    data-testid="addProcessorButton"
+                  >
+                    {`Add processor`}
+                  </EuiSmallButtonEmpty>
+                }
+                isOpen={isPopoverOpen}
+                closePopover={closePopover}
+                panelPaddingSize="none"
+                anchorPosition="downLeft"
+              >
+                <EuiContextMenu
+                  size="s"
+                  initialPanelId={PANEL_ID}
+                  panels={[
+                    {
+                      id: PANEL_ID,
+                      title: 'PROCESSORS',
+                      items:
+                        props.context === PROCESSOR_CONTEXT.INGEST
+                          ? [
+                              {
+                                name: 'ML Inference Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(new MLIngestProcessor().toObj());
+                                },
+                              },
+                              {
+                                name: 'Split Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new SplitIngestProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Sort Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new SortIngestProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Text Chunking Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new TextChunkingIngestProcessor().toObj()
+                                  );
+                                },
+                              },
+                            ]
+                          : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                          ? [
+                              {
+                                name: 'ML Inference Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new MLSearchRequestProcessor().toObj()
+                                  );
+                                },
+                              },
+                            ]
+                          : [
+                              {
+                                name: 'ML Inference Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new MLSearchResponseProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Split Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new SplitSearchResponseProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Sort Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new SortSearchResponseProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Normalization Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(
+                                    new NormalizationProcessor().toObj()
+                                  );
+                                },
+                              },
+                              {
+                                name: 'Collapse Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(new CollapseProcessor().toObj());
+                                },
+                              },
+                            ],
+                    },
+                  ]}
+                />
+              </EuiPopover>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -153,7 +153,6 @@ export function ProcessorsList(props: ProcessorsListProps) {
                 buttonContent={`${processor.name || 'Processor'}`}
                 extraAction={
                   <EuiSmallButtonIcon
-                    style={{ marginTop: '8px' }}
                     iconType={'trash'}
                     color="danger"
                     aria-label="Delete"

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -140,47 +140,50 @@ export function ProcessorsList(props: ProcessorsListProps) {
   }
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       {processors.map((processor: IProcessorConfig, processorIndex) => {
         return (
           <EuiFlexItem key={processorIndex}>
-            <EuiAccordion
-              initialIsOpen={
-                processorAdded && processorIndex === processors.length - 1
-              }
-              id={`accordion${processor.id}`}
-              buttonContent={`${processor.name || 'Processor'}`}
-              extraAction={
-                <EuiSmallButtonIcon
-                  style={{ marginTop: '8px' }}
-                  iconType={'trash'}
-                  color="danger"
-                  aria-label="Delete"
-                  onClick={() => {
-                    deleteProcessor(processor.id);
-                  }}
-                />
-              }
-            >
-              <EuiSpacer size="s" />
-              <EuiPanel>
-                <ProcessorInputs
-                  uiConfig={props.uiConfig}
-                  config={processor}
-                  baseConfigPath={
-                    props.context === PROCESSOR_CONTEXT.INGEST
-                      ? 'ingest.enrich'
-                      : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-                      ? 'search.enrichRequest'
-                      : 'search.enrichResponse'
-                  }
-                  context={props.context}
-                />
-              </EuiPanel>
-            </EuiAccordion>
+            <EuiPanel paddingSize="s">
+              <EuiAccordion
+                initialIsOpen={
+                  processorAdded && processorIndex === processors.length - 1
+                }
+                id={`accordion${processor.id}`}
+                buttonContent={`${processor.name || 'Processor'}`}
+                extraAction={
+                  <EuiSmallButtonIcon
+                    style={{ marginTop: '8px' }}
+                    iconType={'trash'}
+                    color="danger"
+                    aria-label="Delete"
+                    onClick={() => {
+                      deleteProcessor(processor.id);
+                    }}
+                  />
+                }
+              >
+                <EuiSpacer size="s" />
+                <EuiFlexItem style={{ paddingLeft: '28px' }}>
+                  <ProcessorInputs
+                    uiConfig={props.uiConfig}
+                    config={processor}
+                    baseConfigPath={
+                      props.context === PROCESSOR_CONTEXT.INGEST
+                        ? 'ingest.enrich'
+                        : props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                        ? 'search.enrichRequest'
+                        : 'search.enrichResponse'
+                    }
+                    context={props.context}
+                  />
+                </EuiFlexItem>
+              </EuiAccordion>
+            </EuiPanel>
           </EuiFlexItem>
         );
       })}
+      <EuiSpacer size="s" />
       <EuiFlexItem grow={false}>
         <div>
           <EuiPopover

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -190,7 +190,7 @@ export function processorConfigsToTemplateProcessors(
         if (output_map?.length > 0) {
           processor.ml_inference.output_map = output_map.map(
             (mapFormValue: MapFormValue) =>
-              mergeMapIntoSingleObj(mapFormValue, true) // we reverse the form inputs, so reverse back when converting back to the underlying template configuration
+              mergeMapIntoSingleObj(mapFormValue, true) // we reverse the form inputs for the output map, so reverse back when converting back to the underlying template configuration
           );
         }
 

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -189,7 +189,8 @@ export function processorConfigsToTemplateProcessors(
 
         if (output_map?.length > 0) {
           processor.ml_inference.output_map = output_map.map(
-            (mapFormValue: MapFormValue) => mergeMapIntoSingleObj(mapFormValue)
+            (mapFormValue: MapFormValue) =>
+              mergeMapIntoSingleObj(mapFormValue, true) // we reverse the form inputs, so reverse back when converting back to the underlying template configuration
           );
         }
 
@@ -420,13 +421,21 @@ export function reduceToTemplate(workflow: Workflow): WorkflowTemplate {
 // Helper fn to merge the form map (an arr of objs) into a single obj, such that each key
 // is an obj property, and each value is a property value. Used to format into the
 // expected inputs for input_maps and output_maps of the ML inference processors.
-function mergeMapIntoSingleObj(mapFormValue: MapFormValue): {} {
+function mergeMapIntoSingleObj(
+  mapFormValue: MapFormValue,
+  reverse: boolean = false
+): {} {
   let curMap = {} as MapEntry;
   mapFormValue.forEach((mapEntry) => {
-    curMap = {
-      ...curMap,
-      [mapEntry.key]: mapEntry.value,
-    };
+    curMap = reverse
+      ? {
+          ...curMap,
+          [mapEntry.value]: mapEntry.key,
+        }
+      : {
+          ...curMap,
+          [mapEntry.key]: mapEntry.value,
+        };
   });
   return curMap;
 }


### PR DESCRIPTION
### Description

Updates and refactors several components related to the processor forms.

Specifically:
- wraps each processor accordion in a panel
- wraps the add processor button in a panel
- several ML processor improvements: 1/ autopopulating the model inputs / outputs if there is a defined interface, 2/ swapping the k/v entries for the output map for readability purpose, 3/ making the model inputs/outputs static if there is a defined interface, and 4/ updates to the buttons (add input/output, add input/output group) for consistency with other button changes
- updates the template conversion helper fn. Since we swap the keys/values for the output map in the form, we need to swap back when creating the underlying processor config.

Demo video showcasing the form updates:

[screen-capture (15).webm](https://github.com/user-attachments/assets/f051d5d8-3ef0-4470-8a5b-52f04e816186)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
