### PR TITLE
Improve consistency of JSONPath parsing & execution across frontend/backend

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -464,6 +464,10 @@ export enum PROCESSOR_CONTEXT {
   SEARCH_REQUEST = 'search_request',
   SEARCH_RESPONSE = 'search_response',
 }
+export enum TRANSFORM_CONTEXT {
+  INPUT = 'input',
+  OUTPUT = 'output',
+}
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -24,7 +24,6 @@ import {
   IConfigField,
   PROCESSOR_CONTEXT,
   WorkflowConfig,
-  JSONPATH_ROOT_SELECTOR,
   WorkflowFormValues,
   ModelInterface,
   IndexMappings,
@@ -41,6 +40,7 @@ import {
 } from './modals';
 import { AppState, getMappings, useAppDispatch } from '../../../../store';
 import {
+  convertArrayAccessorsToBracketNotation,
   formikToPartialPipeline,
   getDataSourceId,
   parseModelInputs,
@@ -186,7 +186,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         setDocFields(
           docObjKeys.map((key) => {
             return {
-              label: key,
+              label: convertArrayAccessorsToBracketNotation(key),
             };
           })
         );
@@ -202,7 +202,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         setQueryFields(
           queryObjKeys.map((key) => {
             return {
-              label: key,
+              label: convertArrayAccessorsToBracketNotation(key),
             };
           })
         );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -40,11 +40,11 @@ import {
 } from './modals';
 import { AppState, getMappings, useAppDispatch } from '../../../../store';
 import {
-  convertArrayAccessorsToBracketNotation,
   formikToPartialPipeline,
   getDataSourceId,
   parseModelInputs,
   parseModelOutputs,
+  sanitizeJSONPath,
 } from '../../../../utils';
 import { ConfigFieldList } from '../config_field_list';
 import { OverrideQueryModal } from './modals/override_query_modal';
@@ -186,7 +186,13 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         setDocFields(
           docObjKeys.map((key) => {
             return {
-              label: convertArrayAccessorsToBracketNotation(key),
+              label:
+                // ingest inputs can handle dot notation, and hence don't need
+                // sanitizing to handle JSONPath edge cases. The other contexts
+                // only support JSONPath, and hence need some post-processing/sanitizing.
+                props.context === PROCESSOR_CONTEXT.INGEST
+                  ? key
+                  : sanitizeJSONPath(key),
             };
           })
         );
@@ -202,7 +208,13 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
         setQueryFields(
           queryObjKeys.map((key) => {
             return {
-              label: convertArrayAccessorsToBracketNotation(key),
+              label:
+                // ingest inputs can handle dot notation, and hence don't need
+                // sanitizing to handle JSONPath edge cases. The other contexts
+                // only support JSONPath, and hence need some post-processing/sanitizing.
+                props.context === PROCESSOR_CONTEXT.INGEST
+                  ? key
+                  : sanitizeJSONPath(key),
             };
           })
         );
@@ -391,7 +403,15 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 ? 'Specify a query field'
                 : 'Define a document field'
             }
-            valueHelpText={`Specify a document field or define JSONPath to transform the document to map to a model input field.`}
+            valueHelpText={`Specify a ${
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'query'
+                : 'document'
+            } field or define JSONPath to transform the ${
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'query'
+                : 'document'
+            } to map to a model input field.`}
             valueOptions={
               props.context === PROCESSOR_CONTEXT.INGEST
                 ? docFields

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -42,6 +42,7 @@ import {
   PROCESSOR_CONTEXT,
   SearchHit,
   SimulateIngestPipelineResponse,
+  TRANSFORM_CONTEXT,
   WorkflowConfig,
   WorkflowFormValues,
   customStringify,
@@ -186,12 +187,14 @@ export function InputTransformModal(props: InputTransformModalProps) {
             ? generateArrayTransform(
                 sampleSourceInput as [],
                 tempInputMap[selectedTransformOption],
-                props.context
+                props.context,
+                TRANSFORM_CONTEXT.INPUT
               )
             : generateTransform(
                 sampleSourceInput,
                 tempInputMap[selectedTransformOption],
-                props.context
+                props.context,
+                TRANSFORM_CONTEXT.INPUT
               );
 
         setTransformedInput(customStringify(output));

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -308,7 +308,15 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 ? 'Specify a query field'
                 : 'Define a document field'
             }
-            valueHelpText={`Specify a document field or define JSONPath to transform the document to map to a model input field.`}
+            valueHelpText={`Specify a ${
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'query'
+                : 'document'
+            } field or define JSONPath to transform the ${
+              props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                ? 'query'
+                : 'document'
+            } to map to a model input field.`}
             valueOptions={props.valueOptions}
             // If the map we are adding is the first one, populate the selected option to index 0
             onMapAdd={(curArray) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -185,11 +185,13 @@ export function InputTransformModal(props: InputTransformModalProps) {
           Array.isArray(sampleSourceInput)
             ? generateArrayTransform(
                 sampleSourceInput as [],
-                tempInputMap[selectedTransformOption]
+                tempInputMap[selectedTransformOption],
+                props.context
               )
             : generateTransform(
                 sampleSourceInput,
-                tempInputMap[selectedTransformOption]
+                tempInputMap[selectedTransformOption],
+                props.context
               );
 
         setTransformedInput(customStringify(output));

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -42,6 +42,7 @@ import {
   SearchHit,
   SearchPipelineConfig,
   SimulateIngestPipelineResponse,
+  TRANSFORM_CONTEXT,
   WorkflowConfig,
   WorkflowFormValues,
   customStringify,
@@ -158,7 +159,8 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
         const output = generateTransform(
           sampleSourceOutput,
           reverseKeysAndValues(tempOutputMap[selectedTransformOption]),
-          props.context
+          props.context,
+          TRANSFORM_CONTEXT.OUTPUT
         );
         setTransformedOutput(customStringify(output));
       } catch {}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/output_transform_modal.tsx
@@ -157,7 +157,8 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
         sampleSourceOutput = JSON.parse(sourceOutput);
         const output = generateTransform(
           sampleSourceOutput,
-          reverseKeysAndValues(tempOutputMap[selectedTransformOption])
+          reverseKeysAndValues(tempOutputMap[selectedTransformOption]),
+          props.context
         );
         setTransformedOutput(customStringify(output));
       } catch {}

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -35,6 +35,7 @@ import {
   SearchPipelineConfig,
 } from '../../common';
 import { processorConfigToFormik } from './config_to_form_utils';
+import { sanitizeJSONPath } from './utils';
 
 /*
  **************** Config -> template utils **********************
@@ -451,11 +452,11 @@ function mergeMapIntoSingleObj(
     curMap = reverse
       ? {
           ...curMap,
-          [mapEntry.value]: mapEntry.key,
+          [sanitizeJSONPath(mapEntry.value)]: sanitizeJSONPath(mapEntry.key),
         }
       : {
           ...curMap,
-          [mapEntry.key]: mapEntry.value,
+          [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(mapEntry.value),
         };
   });
   return curMap;

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -486,10 +486,21 @@ export const getErrorMessageForStepType = (
   }
 };
 
-export function convertArrayAccessorsToBracketNotation(path: string): string {
+// Sanitize the nested keys in a given JSONPath definition.
+// to ensure it works consistently on the frontend & backend. There are several discrepancies
+// between the frontend and the backend packages, such that some
+// scenarios will succeed on the frontend and fail on the backend,
+// or vice versa.
+export function sanitizeJSONPath(path: string): string {
   return path.split('.').reduce((prevValue, curValue, idx) => {
-    return isNaN(parseInt(curValue))
-      ? prevValue + '.' + curValue
-      : prevValue + `[${curValue}]`;
+    // Case 1: accessing array via dot notation. Fails on the backend.
+    if (!isNaN(parseInt(curValue))) {
+      return prevValue + `[${curValue}]`;
+      // Case 2: accessing key with a dash via dot notation. Fails on the frontend.
+    } else if (curValue.includes('-')) {
+      return prevValue + `["${curValue}"]`;
+    } else {
+      return prevValue + '.' + curValue;
+    }
   });
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -473,3 +473,11 @@ export const getErrorMessageForStepType = (
       return '';
   }
 };
+
+export function convertArrayAccessorsToBracketNotation(path: string): string {
+  return path.split('.').reduce((prevValue, curValue, idx) => {
+    return isNaN(parseInt(curValue))
+      ? prevValue + '.' + curValue
+      : prevValue + `[${curValue}]`;
+  });
+}

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -15,6 +15,7 @@ import {
   ModelInterface,
   ModelOutput,
   ModelOutputFormField,
+  PROCESSOR_CONTEXT,
   SimulateIngestPipelineDoc,
   SimulateIngestPipelineResponse,
   WORKFLOW_RESOURCE_TYPE,
@@ -182,14 +183,19 @@ export function unwrapTransformedDocs(
 
 // ML inference processors will use standard dot notation or JSONPath depending on the input.
 // We follow the same logic here to generate consistent results.
-export function generateTransform(input: {} | [], map: MapFormValue): {} {
+export function generateTransform(
+  input: {} | [],
+  map: MapFormValue,
+  context: PROCESSOR_CONTEXT
+): {} {
   let output = {};
   map.forEach((mapEntry) => {
     try {
       const transformedResult = getTransformedResult(
         mapEntry,
         input,
-        mapEntry.value
+        mapEntry.value,
+        context
       );
       output = {
         ...output,
@@ -204,12 +210,16 @@ export function generateTransform(input: {} | [], map: MapFormValue): {} {
 // a single field value in the transformed output.
 // A specialty scenario for when configuring input on search response processors, one-to-one is false,
 // and the input is an array.
-export function generateArrayTransform(input: [], map: MapFormValue): {}[] {
+export function generateArrayTransform(
+  input: [],
+  map: MapFormValue,
+  context: PROCESSOR_CONTEXT
+): {}[] {
   let output = [] as {}[];
   map.forEach((mapEntry) => {
     try {
       const transformedResult = input.map((inputEntry) =>
-        getTransformedResult(mapEntry, inputEntry, mapEntry.value)
+        getTransformedResult(mapEntry, inputEntry, mapEntry.value, context)
       );
       output = {
         ...output,
@@ -223,19 +233,60 @@ export function generateArrayTransform(input: [], map: MapFormValue): {}[] {
 function getTransformedResult(
   mapEntry: MapEntry,
   input: {},
-  path: string
+  path: string,
+  context: PROCESSOR_CONTEXT
 ): any {
-  // Edge case: if the path is ".", it implies returning
-  // the entire value. This may happen if full_response_path=false
-  // and the input is the entire result with nothing else to parse out.
-  // get() does not cover this case, so we override manually.
-  return path === '.'
-    ? input
-    : mapEntry.value.startsWith(JSONPATH_ROOT_SELECTOR)
-    ? // JSONPath transform
-      jsonpath.query(input, path)
-    : // Standard dot notation
-      get(input, path);
+  // Rregular dot notation can only be executed if 1/ the JSONPath selector is not explicitly defined,
+  // and 2/ it is in the context of ingest. For search request / search response parsing,
+  // it can only be JSONPath, due to backend parsing limitations.
+  if (
+    !mapEntry.value.startsWith(JSONPATH_ROOT_SELECTOR) &&
+    context === PROCESSOR_CONTEXT.INGEST
+  ) {
+    // sub-edge case: if the path is ".", it implies returning
+    // the entire value. This may happen if full_response_path=false
+    // and the input is the entire result with nothing else to parse out.
+    // get() does not cover this case, so we override manually.
+    if (path === '.') {
+      return input;
+    } else {
+      return get(input, path);
+    }
+  } else {
+    // The backend sets a JSONPath setting ALWAYS_RETURN_LIST=false, which
+    // dynamically returns a list or single value, based on whether
+    // the path is definite or not. We try to mimic that with a
+    // custom fn isIndefiniteJsonPath(), since this setting, nor
+    // knowing if the path is definite or indefinite, is not exposed
+    // by any known jsonpath JS-based / NPM libraries.
+    // if found to be definite, we remove the outermost array, which
+    // will always be returned by default when running query().
+    const isIndefinite = isIndefiniteJsonPath(path);
+    const res = jsonpath.query(input, path);
+    if (isIndefinite) {
+      return res;
+    } else {
+      return res[0];
+    }
+  }
+}
+
+// Indefinite/definite path defns:
+// https://github.com/json-path/JsonPath?tab=readme-ov-file#what-is-returned-when
+// Note this may not cover every use case, as the true definition requires low-level
+// branch navigation of the path nodes, which is not exposed by this npm library.
+// Hence, we do our best to cover the majority of use cases and common patterns.
+function isIndefiniteJsonPath(path: string): boolean {
+  // regex has 3 overall OR checks:
+  // 1. consecutive '.'s, indicating deep scan - \.{2}
+  // 2. ?(<anything>), indicating an expression - \?\(.*\)
+  // 3. multiple array indices - \[\d+,\d+\] | \[.*:.*\] | \[\*\]
+  // if any are met, then we call the path indefinite.
+  const indefiniteRegEx = new RegExp(
+    /\.{2}|\?\(.*\)|\[\d+,\d+\]|\[.*:.*\]|\[\*\]/,
+    'g'
+  );
+  return indefiniteRegEx.test(path);
 }
 
 // Derive the collection of model inputs from the model interface JSONSchema into a form-ready list


### PR DESCRIPTION
### Description

This PR improves the path parsing and JSONPath handling when configuring advanced transforms in the ML processors. Added detailed comments in the source code for readability.

- improves `generateTransform` to handle more edge cases and be consistent without the backend handles path parsing for the different scenarios (input vs. output, ingest vs. search request vs. search response).
- adds new`sanitizeJSONPath()` fn used in 2 places: 1/ when auto-populating keys for the query or document JSONs (ensures they will run consistently on frontend & backend), and 2/ when converting to a template (to ensure it runs properly on the backend).
- adds new fn `isIndefiniteJsonPath()` to help make the return values of a JSONPath execution consistent. Note: this is not a full-featured fn. The frontend libraries do not have any configuration similar to `ALWAYS_RETURN_LIST`, nor a mechanism to determine whether a path is definite or indefinite. The purpose of this function is to broadly cover the majority of use cases to mimic the implementation as close as possible.

More details on the fixes this covers in the related issue #478 .

### Issues Resolved

Resolves #478 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
