### PR TITLE
Onboard rerank by field processor

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -127,6 +127,7 @@ export enum PROCESSOR_TYPE {
   TEXT_CHUNKING = 'text_chunking',
   NORMALIZATION = 'normalization-processor',
   COLLAPSE = 'collapse',
+  RERANK = 'rerank',
 }
 
 export enum MODEL_TYPE {

--- a/public/configs/search_response_processors/index.ts
+++ b/public/configs/search_response_processors/index.ts
@@ -8,3 +8,4 @@ export * from './split_search_response_processor';
 export * from './sort_search_response_processor';
 export * from './normalization_processor';
 export * from './collapse_processor';
+export * from './rerank_processor';

--- a/public/configs/search_response_processors/rerank_processor.ts
+++ b/public/configs/search_response_processors/rerank_processor.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PROCESSOR_TYPE } from '../../../common';
+import { Processor } from '../processor';
+import { generateId } from '../../utils';
+
+/**
+ * The rerank processor config. Used in search flows.
+ * For now, only supports the by_field type. For details, see
+ * https://opensearch.org/docs/latest/search-plugins/search-pipelines/rerank-processor/#the-by_field-rerank-type
+ */
+export class RerankProcessor extends Processor {
+  constructor() {
+    super();
+    this.id = generateId('rerank_processor');
+    this.type = PROCESSOR_TYPE.RERANK;
+    this.name = 'Rerank Processor';
+    this.fields = [
+      {
+        id: 'target_field',
+        type: 'string',
+      },
+    ];
+    this.optionalFields = [
+      {
+        id: 'remove_target_field',
+        type: 'boolean',
+        value: false,
+      },
+      {
+        id: 'keep_previous_score',
+        type: 'boolean',
+        value: false,
+      },
+      {
+        id: 'tag',
+        type: 'string',
+      },
+      {
+        id: 'description',
+        type: 'string',
+      },
+      {
+        id: 'ignore_failure',
+        type: 'boolean',
+        value: false,
+      },
+    ];
+  }
+}

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -30,6 +30,7 @@ import {
   MLSearchRequestProcessor,
   MLSearchResponseProcessor,
   NormalizationProcessor,
+  RerankProcessor,
   SortIngestProcessor,
   SortSearchResponseProcessor,
   SplitIngestProcessor,
@@ -274,6 +275,13 @@ export function ProcessorsList(props: ProcessorsListProps) {
                                   addProcessor(
                                     new MLSearchResponseProcessor().toObj()
                                   );
+                                },
+                              },
+                              {
+                                name: 'Rerank Processor',
+                                onClick: () => {
+                                  closePopover();
+                                  addProcessor(new RerankProcessor().toObj());
                                 },
                               },
                               {

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -314,6 +314,27 @@ export function processorConfigsToTemplateProcessors(
         });
         break;
       }
+      // Since we only support the by_field type of the rerank processor,
+      // we need to nest the form values within the parent "by_field" field.
+      case PROCESSOR_TYPE.RERANK: {
+        const formValues = processorConfigToFormik(processorConfig);
+        let finalFormValues = {} as FormikValues;
+        Object.keys(formValues).forEach((formKey: string) => {
+          const formValue = formValues[formKey];
+          finalFormValues = optionallyAddToFinalForm(
+            finalFormValues,
+            formKey,
+            formValue
+          );
+        });
+        finalFormValues = {
+          by_field: finalFormValues,
+        };
+        processorsList.push({
+          [processorConfig.type]: finalFormValues,
+        });
+        break;
+      }
       case PROCESSOR_TYPE.SPLIT:
       case PROCESSOR_TYPE.SORT:
       case PROCESSOR_TYPE.COLLAPSE:

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -348,6 +348,14 @@ function processorsConfigToWorkspaceFlow(
         );
         break;
       }
+      case PROCESSOR_TYPE.RERANK: {
+        transformer = new BaseTransformer(
+          processorConfig.name,
+          'Rerank results by a document field',
+          context
+        );
+        break;
+      }
       default: {
         transformer = new BaseTransformer(processorConfig.name, '', context);
         break;


### PR DESCRIPTION
### Description

Onboards the rerank search response processor ([by_field](https://opensearch.org/docs/latest/search-plugins/search-pipelines/rerank-processor#the-by_field-rerank-type) type only). This can be used in conjunction with a reranking model, to re-sort the returned documents by the model's scores, instead of the default BM25 `_score`.

Demo video, showing the basic re-sorting by `review` field instead of `_score`.

[screen-capture (2).webm](https://github.com/user-attachments/assets/014d3bc8-549f-44f9-ae72-aef6c78fdac6)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
