### PR TITLE
Add support for query request parsing in ml search resp processor

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -481,6 +481,8 @@ export const NO_TEMPLATES_FOUND_MSG = 'There are no templates';
 export const NO_MODIFICATIONS_FOUND_TEXT =
   'Template does not contain any modifications';
 export const JSONPATH_ROOT_SELECTOR = '$';
+export const REQUEST_PREFIX = '_request.';
+export const REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR = '$._request.';
 export enum SORT_ORDER {
   ASC = 'asc',
   DESC = 'desc',

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -31,6 +31,8 @@ import {
   MapArrayFormValue,
   MapEntry,
   MapFormValue,
+  REQUEST_PREFIX,
+  REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
 } from '../../../../../common';
 import { MapArrayField, ModelField } from '../input_fields';
 import {
@@ -411,7 +413,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'query'
                 : 'document'
-            } to map to a model input field.`}
+            } to map to a model input field.${
+              props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR} - for example, "_request.query.match.my_field"`
+                : ''
+            }`}
             valueOptions={
               props.context === PROCESSOR_CONTEXT.INGEST
                 ? docFields

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs.tsx
@@ -415,7 +415,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 : 'document'
             } to map to a model input field.${
               props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
-                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR} - for example, "_request.query.match.my_field"`
+                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR}" - for example, "_request.query.match.my_field"`
                 : ''
             }`}
             valueOptions={

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -46,6 +46,8 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
   customStringify,
+  REQUEST_PREFIX,
+  REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
 } from '../../../../../../common';
 import {
   formikToPartialPipeline,
@@ -188,13 +190,15 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 sampleSourceInput as [],
                 tempInputMap[selectedTransformOption],
                 props.context,
-                TRANSFORM_CONTEXT.INPUT
+                TRANSFORM_CONTEXT.INPUT,
+                queryObj
               )
             : generateTransform(
                 sampleSourceInput,
                 tempInputMap[selectedTransformOption],
                 props.context,
-                TRANSFORM_CONTEXT.INPUT
+                TRANSFORM_CONTEXT.INPUT,
+                queryObj
               );
 
         setTransformedInput(customStringify(output));
@@ -316,7 +320,11 @@ export function InputTransformModal(props: InputTransformModalProps) {
               props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                 ? 'query'
                 : 'document'
-            } to map to a model input field.`}
+            } to map to a model input field.${
+              props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR} - for example, "_request.query.match.my_field"`
+                : ''
+            }`}
             valueOptions={props.valueOptions}
             // If the map we are adding is the first one, populate the selected option to index 0
             onMapAdd={(curArray) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/modals/input_transform_modal.tsx
@@ -322,7 +322,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
                 : 'document'
             } to map to a model input field.${
               props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
-                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR} - for example, "_request.query.match.my_field"`
+                ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR}" - for example, "_request.query.match.my_field"`
                 : ''
             }`}
             valueOptions={props.valueOptions}

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -227,8 +227,8 @@ export function generateArrayTransform(
   map.forEach((mapEntry) => {
     try {
       // If users define a path using the special query request
-      // prefix, parse the query context, instead of the other input.      let transformedResult = [] as any[];
-      let transformedResult = [] as any[];
+      // prefix, parse the query context, instead of the other input.
+      let transformedResult;
       if (
         (mapEntry.value.startsWith(REQUEST_PREFIX) ||
           mapEntry.value.startsWith(


### PR DESCRIPTION
### Description

The request can be accessed in the ML search response processors via `_request`. This can be useful for rerank use cases, which may want to tie in original query context info, with returned documents, to generate reranked scores.

This PR adds some helper tooltip text on how to add, and updates the transform logic to handle this special case.

Example below demonstrates a rerank use case using Cohere ReRank English V3. The original query text is combined with the returned documents and sent off to the model.

[screen-capture (4).webm](https://github.com/user-attachments/assets/792b4e13-c5d0-4208-9da5-76798e550c3c)


### Issues Resolved



### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
