### PR TITLE
Warn users on browser refresh if unsaved changes

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -195,6 +195,23 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
       ? ingestSaveButtonDisabled
       : searchSaveButtonDisabled;
 
+  // Add warning when exiting with unsaved changes
+  function alertFn(e: BeforeUnloadEvent) {
+    e.preventDefault();
+  }
+
+  // Hook for warning of unsaved changes if a browser refresh is detected
+  useEffect(() => {
+    if (!saveDisabled) {
+      window.addEventListener('beforeunload', alertFn);
+    } else {
+      window.removeEventListener('beforeunload', alertFn);
+    }
+    return () => {
+      window.removeEventListener('beforeunload', alertFn);
+    };
+  }, [saveDisabled]);
+
   // Utility fn to update the workflow UI config only, based on the current form values.
   // A get workflow API call is subsequently run to fetch the updated state.
   async function updateWorkflowUiConfig() {

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -160,7 +160,6 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                 history.replace(
                   constructUrlWithParams(
                     APP_PATH.WORKFLOWS,
-
                     workflow.id,
                     dataSourceId
                   )


### PR DESCRIPTION
### Description

Use browser-native popups to warn users of unsaved changes when refreshing. Adds a basic hook to add/remove event listeners when the component is unloaded (triggered on refresh), and if `saveDisabled` is `false`, indicating there are unsaved changes.

### Issues Resolved

Makes progress on #469 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
