### PR TITLE
Show experimental badge on Workflow Details page (new and old)

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -47,13 +47,14 @@ import {
 import { DataSourceViewConfig } from '../../../../../../src/plugins/data_source_management/public';
 import { HeaderVariant } from '../../../../../../src/core/public';
 import {
-  TopNavControlTextData,
+  TopNavControlData,
   TopNavMenuIconData,
 } from '../../../../../../src/plugins/navigation/public';
 import { MountPoint } from '../../../../../../src/core/public';
 import { getWorkflow, updateWorkflow, useAppDispatch } from '../../../store';
 import { useFormikContext } from 'formik';
 import { isEmpty, isEqual } from 'lodash';
+import { ExperimentalBadge } from '../../../general_components';
 
 interface WorkflowDetailHeaderProps {
   workflow?: Workflow;
@@ -342,10 +343,18 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
             setMountPoint={setAppRightControls}
             controls={[
               {
+                renderComponent: (
+                  <ExperimentalBadge
+                    popoverEnabled={true}
+                    popoverAnchorPosition="downLeft"
+                  />
+                ),
+              },
+              {
                 text: `Last updated: ${workflowLastUpdated}`,
                 color: 'subdued',
                 className: 'workflow-detail-last-updated',
-              } as TopNavControlTextData,
+              } as TopNavControlData,
             ]}
           />
         </>
@@ -402,6 +411,10 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
               <EuiText color="subdued" size="s">
                 {`Last updated: ${workflowLastUpdated}`}
               </EuiText>,
+              <ExperimentalBadge
+                popoverEnabled={true}
+                popoverAnchorPosition="downLeft"
+              />,
             ]}
             bottomBorder={false}
             rightSideGroupProps={{


### PR DESCRIPTION
### Description

Show experimental badge on Workflow Details page (new and old).

Screenshot (new)
![Screenshot 2024-11-18 at 4 38 30 PM](https://github.com/user-attachments/assets/088ee4db-6131-4203-a2ea-7946d4723d0e)

Screenshot (old):
![Screenshot 2024-11-18 at 4 39 37 PM](https://github.com/user-attachments/assets/81ccb92e-2982-45df-823b-d68ff60e6bb2)

Screenshot (old, popover opened):
![Screenshot 2024-11-18 at 4 40 09 PM](https://github.com/user-attachments/assets/793c6485-8b85-4d34-bc0d-1a4936f67a46)

### Issues resolved
Makes progress on #461 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
