### PR TITLE
Support different input transform types

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -470,10 +470,10 @@ export enum TRANSFORM_CONTEXT {
   OUTPUT = 'output',
 }
 export enum TRANSFORM_TYPE {
-  STRING = 'string',
-  FIELD = 'field',
-  EXPRESSION = 'expression',
-  TEMPLATE = 'template',
+  STRING = 'String',
+  FIELD = 'Field',
+  EXPRESSION = 'Expression',
+  TEMPLATE = 'Template',
 }
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
@@ -503,7 +503,7 @@ export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
 export const EMPTY_INPUT_MAP_ENTRY = {
   key: '',
   value: {
-    transformType: TRANSFORM_TYPE.FIELD,
+    transformType: '' as TRANSFORM_TYPE,
     value: '',
   },
 } as InputMapEntry;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -506,3 +506,9 @@ export enum SOURCE_OPTIONS {
   UPLOAD = 'upload',
   EXISTING_INDEX = 'existing_index',
 }
+export enum TRANSFORM_TYPE {
+  STRING = 'string',
+  FIELD = 'field',
+  EXPRESSION = 'expression',
+  TEMPLATE = 'template',
+}

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -497,6 +497,7 @@ export enum SORT_ORDER {
 export const MAX_DOCS = 1000;
 export const MAX_STRING_LENGTH = 100;
 export const MAX_JSON_STRING_LENGTH = 10000;
+export const MAX_TEMPLATE_STRING_LENGTH = 10000;
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  InputMapEntry,
   MapEntry,
   PromptPreset,
   QueryPreset,
@@ -468,6 +469,12 @@ export enum TRANSFORM_CONTEXT {
   INPUT = 'input',
   OUTPUT = 'output',
 }
+export enum TRANSFORM_TYPE {
+  STRING = 'string',
+  FIELD = 'field',
+  EXPRESSION = 'expression',
+  TEMPLATE = 'template',
+}
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
@@ -493,6 +500,13 @@ export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
+export const EMPTY_INPUT_MAP_ENTRY = {
+  key: '',
+  value: {
+    transformType: TRANSFORM_TYPE.FIELD,
+    value: '',
+  },
+} as InputMapEntry;
 export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
   'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
 export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';
@@ -505,10 +519,4 @@ export enum SOURCE_OPTIONS {
   MANUAL = 'manual',
   UPLOAD = 'upload',
   EXISTING_INDEX = 'existing_index',
-}
-export enum TRANSFORM_TYPE {
-  STRING = 'string',
-  FIELD = 'field',
-  EXPRESSION = 'expression',
-  TEMPLATE = 'template',
 }

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -140,7 +140,7 @@ export type RequestSchema = WorkflowSchema;
 
 // Form / schema interfaces for the input transform sub-form
 export type InputTransformFormValues = {
-  input_map: MapArrayFormValue;
+  input_map: InputMapArrayFormValue;
   one_to_one: ConfigFieldValue;
 };
 export type InputTransformSchema = WorkflowSchema;

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -102,9 +102,17 @@ export type MapFormValue = MapEntry[];
 
 export type MapArrayFormValue = MapFormValue[];
 
+export type TemplateVar = {
+  name: string;
+  transform: string;
+};
+
 export type Transform = {
   transformType: TRANSFORM_TYPE;
   value: string;
+  // Templates may persist their own set of nested transforms
+  // to be dynamically injected into the template
+  nestedVars?: TemplateVar[];
 };
 
 export type InputMapEntry = {
@@ -153,9 +161,7 @@ export type OutputTransformFormValues = {
 export type OutputTransformSchema = WorkflowSchema;
 
 // Form / schema interfaces for the template sub-form
-export type TemplateFormValues = {
-  template: FormikValues;
-};
+export type TemplateFormValues = Omit<Transform, 'transformType'>;
 export type TemplateSchema = WorkflowSchema;
 
 /**

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -152,6 +152,12 @@ export type OutputTransformFormValues = {
 };
 export type OutputTransformSchema = WorkflowSchema;
 
+// Form / schema interfaces for the template sub-form
+export type TemplateFormValues = {
+  template: FormikValues;
+};
+export type TemplateSchema = WorkflowSchema;
+
 /**
  ********** WORKSPACE TYPES/INTERFACES **********
  */

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -164,6 +164,12 @@ export type OutputTransformSchema = WorkflowSchema;
 export type TemplateFormValues = Omit<Transform, 'transformType'>;
 export type TemplateSchema = WorkflowSchema;
 
+// Form / schema interfaces for the expression/transform sub-form
+export type ExpressionFormValues = {
+  expression: string;
+};
+export type ExpressionSchema = WorkflowSchema;
+
 /**
  ********** WORKSPACE TYPES/INTERFACES **********
  */

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -37,20 +37,9 @@ export type ConfigFieldType =
   | 'mapArray'
   | 'boolean'
   | 'number'
-  | 'transform'
-  | 'transformArray';
+  | 'inputMapArray';
 
-export type ConfigFieldTransformValue = {
-  transformType: TRANSFORM_TYPE;
-  value: string;
-};
-export type ConfigFieldTransformArrayValue = ConfigFieldTransformValue[];
-
-export type ConfigFieldValue =
-  | string
-  | ConfigFieldTransformValue
-  | ConfigFieldTransformArrayValue
-  | {};
+export type ConfigFieldValue = string | {};
 
 export interface IConfigField {
   type: ConfigFieldType;
@@ -113,9 +102,14 @@ export type MapFormValue = MapEntry[];
 
 export type MapArrayFormValue = MapFormValue[];
 
+export type Transform = {
+  transformType: TRANSFORM_TYPE;
+  value: string;
+};
+
 export type InputMapEntry = {
   key: string;
-  value: ConfigFieldTransformValue;
+  value: Transform;
 };
 
 export type InputMapFormValue = InputMapEntry[];

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -10,6 +10,7 @@ import {
   COMPONENT_CLASS,
   PROCESSOR_TYPE,
   PROMPT_FIELD,
+  TRANSFORM_TYPE,
   WORKFLOW_TYPE,
 } from './constants';
 
@@ -35,9 +36,21 @@ export type ConfigFieldType =
   | 'map'
   | 'mapArray'
   | 'boolean'
-  | 'number';
+  | 'number'
+  | 'transform'
+  | 'transformArray';
 
-export type ConfigFieldValue = string | {};
+export type ConfigFieldTransformValue = {
+  transformType: TRANSFORM_TYPE;
+  value: string;
+};
+export type ConfigFieldTransformArrayValue = ConfigFieldTransformValue[];
+
+export type ConfigFieldValue =
+  | string
+  | ConfigFieldTransformValue
+  | ConfigFieldTransformArrayValue
+  | {};
 
 export interface IConfigField {
   type: ConfigFieldType;
@@ -99,6 +112,15 @@ export type MapEntry = {
 export type MapFormValue = MapEntry[];
 
 export type MapArrayFormValue = MapFormValue[];
+
+export type InputMapEntry = {
+  key: string;
+  value: ConfigFieldTransformValue;
+};
+
+export type InputMapFormValue = InputMapEntry[];
+
+export type InputMapArrayFormValue = InputMapFormValue[];
 
 export type WorkflowFormValues = {
   ingest: FormikValues;

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -22,7 +22,7 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'input_map',
-        type: 'mapArray',
+        type: 'transformArray',
       },
       {
         id: 'output_map',

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -22,7 +22,7 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'input_map',
-        type: 'transformArray',
+        type: 'inputMapArray',
       },
       {
         id: 'output_map',

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
@@ -11,3 +11,4 @@ export { MapArrayField } from './map_array_field';
 export { BooleanField } from './boolean_field';
 export { SelectField } from './select_field';
 export { NumberField } from './number_field';
+export { SelectWithCustomOptions } from './select_with_custom_options';

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -185,6 +185,7 @@ export function MapField(props: MapFieldProps) {
                                     placeholder={
                                       props.keyPlaceholder || 'Input'
                                     }
+                                    allowCreate={true}
                                   />
                                 ) : (
                                   <TextField
@@ -221,6 +222,7 @@ export function MapField(props: MapFieldProps) {
                                     placeholder={
                                       props.valuePlaceholder || 'Output'
                                     }
+                                    allowCreate={true}
                                   />
                                 ) : (
                                   <TextField

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -13,6 +13,7 @@ interface SelectWithCustomOptionsProps {
   fieldPath: string;
   placeholder: string;
   options: { label: string }[];
+  allowCreate?: boolean;
 }
 
 /**
@@ -31,6 +32,8 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
     const formValue = getIn(values, props.fieldPath);
     if (!isEmpty(formValue)) {
       setSelectedOption([{ label: formValue }]);
+    } else {
+      setSelectedOption([]);
     }
   }, [getIn(values, props.fieldPath)]);
 
@@ -77,8 +80,10 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
         setFieldTouched(props.fieldPath, true);
         setFieldValue(props.fieldPath, get(options, '0.label'));
       }}
-      onCreateOption={onCreateOption}
-      customOptionText="Add {searchValue} as a custom option"
+      onCreateOption={props.allowCreate ? onCreateOption : undefined}
+      customOptionText={
+        props.allowCreate ? 'Add {searchValue} as a custom option' : undefined
+      }
     />
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -14,6 +14,7 @@ interface SelectWithCustomOptionsProps {
   placeholder: string;
   options: { label: string }[];
   allowCreate?: boolean;
+  onChange?: () => void;
 }
 
 /**
@@ -79,6 +80,9 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
       onChange={(options) => {
         setFieldTouched(props.fieldPath, true);
         setFieldValue(props.fieldPath, get(options, '0.label'));
+        if (props.onChange) {
+          props.onChange();
+        }
       }}
       onCreateOption={props.allowCreate ? onCreateOption : undefined}
       customOptionText={

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -416,6 +416,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           <ModelInputs
             config={props.config}
             baseConfigPath={props.baseConfigPath}
+            uiConfig={props.uiConfig}
             context={props.context}
           />
           <EuiSpacer size="l" />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiToolTip,
   EuiSmallButton,
+  EuiIconTip,
 } from '@elastic/eui';
 import {
   IProcessorConfig,
@@ -31,11 +32,10 @@ import {
   MapArrayFormValue,
   MapEntry,
   MapFormValue,
+  EMPTY_INPUT_MAP_ENTRY,
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
-  TRANSFORM_TYPE,
-  InputMapEntry,
   InputMapFormValue,
   InputMapArrayFormValue,
 } from '../../../../../../common';
@@ -142,15 +142,9 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     const newModelInterface = models[modelId]?.interface;
     setModelInterface(newModelInterface);
     const modelInputsAsForm = [
-      parseModelInputs(newModelInterface).map((modelInput) => {
-        return {
-          key: modelInput.label,
-          value: {
-            transformType: TRANSFORM_TYPE.FIELD,
-            value: '',
-          },
-        } as InputMapEntry;
-      }) as InputMapFormValue,
+      parseModelInputs(newModelInterface).map(
+        (modelInput) => EMPTY_INPUT_MAP_ENTRY
+      ) as InputMapFormValue,
     ] as InputMapArrayFormValue;
     const modelOutputsAsForm = [
       parseModelOutputs(newModelInterface).map((modelOutput) => {
@@ -369,10 +363,29 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           )}
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
-              <EuiText
-                size="m"
-                style={{ marginTop: '4px' }}
-              >{`Inputs`}</EuiText>
+              <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiFlexItem grow={false}>
+                  <EuiText size="m">Inputs</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiIconTip
+                    content={`Specify a ${
+                      props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                        ? 'query'
+                        : 'document'
+                    } field or define JSONPath to transform the ${
+                      props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                        ? 'query'
+                        : 'document'
+                    } to map to a model input field.${
+                      props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                        ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR}" - for example, "_request.query.match.my_field"`
+                        : ''
+                    }`}
+                    position="right"
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -34,6 +34,12 @@ import {
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
+  TRANSFORM_TYPE,
+  InputMapEntry,
+  InputMapFormValue,
+  InputMapArrayFormValue,
+} from '../../../../../../common';
+import {
   ConfigurePromptModal,
   InputTransformModal,
   OutputTransformModal,
@@ -139,10 +145,13 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
       parseModelInputs(newModelInterface).map((modelInput) => {
         return {
           key: modelInput.label,
-          value: '',
-        } as MapEntry;
-      }) as MapFormValue,
-    ] as MapArrayFormValue;
+          value: {
+            transformType: TRANSFORM_TYPE.FIELD,
+            value: '',
+          },
+        } as InputMapEntry;
+      }) as InputMapFormValue,
+    ] as InputMapArrayFormValue;
     const modelOutputsAsForm = [
       parseModelOutputs(newModelInterface).map((modelOutput) => {
         return {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -33,6 +33,8 @@ import {
   MapEntry,
   MapFormValue,
   EMPTY_INPUT_MAP_ENTRY,
+  REQUEST_PREFIX,
+  REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
@@ -142,9 +144,12 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     const newModelInterface = models[modelId]?.interface;
     setModelInterface(newModelInterface);
     const modelInputsAsForm = [
-      parseModelInputs(newModelInterface).map(
-        (modelInput) => EMPTY_INPUT_MAP_ENTRY
-      ) as InputMapFormValue,
+      parseModelInputs(newModelInterface).map((modelInput) => {
+        return {
+          ...EMPTY_INPUT_MAP_ENTRY,
+          key: modelInput.label,
+        };
+      }) as InputMapFormValue,
     ] as InputMapArrayFormValue;
     const modelOutputsAsForm = [
       parseModelOutputs(newModelInterface).map((modelOutput) => {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -1,0 +1,774 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useFormikContext, getIn, Formik } from 'formik';
+import { isEmpty } from 'lodash';
+import * as yup from 'yup';
+import {
+  EuiCodeEditor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSmallButton,
+  EuiText,
+  EuiPopover,
+  EuiContextMenu,
+  EuiSmallButtonEmpty,
+  EuiSmallButtonIcon,
+  EuiSpacer,
+  EuiCopy,
+} from '@elastic/eui';
+import {
+  customStringify,
+  IngestPipelineConfig,
+  InputMapEntry,
+  IProcessorConfig,
+  MAX_STRING_LENGTH,
+  MAX_TEMPLATE_STRING_LENGTH,
+  ModelInterface,
+  PROCESSOR_CONTEXT,
+  PROMPT_PRESETS,
+  PromptPreset,
+  SearchHit,
+  SimulateIngestPipelineResponse,
+  TemplateFormValues,
+  TemplateSchema,
+  TemplateVar,
+  TRANSFORM_CONTEXT,
+  WorkflowConfig,
+  WorkflowFormValues,
+} from '../../../../../../../common';
+import {
+  formikToPartialPipeline,
+  generateArrayTransform,
+  generateTransform,
+  getDataSourceId,
+  getInitialValue,
+  prepareDocsForSimulate,
+  unwrapTransformedDocs,
+} from '../../../../../../utils';
+import { TextField } from '../../../input_fields';
+import {
+  searchIndex,
+  simulatePipeline,
+  useAppDispatch,
+} from '../../../../../../store';
+import { getCore } from '../../../../../../services';
+
+interface ConfigureExpressionModalProps {
+  uiConfig: WorkflowConfig;
+  config: IProcessorConfig;
+  context: PROCESSOR_CONTEXT;
+  baseConfigPath: string;
+
+  fieldPath: string;
+  modelInterface: ModelInterface | undefined;
+  onClose: () => void;
+}
+
+// Spacing between the input field columns
+const KEY_FLEX_RATIO = 4;
+const VALUE_FLEX_RATIO = 6;
+
+// the max number of input docs we use to display & test transforms with (search response hits)
+const MAX_INPUT_DOCS = 10;
+
+/**
+ * A modal to configure a JSONPath expression / transform.
+ */
+export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+  const { values, setFieldValue, setFieldTouched } = useFormikContext<
+    WorkflowFormValues
+  >();
+
+  // sub-form values/schema
+  const templateFormValues = {
+    value: getInitialValue('string'),
+    nestedVars: [],
+  } as TemplateFormValues;
+  const templateFormSchema = yup.object({
+    value: yup
+      .string()
+      .trim()
+      .min(1, 'Too short')
+      .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long')
+      .required('Required') as yup.Schema,
+    nestedVars: yup.array().of(
+      yup.object().shape({
+        name: yup
+          .string()
+          .trim()
+          .min(1, 'Too short')
+          .max(MAX_STRING_LENGTH, 'Too long')
+          .required('Required') as yup.Schema,
+        transform: yup
+          .string()
+          .trim()
+          .min(1, 'Too short')
+          .max(MAX_STRING_LENGTH, 'Too long')
+          .required('Required') as yup.Schema,
+      })
+    ) as yup.Schema,
+  }) as TemplateSchema;
+
+  // persist standalone values. update / initialize when it is first opened
+  const [tempTemplate, setTempTemplate] = useState<string>('');
+  const [tempNestedVars, setTempNestedVars] = useState<TemplateVar[]>([]);
+  const [tempErrors, setTempErrors] = useState<boolean>(false);
+
+  // get some current form values
+  const oneToOne = getIn(
+    values,
+    `${props.baseConfigPath}.${props.config.id}.one_to_one`
+  );
+  const docs = getIn(values, 'ingest.docs');
+  let docObjs = [] as {}[] | undefined;
+  try {
+    docObjs = JSON.parse(docs);
+  } catch {}
+  const query = getIn(values, 'search.request');
+  let queryObj = {} as {} | undefined;
+  try {
+    queryObj = JSON.parse(query);
+  } catch {}
+  const onIngestAndNoDocs =
+    props.context === PROCESSOR_CONTEXT.INGEST && isEmpty(docObjs);
+  const onSearchAndNoQuery =
+    (props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST ||
+      props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE) &&
+    isEmpty(queryObj);
+
+  // transformed template state
+  const [transformedTemplate, setTransformedTemplate] = useState<string>('');
+
+  // button updating state
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
+  // popover states
+  const [presetsPopoverOpen, setPresetsPopoverOpen] = useState<boolean>(false);
+
+  // source input / transformed input state
+  const [sourceInput, setSourceInput] = useState<string>('{}');
+  const [transformedInput, setTransformedInput] = useState<string>('{}');
+
+  // fetching input data state
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+
+  // hook to re-generate the transform when any inputs to the transform are updated
+  useEffect(() => {
+    const nestedVarsAsInputMap = tempNestedVars?.map((templateVar) => {
+      return {
+        key: templateVar.name,
+        value: {
+          value: templateVar.transform,
+        },
+      } as InputMapEntry;
+    });
+    if (!isEmpty(nestedVarsAsInputMap) && !isEmpty(JSON.parse(sourceInput))) {
+      let sampleSourceInput = {} as {} | [];
+      try {
+        sampleSourceInput = JSON.parse(sourceInput);
+        const output =
+          // Edge case: users are collapsing input docs into a single input field when many-to-one is selected
+          // fo input transforms on search response processors.
+          oneToOne === false &&
+          props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE &&
+          Array.isArray(sampleSourceInput)
+            ? generateArrayTransform(
+                sampleSourceInput as [],
+                nestedVarsAsInputMap,
+                props.context,
+                TRANSFORM_CONTEXT.INPUT,
+                queryObj
+              )
+            : generateTransform(
+                sampleSourceInput,
+                nestedVarsAsInputMap,
+                props.context,
+                TRANSFORM_CONTEXT.INPUT,
+                queryObj
+              );
+
+        setTransformedInput(customStringify(output));
+      } catch {}
+    } else {
+      setTransformedInput('{}');
+    }
+  }, [tempNestedVars, sourceInput]);
+
+  // hook to set the transformed template, when the template
+  // and/or its injected variables are updated
+  useEffect(() => {
+    if (!isEmpty(tempTemplate)) {
+      setTransformedTemplate(
+        injectValuesIntoTemplate(tempTemplate, JSON.parse(transformedInput))
+      );
+    }
+  }, [tempTemplate, transformedInput]);
+
+  // if updating, take the temp vars and assign it to the parent form
+  function onUpdate() {
+    setIsUpdating(true);
+    setFieldValue(`${props.fieldPath}.value`, tempTemplate);
+    setFieldValue(`${props.fieldPath}.nestedVars`, tempNestedVars);
+    setFieldTouched(props.fieldPath, true);
+    props.onClose();
+  }
+
+  return (
+    <Formik
+      enableReinitialize={false}
+      initialValues={templateFormValues}
+      validationSchema={templateFormSchema}
+      onSubmit={(values) => {}}
+      validate={(values) => {}}
+    >
+      {(formikProps) => {
+        // override to parent form values when changes detected
+        useEffect(() => {
+          formikProps.setFieldValue(
+            'value',
+            getIn(values, `${props.fieldPath}.value`)
+          );
+          formikProps.setFieldValue(
+            'nestedVars',
+            getIn(values, `${props.fieldPath}.nestedVars`)
+          );
+        }, [getIn(values, props.fieldPath)]);
+
+        // update temp vars when form changes are detected
+        useEffect(() => {
+          setTempTemplate(getIn(formikProps.values, 'value'));
+        }, [getIn(formikProps.values, 'value')]);
+        useEffect(() => {
+          setTempNestedVars(getIn(formikProps.values, 'nestedVars'));
+        }, [getIn(formikProps.values, 'nestedVars')]);
+
+        // update tempErrors if errors detected
+        useEffect(() => {
+          setTempErrors(!isEmpty(formikProps.errors));
+        }, [formikProps.errors]);
+
+        // Adding an input var to the end of the existing arr
+        function addInputVar(curInputVars: TemplateVar[]): void {
+          const updatedInputVars = [
+            ...curInputVars,
+            { name: '', transform: '' } as TemplateVar,
+          ];
+          formikProps.setFieldValue(`nestedVars`, updatedInputVars);
+          formikProps.setFieldTouched(`nestedVars`, true);
+        }
+
+        // Deleting an input var
+        function deleteInputVar(
+          curInputVars: TemplateVar[],
+          idxToDelete: number
+        ): void {
+          const updatedInputVars = [...curInputVars];
+          updatedInputVars.splice(idxToDelete, 1);
+          formikProps.setFieldValue('nestedVars', updatedInputVars);
+          formikProps.setFieldTouched('nestedVars', true);
+        }
+
+        return (
+          <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <p>{`Extract data with expression`}</p>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody style={{ height: '40vh' }}>
+              <EuiFlexGroup direction="row">
+                <EuiFlexItem grow={6}>
+                  <EuiFlexGroup direction="column" gutterSize="xs">
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceAround"
+                      >
+                        <EuiFlexItem>
+                          <EuiText size="m">Prompt</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiPopover
+                            button={
+                              <EuiSmallButton
+                                onClick={() =>
+                                  setPresetsPopoverOpen(!presetsPopoverOpen)
+                                }
+                                iconSide="right"
+                                iconType="arrowDown"
+                              >
+                                Choose from a preset
+                              </EuiSmallButton>
+                            }
+                            isOpen={presetsPopoverOpen}
+                            closePopover={() => setPresetsPopoverOpen(false)}
+                            anchorPosition="downLeft"
+                          >
+                            <EuiContextMenu
+                              size="s"
+                              initialPanelId={0}
+                              panels={[
+                                {
+                                  id: 0,
+                                  items: PROMPT_PRESETS.map(
+                                    (preset: PromptPreset) => ({
+                                      name: preset.name,
+                                      onClick: () => {
+                                        try {
+                                          formikProps.setFieldValue(
+                                            'value',
+                                            preset.prompt
+                                          );
+                                        } catch {}
+                                        formikProps.setFieldTouched(
+                                          'value',
+                                          true
+                                        );
+                                        setPresetsPopoverOpen(false);
+                                      },
+                                    })
+                                  ),
+                                },
+                              ]}
+                            />
+                          </EuiPopover>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiSpacer size="s" />
+                    <EuiFlexItem grow={false}>
+                      <EuiCodeEditor
+                        mode="json"
+                        theme="textmate"
+                        width="100%"
+                        height="15vh"
+                        value={tempTemplate}
+                        readOnly={false}
+                        setOptions={{
+                          fontSize: '12px',
+                          autoScrollEditorIntoView: true,
+                          showLineNumbers: false,
+                          showGutter: false,
+                          showPrintMargin: false,
+                          wrap: true,
+                        }}
+                        tabSize={2}
+                        onChange={(value) =>
+                          formikProps.setFieldValue('value', value)
+                        }
+                        onBlur={(e) => {
+                          formikProps.setFieldTouched('value');
+                        }}
+                      />
+                    </EuiFlexItem>
+                    <EuiSpacer size="s" />
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="m">Input variables</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceAround"
+                      >
+                        <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                          <EuiText size="s" color="subdued">
+                            {`Name`}
+                          </EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                          <EuiText size="s" color="subdued">
+                            {`Expression`}
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                      <EuiSpacer size="s" />
+                      {formikProps.values.nestedVars?.map(
+                        (templateVar, idx) => {
+                          return (
+                            <div key={idx}>
+                              <EuiFlexGroup
+                                key={idx}
+                                direction="row"
+                                justifyContent="spaceAround"
+                                gutterSize="s"
+                              >
+                                <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                                  <TextField
+                                    fullWidth={true}
+                                    fieldPath={`nestedVars.${idx}.name`}
+                                    placeholder={`Name`}
+                                    showError={true}
+                                  />
+                                </EuiFlexItem>
+                                <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                                  <EuiFlexGroup
+                                    direction="row"
+                                    justifyContent="spaceAround"
+                                    gutterSize="xs"
+                                  >
+                                    <EuiFlexItem>
+                                      <TextField
+                                        fullWidth={true}
+                                        fieldPath={`nestedVars.${idx}.transform`}
+                                        placeholder={`Transform`}
+                                        showError={true}
+                                      />
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                      <EuiCopy
+                                        textToCopy={getPlaceholderString(
+                                          getIn(
+                                            formikProps.values,
+                                            `nestedVars.${idx}.name`
+                                          )
+                                        )}
+                                      >
+                                        {(copy) => (
+                                          <EuiSmallButtonIcon
+                                            aria-label="Copy"
+                                            iconType="copy"
+                                            disabled={isEmpty(
+                                              getIn(
+                                                formikProps.values,
+                                                `nestedVars.${idx}.transform`
+                                              )
+                                            )}
+                                            color={
+                                              isEmpty(
+                                                getIn(
+                                                  formikProps.values,
+                                                  `nestedVars.${idx}.transform`
+                                                )
+                                              )
+                                                ? 'subdued'
+                                                : 'primary'
+                                            }
+                                            onClick={copy}
+                                          />
+                                        )}
+                                      </EuiCopy>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                      <EuiSmallButtonIcon
+                                        iconType={'trash'}
+                                        color="danger"
+                                        aria-label="Delete"
+                                        onClick={() => {
+                                          deleteInputVar(
+                                            formikProps.values.nestedVars || [],
+                                            idx
+                                          );
+                                        }}
+                                      />
+                                    </EuiFlexItem>
+                                  </EuiFlexGroup>
+                                </EuiFlexItem>
+                              </EuiFlexGroup>
+                              <EuiSpacer size="s" />
+                            </div>
+                          );
+                        }
+                      )}
+                      <EuiSmallButtonEmpty
+                        style={{
+                          marginLeft: '-8px',
+                          width: '125px',
+                        }}
+                        iconType={'plusInCircle'}
+                        iconSide="left"
+                        onClick={() => {
+                          addInputVar(formikProps.values.nestedVars || []);
+                        }}
+                      >
+                        {`Add variable`}
+                      </EuiSmallButtonEmpty>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem grow={4}>
+                  <EuiFlexGroup direction="column" gutterSize="xs">
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceAround"
+                      >
+                        <EuiFlexItem>
+                          <EuiText size="m">Prompt preview</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiSmallButton
+                            style={{ width: '100px' }}
+                            isLoading={isFetching}
+                            disabled={onIngestAndNoDocs || onSearchAndNoQuery}
+                            onClick={async () => {
+                              setIsFetching(true);
+                              switch (props.context) {
+                                case PROCESSOR_CONTEXT.INGEST: {
+                                  // get the current ingest pipeline up to, but not including, this processor
+                                  const curIngestPipeline = formikToPartialPipeline(
+                                    values,
+                                    props.uiConfig,
+                                    props.config.id,
+                                    false,
+                                    PROCESSOR_CONTEXT.INGEST
+                                  );
+                                  // if there are preceding processors, we need to simulate the partial ingest pipeline,
+                                  // in order to get the latest transformed version of the docs
+                                  if (curIngestPipeline !== undefined) {
+                                    const curDocs = prepareDocsForSimulate(
+                                      values.ingest.docs,
+                                      values.ingest.index.name
+                                    );
+                                    await dispatch(
+                                      simulatePipeline({
+                                        apiBody: {
+                                          pipeline: curIngestPipeline as IngestPipelineConfig,
+                                          docs: [curDocs[0]],
+                                        },
+                                        dataSourceId,
+                                      })
+                                    )
+                                      .unwrap()
+                                      .then(
+                                        (
+                                          resp: SimulateIngestPipelineResponse
+                                        ) => {
+                                          const docObjs = unwrapTransformedDocs(
+                                            resp
+                                          );
+                                          if (docObjs.length > 0) {
+                                            setSourceInput(
+                                              customStringify(docObjs[0])
+                                            );
+                                          }
+                                        }
+                                      )
+                                      .catch((error: any) => {
+                                        getCore().notifications.toasts.addDanger(
+                                          `Failed to fetch input data`
+                                        );
+                                      })
+                                      .finally(() => {
+                                        setIsFetching(false);
+                                      });
+                                  } else {
+                                    try {
+                                      const docObjs = JSON.parse(
+                                        values.ingest.docs
+                                      ) as {}[];
+                                      if (docObjs.length > 0) {
+                                        setSourceInput(
+                                          customStringify(docObjs[0])
+                                        );
+                                      }
+                                    } catch {
+                                    } finally {
+                                      setIsFetching(false);
+                                    }
+                                  }
+                                  break;
+                                }
+                                case PROCESSOR_CONTEXT.SEARCH_REQUEST: {
+                                  // get the current search pipeline up to, but not including, this processor
+                                  const curSearchPipeline = formikToPartialPipeline(
+                                    values,
+                                    props.uiConfig,
+                                    props.config.id,
+                                    false,
+                                    PROCESSOR_CONTEXT.SEARCH_REQUEST
+                                  );
+                                  // if there are preceding processors, we cannot generate. The button to render
+                                  // this modal should be disabled if the search pipeline would be enabled. We add
+                                  // this if check as an extra layer of checking, and if mechanism for gating
+                                  // this is changed in the future.
+                                  if (curSearchPipeline === undefined) {
+                                    setSourceInput(values.search.request);
+                                  }
+                                  setIsFetching(false);
+                                  break;
+                                }
+                                case PROCESSOR_CONTEXT.SEARCH_RESPONSE: {
+                                  // get the current search pipeline up to, but not including, this processor
+                                  const curSearchPipeline = formikToPartialPipeline(
+                                    values,
+                                    props.uiConfig,
+                                    props.config.id,
+                                    false,
+                                    PROCESSOR_CONTEXT.SEARCH_RESPONSE
+                                  );
+                                  // Execute search. If there are preceding processors, augment the existing query with
+                                  // the partial search pipeline (inline) to get the latest transformed version of the response.
+                                  dispatch(
+                                    searchIndex({
+                                      apiBody: {
+                                        index: values.search.index.name,
+                                        body: JSON.stringify({
+                                          ...JSON.parse(
+                                            values.search.request as string
+                                          ),
+                                          search_pipeline:
+                                            curSearchPipeline || {},
+                                        }),
+                                      },
+                                      dataSourceId,
+                                    })
+                                  )
+                                    .unwrap()
+                                    .then(async (resp) => {
+                                      const hits = resp?.hits?.hits
+                                        ?.map((hit: SearchHit) => hit._source)
+                                        .slice(0, MAX_INPUT_DOCS);
+                                      if (hits.length > 0) {
+                                        setSourceInput(
+                                          // if one-to-one, treat the source input as a single retrieved document
+                                          // else, treat it as all of the returned documents
+                                          customStringify(
+                                            oneToOne ? hits[0] : hits
+                                          )
+                                        );
+                                      }
+                                    })
+                                    .catch((error: any) => {
+                                      getCore().notifications.toasts.addDanger(
+                                        `Failed to fetch source input data`
+                                      );
+                                    })
+                                    .finally(() => {
+                                      setIsFetching(false);
+                                    });
+                                  break;
+                                }
+                              }
+                            }}
+                          >
+                            Run preview
+                          </EuiSmallButton>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s">Source data</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiCodeEditor
+                        mode="json"
+                        theme="textmate"
+                        width="100%"
+                        height="15vh"
+                        value={sourceInput}
+                        readOnly={true}
+                        setOptions={{
+                          fontSize: '12px',
+                          autoScrollEditorIntoView: true,
+                          showLineNumbers: false,
+                          showGutter: false,
+                          showPrintMargin: false,
+                          wrap: true,
+                        }}
+                        tabSize={2}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s">Extracted data</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiCodeEditor
+                        mode="json"
+                        theme="textmate"
+                        width="100%"
+                        height="15vh"
+                        value={transformedInput}
+                        readOnly={true}
+                        setOptions={{
+                          fontSize: '12px',
+                          autoScrollEditorIntoView: true,
+                          showLineNumbers: false,
+                          showGutter: false,
+                          showPrintMargin: false,
+                          wrap: true,
+                        }}
+                        tabSize={2}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiSmallButtonEmpty
+                onClick={props.onClose}
+                color="primary"
+                data-testid="closeTemplateButton"
+              >
+                Cancel
+              </EuiSmallButtonEmpty>
+              <EuiSmallButton
+                onClick={() => {
+                  formikProps
+                    .submitForm()
+                    .then((value: any) => {
+                      onUpdate();
+                    })
+                    .catch((err: any) => {});
+                }}
+                isLoading={isUpdating}
+                isDisabled={tempErrors} // blocking update until valid input is given
+                fill={true}
+                color="primary"
+                data-testid="updateTemplateButton"
+              >
+                Save
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        );
+      }}
+    </Formik>
+  );
+}
+
+// small util fn to get the full placeholder string to be
+// inserted into the template. String conversion is required
+// if the input is an array, for example. Also, all values
+// should be prepended with "parameters.", as all inputs
+// will be nested under a base parameters obj.
+function getPlaceholderString(label: string, type?: string) {
+  return type === 'array'
+    ? `\$\{parameters.${label}.toString()\}`
+    : `\$\{parameters.${label}\}`;
+}
+
+function injectValuesIntoTemplate(
+  template: string,
+  parameters: { [key: string]: string }
+): string {
+  let finalTemplate = template;
+  // replace any parameter placeholders in the prompt with any values found in the
+  // parameters obj.
+  // we do 2 checks - one for the regular prompt, and one with "toString()" appended.
+  // this is required for parameters that have values as a list, for example.
+  Object.keys(parameters).forEach((parameterKey) => {
+    const parameterValue = parameters[parameterKey];
+    const regex = new RegExp(`\\$\\{parameters.${parameterKey}\\}`, 'g');
+    const regexWithToString = new RegExp(
+      `\\$\\{parameters.${parameterKey}.toString\\(\\)\\}`,
+      'g'
+    );
+    finalTemplate = finalTemplate
+      .replace(regex, parameterValue)
+      .replace(regexWithToString, parameterValue);
+  });
+
+  return finalTemplate;
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -225,13 +225,13 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
           <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
             <EuiModalHeader>
               <EuiModalHeaderTitle>
-                <p>{`Configure template`}</p>
+                <p>{`Configure prompt`}</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiModalBody style={{ height: '40vh' }}>
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow={6}>
-                  <EuiFlexGroup direction="column">
+                  <EuiFlexGroup direction="column" gutterSize="xs">
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
@@ -288,7 +288,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
-                    <EuiFlexItem>
+                    <EuiFlexItem grow={false}>
                       <EuiCodeEditor
                         mode="json"
                         theme="textmate"
@@ -313,10 +313,11 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         }}
                       />
                     </EuiFlexItem>
+                    <EuiSpacer size="s" />
                     <EuiFlexItem grow={false}>
                       <EuiText size="m">Input variables</EuiText>
                     </EuiFlexItem>
-                    <EuiFlexItem>
+                    <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
                         justifyContent="spaceAround"
@@ -437,7 +438,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                   </EuiFlexGroup>
                 </EuiFlexItem>
                 <EuiFlexItem grow={4}>
-                  <EuiFlexGroup direction="column">
+                  <EuiFlexGroup direction="column" gutterSize="xs">
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
@@ -607,6 +608,28 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         width="100%"
                         height="15vh"
                         value={sourceInput}
+                        readOnly={true}
+                        setOptions={{
+                          fontSize: '12px',
+                          autoScrollEditorIntoView: true,
+                          showLineNumbers: false,
+                          showGutter: false,
+                          showPrintMargin: false,
+                          wrap: true,
+                        }}
+                        tabSize={2}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s">Prompt</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiCodeEditor
+                        mode="json"
+                        theme="textmate"
+                        width="100%"
+                        height="15vh"
+                        value={transformedInput}
                         readOnly={true}
                         setOptions={{
                           fontSize: '12px',

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
-import { useFormikContext, getIn } from 'formik';
+import React, { useEffect, useState } from 'react';
+import { useFormikContext, getIn, Formik } from 'formik';
+import * as yup from 'yup';
 import {
   EuiCodeEditor,
   EuiFlexGroup,
@@ -19,13 +20,19 @@ import {
   EuiText,
   EuiPopover,
   EuiContextMenu,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import {
+  MAX_TEMPLATE_STRING_LENGTH,
   ModelInterface,
   PROMPT_PRESETS,
   PromptPreset,
+  TemplateFormValues,
+  TemplateSchema,
   WorkflowFormValues,
 } from '../../../../../../../common';
+import { getInitialValue } from '../../../../../../utils';
+import { isEmpty } from 'lodash';
 
 interface ConfigureTemplateModalProps {
   fieldPath: string;
@@ -42,88 +49,166 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
     WorkflowFormValues
   >();
 
+  // sub-form values/schema
+  const templateFormValues = {
+    template: getInitialValue('string'),
+  } as TemplateFormValues;
+  const templateFormSchema = yup.object({
+    template: yup
+      .string()
+      .trim()
+      .min(1, 'Too short')
+      .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long')
+      .required('Required') as yup.Schema,
+  }) as TemplateSchema;
+
+  // persist standalone values. update / initialize when it is first opened
+  const [tempTemplate, setTempTemplate] = useState<string>('');
+  const [tempErrors, setTempErrors] = useState<boolean>(false);
+
+  // button updating state
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
   // popover states
   const [presetsPopoverOpen, setPresetsPopoverOpen] = useState<boolean>(false);
 
+  // if updating, take the temp var and assign it to the parent form
+  function onUpdate() {
+    setIsUpdating(true);
+    setFieldValue(props.fieldPath, tempTemplate);
+    setFieldTouched(props.fieldPath, true);
+    props.onClose();
+  }
+
   return (
-    <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
-      <EuiModalHeader>
-        <EuiModalHeaderTitle>
-          <p>{`Configure template`}</p>
-        </EuiModalHeaderTitle>
-      </EuiModalHeader>
-      <EuiModalBody style={{ height: '40vh' }}>
-        <EuiFlexGroup direction="column">
-          <EuiFlexItem>
-            <>
-              <EuiSpacer size="s" />
-              <EuiPopover
-                button={
-                  <EuiSmallButton
-                    onClick={() => setPresetsPopoverOpen(!presetsPopoverOpen)}
-                    iconSide="right"
-                    iconType="arrowDown"
-                  >
-                    Choose from a preset
-                  </EuiSmallButton>
-                }
-                isOpen={presetsPopoverOpen}
-                closePopover={() => setPresetsPopoverOpen(false)}
-                anchorPosition="downLeft"
+    <Formik
+      enableReinitialize={false}
+      initialValues={templateFormValues}
+      validationSchema={templateFormSchema}
+      onSubmit={(values) => {}}
+      validate={(values) => {}}
+    >
+      {(formikProps) => {
+        // override to parent form value when changes detected
+        useEffect(() => {
+          formikProps.setFieldValue('template', getIn(values, props.fieldPath));
+        }, [getIn(values, 'ingest.docs')]);
+
+        // update tempTemplate when form changes are detected
+        useEffect(() => {
+          setTempTemplate(getIn(formikProps.values, 'template'));
+        }, [getIn(formikProps.values, 'template')]);
+
+        // update tempErrors if errors detected
+        useEffect(() => {
+          setTempErrors(!isEmpty(formikProps.errors));
+        }, [formikProps.errors]);
+
+        return (
+          <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <p>{`Configure template`}</p>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody style={{ height: '40vh' }}>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <>
+                    <EuiSpacer size="s" />
+                    <EuiPopover
+                      button={
+                        <EuiSmallButton
+                          onClick={() =>
+                            setPresetsPopoverOpen(!presetsPopoverOpen)
+                          }
+                          iconSide="right"
+                          iconType="arrowDown"
+                        >
+                          Choose from a preset
+                        </EuiSmallButton>
+                      }
+                      isOpen={presetsPopoverOpen}
+                      closePopover={() => setPresetsPopoverOpen(false)}
+                      anchorPosition="downLeft"
+                    >
+                      <EuiContextMenu
+                        size="s"
+                        initialPanelId={0}
+                        panels={[
+                          {
+                            id: 0,
+                            items: PROMPT_PRESETS.map(
+                              (preset: PromptPreset) => ({
+                                name: preset.name,
+                                onClick: () => {
+                                  try {
+                                    formikProps.setFieldValue(
+                                      'template',
+                                      preset.prompt
+                                    );
+                                  } catch {}
+                                  formikProps.setFieldTouched('template', true);
+                                  setPresetsPopoverOpen(false);
+                                },
+                              })
+                            ),
+                          },
+                        ]}
+                      />
+                    </EuiPopover>
+                    <EuiSpacer size="m" />
+                    <EuiText size="s">Prompt</EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiCodeEditor
+                      mode="json"
+                      theme="textmate"
+                      width="100%"
+                      height="15vh"
+                      value={tempTemplate}
+                      readOnly={false}
+                      setOptions={{
+                        fontSize: '12px',
+                        autoScrollEditorIntoView: true,
+                        showLineNumbers: false,
+                        showGutter: false,
+                        showPrintMargin: false,
+                        wrap: true,
+                      }}
+                      tabSize={2}
+                      onChange={(value) =>
+                        formikProps.setFieldValue('template', value)
+                      }
+                      onBlur={(e) => {
+                        formikProps.setFieldTouched('template');
+                      }}
+                    />
+                  </>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiSmallButtonEmpty
+                onClick={props.onClose}
+                color="primary"
+                data-testid="closeTemplateButton"
               >
-                <EuiContextMenu
-                  size="s"
-                  initialPanelId={0}
-                  panels={[
-                    {
-                      id: 0,
-                      items: PROMPT_PRESETS.map((preset: PromptPreset) => ({
-                        name: preset.name,
-                        onClick: () => {
-                          try {
-                            setFieldValue(props.fieldPath, preset.prompt);
-                          } catch {}
-                          setFieldTouched(props.fieldPath, true);
-                          setPresetsPopoverOpen(false);
-                        },
-                      })),
-                    },
-                  ]}
-                />
-              </EuiPopover>
-              <EuiSpacer size="m" />
-              <EuiText size="s">Prompt</EuiText>
-              <EuiSpacer size="s" />
-              <EuiCodeEditor
-                mode="json"
-                theme="textmate"
-                width="100%"
-                height="15vh"
-                value={getIn(values, props.fieldPath)}
-                readOnly={false}
-                setOptions={{
-                  fontSize: '12px',
-                  autoScrollEditorIntoView: true,
-                  showLineNumbers: false,
-                  showGutter: false,
-                  showPrintMargin: false,
-                  wrap: true,
-                }}
-                tabSize={2}
-                onChange={(value) => setFieldValue(props.fieldPath, value)}
-                onBlur={(e) => {
-                  setFieldTouched(props.fieldPath);
-                }}
-              />
-            </>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiModalBody>
-      <EuiModalFooter>
-        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
-          Close
-        </EuiSmallButton>
-      </EuiModalFooter>
-    </EuiModal>
+                Cancel
+              </EuiSmallButtonEmpty>
+              <EuiSmallButton
+                onClick={() => onUpdate()}
+                isLoading={isUpdating}
+                isDisabled={tempErrors} // blocking update until valid input is given
+                fill={true}
+                color="primary"
+                data-testid="updateTemplateButton"
+              >
+                Save
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        );
+      }}
+    </Formik>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { useFormikContext, getIn } from 'formik';
+import {
+  EuiCodeEditor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSmallButton,
+  EuiSpacer,
+  EuiText,
+  EuiPopover,
+  EuiContextMenu,
+} from '@elastic/eui';
+import {
+  ModelInterface,
+  PROMPT_PRESETS,
+  PromptPreset,
+  WorkflowFormValues,
+} from '../../../../../../../common';
+
+interface ConfigureTemplateModalProps {
+  fieldPath: string;
+  modelInterface: ModelInterface | undefined;
+  onClose: () => void;
+}
+
+/**
+ * A modal to configure a prompt template. Can manually configure, include placeholder values
+ * using other model inputs, and/or select from a presets library.
+ */
+export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
+  const { values, setFieldValue, setFieldTouched } = useFormikContext<
+    WorkflowFormValues
+  >();
+
+  // popover states
+  const [presetsPopoverOpen, setPresetsPopoverOpen] = useState<boolean>(false);
+
+  return (
+    <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <p>{`Configure template`}</p>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody style={{ height: '40vh' }}>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <>
+              <EuiSpacer size="s" />
+              <EuiPopover
+                button={
+                  <EuiSmallButton
+                    onClick={() => setPresetsPopoverOpen(!presetsPopoverOpen)}
+                    iconSide="right"
+                    iconType="arrowDown"
+                  >
+                    Choose from a preset
+                  </EuiSmallButton>
+                }
+                isOpen={presetsPopoverOpen}
+                closePopover={() => setPresetsPopoverOpen(false)}
+                anchorPosition="downLeft"
+              >
+                <EuiContextMenu
+                  size="s"
+                  initialPanelId={0}
+                  panels={[
+                    {
+                      id: 0,
+                      items: PROMPT_PRESETS.map((preset: PromptPreset) => ({
+                        name: preset.name,
+                        onClick: () => {
+                          try {
+                            setFieldValue(props.fieldPath, preset.prompt);
+                          } catch {}
+                          setFieldTouched(props.fieldPath, true);
+                          setPresetsPopoverOpen(false);
+                        },
+                      })),
+                    },
+                  ]}
+                />
+              </EuiPopover>
+              <EuiSpacer size="m" />
+              <EuiText size="s">Prompt</EuiText>
+              <EuiSpacer size="s" />
+              <EuiCodeEditor
+                mode="json"
+                theme="textmate"
+                width="100%"
+                height="15vh"
+                value={getIn(values, props.fieldPath)}
+                readOnly={false}
+                setOptions={{
+                  fontSize: '12px',
+                  autoScrollEditorIntoView: true,
+                  showLineNumbers: false,
+                  showGutter: false,
+                  showPrintMargin: false,
+                  wrap: true,
+                }}
+                tabSize={2}
+                onChange={(value) => setFieldValue(props.fieldPath, value)}
+                onBlur={(e) => {
+                  setFieldTouched(props.fieldPath);
+                }}
+              />
+            </>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButton onClick={props.onClose} fill={false} color="primary">
+          Close
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -22,6 +22,7 @@ import {
   EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiSpacer,
+  EuiCopy,
 } from '@elastic/eui';
 import {
   MAX_STRING_LENGTH,
@@ -282,6 +283,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                 key={idx}
                                 direction="row"
                                 justifyContent="spaceAround"
+                                gutterSize="s"
                               >
                                 <EuiFlexItem grow={KEY_FLEX_RATIO}>
                                   <TextField
@@ -295,6 +297,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                   <EuiFlexGroup
                                     direction="row"
                                     justifyContent="spaceAround"
+                                    gutterSize="xs"
                                   >
                                     <EuiFlexItem>
                                       <TextField
@@ -303,6 +306,40 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                         placeholder={`Transform`}
                                         showError={true}
                                       />
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                      <EuiCopy
+                                        textToCopy={getPlaceholderString(
+                                          getIn(
+                                            formikProps.values,
+                                            `nestedVars.${idx}.transform`
+                                          )
+                                        )}
+                                      >
+                                        {(copy) => (
+                                          <EuiSmallButtonIcon
+                                            aria-label="Copy"
+                                            iconType="copy"
+                                            disabled={isEmpty(
+                                              getIn(
+                                                formikProps.values,
+                                                `nestedVars.${idx}.transform`
+                                              )
+                                            )}
+                                            color={
+                                              isEmpty(
+                                                getIn(
+                                                  formikProps.values,
+                                                  `nestedVars.${idx}.transform`
+                                                )
+                                              )
+                                                ? 'subdued'
+                                                : 'primary'
+                                            }
+                                            onClick={copy}
+                                          />
+                                        )}
+                                      </EuiCopy>
                                     </EuiFlexItem>
                                     <EuiFlexItem grow={false}>
                                       <EuiSmallButtonIcon
@@ -401,4 +438,15 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
       }}
     </Formik>
   );
+}
+
+// small util fn to get the full placeholder string to be
+// inserted into the template. String conversion is required
+// if the input is an array, for example. Also, all values
+// should be prepended with "parameters.", as all inputs
+// will be nested under a base parameters obj.
+function getPlaceholderString(label: string, type?: string) {
+  return type === 'array'
+    ? `\$\{parameters.${label}.toString()\}`
+    : `\$\{parameters.${label}\}`;
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -347,6 +347,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
+                    <EuiSpacer size="s" />
                     <EuiFlexItem grow={false}>
                       <EuiCodeEditor
                         mode="json"

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -112,78 +112,124 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiModalBody style={{ height: '40vh' }}>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem>
-                  <>
-                    <EuiSpacer size="s" />
-                    <EuiPopover
-                      button={
-                        <EuiSmallButton
-                          onClick={() =>
-                            setPresetsPopoverOpen(!presetsPopoverOpen)
-                          }
-                          iconSide="right"
-                          iconType="arrowDown"
-                        >
-                          Choose from a preset
-                        </EuiSmallButton>
-                      }
-                      isOpen={presetsPopoverOpen}
-                      closePopover={() => setPresetsPopoverOpen(false)}
-                      anchorPosition="downLeft"
-                    >
-                      <EuiContextMenu
-                        size="s"
-                        initialPanelId={0}
-                        panels={[
-                          {
-                            id: 0,
-                            items: PROMPT_PRESETS.map(
-                              (preset: PromptPreset) => ({
-                                name: preset.name,
-                                onClick: () => {
-                                  try {
-                                    formikProps.setFieldValue(
-                                      'template',
-                                      preset.prompt
-                                    );
-                                  } catch {}
-                                  formikProps.setFieldTouched('template', true);
-                                  setPresetsPopoverOpen(false);
+              <EuiFlexGroup direction="row">
+                <EuiFlexItem grow={6}>
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceAround"
+                      >
+                        <EuiFlexItem>
+                          <EuiText size="m">Prompt</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiPopover
+                            button={
+                              <EuiSmallButton
+                                onClick={() =>
+                                  setPresetsPopoverOpen(!presetsPopoverOpen)
+                                }
+                                iconSide="right"
+                                iconType="arrowDown"
+                              >
+                                Choose from a preset
+                              </EuiSmallButton>
+                            }
+                            isOpen={presetsPopoverOpen}
+                            closePopover={() => setPresetsPopoverOpen(false)}
+                            anchorPosition="downLeft"
+                          >
+                            <EuiContextMenu
+                              size="s"
+                              initialPanelId={0}
+                              panels={[
+                                {
+                                  id: 0,
+                                  items: PROMPT_PRESETS.map(
+                                    (preset: PromptPreset) => ({
+                                      name: preset.name,
+                                      onClick: () => {
+                                        try {
+                                          formikProps.setFieldValue(
+                                            'template',
+                                            preset.prompt
+                                          );
+                                        } catch {}
+                                        formikProps.setFieldTouched(
+                                          'template',
+                                          true
+                                        );
+                                        setPresetsPopoverOpen(false);
+                                      },
+                                    })
+                                  ),
                                 },
-                              })
-                            ),
-                          },
-                        ]}
+                              ]}
+                            />
+                          </EuiPopover>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiCodeEditor
+                        mode="json"
+                        theme="textmate"
+                        width="100%"
+                        height="25vh"
+                        value={tempTemplate}
+                        readOnly={false}
+                        setOptions={{
+                          fontSize: '12px',
+                          autoScrollEditorIntoView: true,
+                          showLineNumbers: false,
+                          showGutter: false,
+                          showPrintMargin: false,
+                          wrap: true,
+                        }}
+                        tabSize={2}
+                        onChange={(value) =>
+                          formikProps.setFieldValue('template', value)
+                        }
+                        onBlur={(e) => {
+                          formikProps.setFieldTouched('template');
+                        }}
                       />
-                    </EuiPopover>
-                    <EuiSpacer size="m" />
-                    <EuiText size="s">Prompt</EuiText>
-                    <EuiSpacer size="s" />
-                    <EuiCodeEditor
-                      mode="json"
-                      theme="textmate"
-                      width="100%"
-                      height="15vh"
-                      value={tempTemplate}
-                      readOnly={false}
-                      setOptions={{
-                        fontSize: '12px',
-                        autoScrollEditorIntoView: true,
-                        showLineNumbers: false,
-                        showGutter: false,
-                        showPrintMargin: false,
-                        wrap: true,
-                      }}
-                      tabSize={2}
-                      onChange={(value) =>
-                        formikProps.setFieldValue('template', value)
-                      }
-                      onBlur={(e) => {
-                        formikProps.setFieldTouched('template');
-                      }}
-                    />
-                  </>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="m">Input variables</EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiText>TODO add input var mappings here</EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem grow={4}>
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceAround"
+                      >
+                        <EuiFlexItem>
+                          <EuiText size="m">Prompt preview</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiSmallButton
+                            onClick={() =>
+                              // TODO
+                              console.log('executing preview...')
+                            }
+                          >
+                            Run preview
+                          </EuiSmallButton>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiText>TODO add transform here</EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiModalBody>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
@@ -8,3 +8,4 @@ export * from './output_transform_modal';
 export * from './configure_prompt_modal';
 export * from './override_query_modal';
 export * from './configure_template_modal';
+export * from './configure_expression_modal';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
@@ -7,3 +7,4 @@ export * from './input_transform_modal';
 export * from './output_transform_modal';
 export * from './configure_prompt_modal';
 export * from './override_query_modal';
+export * from './configure_template_modal';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -349,11 +349,15 @@ export function ModelInputs(props: ModelInputsProps) {
                                     placeholder={`Input type`}
                                     allowCreate={false}
                                     onChange={() => {
-                                      // If the transform type changes, clear any set value as it will likely not make sense
-                                      // under other types/contexts.
+                                      // If the transform type changes, clear any set value and/or nested vars,
+                                      // as it will likely not make sense under other types/contexts.
                                       setFieldValue(
                                         `${inputMapFieldPath}.${idx}.value.value`,
                                         ''
+                                      );
+                                      setFieldValue(
+                                        `${inputMapFieldPath}.${idx}.value.nestedVars`,
+                                        []
                                       );
                                     }}
                                   />
@@ -387,6 +391,10 @@ export function ModelInputs(props: ModelInputsProps) {
                                         context={props.context}
                                         fieldPath={`${inputMapFieldPath}.${idx}.value`}
                                         modelInterface={modelInterface}
+                                        modelInputFieldName={getIn(
+                                          values,
+                                          `${inputMapFieldPath}.${idx}.key`
+                                        )}
                                         onClose={() =>
                                           setIsExpressionModalOpen(false)
                                         }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -15,8 +15,6 @@ import {
   WorkflowFormValues,
   ModelInterface,
   IndexMappings,
-  REQUEST_PREFIX,
-  REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
   InputMapEntry,
   InputMapFormValue,
   TRANSFORM_TYPE,
@@ -34,7 +32,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiIconTip,
   EuiPanel,
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -49,10 +46,16 @@ interface ModelInputsProps {
   context: PROCESSOR_CONTEXT;
 }
 
-// The keys will be more static in general. Give more space for values where users
-// will typically be writing out more complex transforms/configuration (in the case of ML inference processors).
-const KEY_FLEX_RATIO = 4;
-const VALUE_FLEX_RATIO = 6;
+// Determining spacing between the input field columns
+const KEY_FLEX_RATIO = 3;
+const TYPE_FLEX_RATIO = 2;
+const VALUE_FLEX_RATIO = 5;
+
+const TRANSFORM_OPTIONS = Object.values(TRANSFORM_TYPE).map((type) => {
+  return {
+    label: type,
+  };
+});
 
 /**
  * Base component to configure ML inputs.
@@ -75,7 +78,6 @@ export function ModelInputs(props: ModelInputsProps) {
   ) as IConfigField;
   const modelFieldPath = `${props.baseConfigPath}.${props.config.id}.${modelField.id}`;
   // Assuming no more than one set of input map entries.
-  // TODO: confirm the above.
   const inputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.input_map.0`;
 
   // model interface state
@@ -177,7 +179,7 @@ export function ModelInputs(props: ModelInputsProps) {
       {
         key: '',
         value: {
-          transformType: TRANSFORM_TYPE.FIELD,
+          transformType: '' as TRANSFORM_TYPE,
           value: '',
         },
       } as InputMapEntry,
@@ -198,26 +200,12 @@ export function ModelInputs(props: ModelInputsProps) {
   }
 
   // Defining constants for the key/value text vars, typically dependent on the different processor contexts.
-  const keyTitle = 'Name';
   const keyPlaceholder = 'Name';
   const keyOptions = parseModelInputs(modelInterface);
-  const valueTitle =
-    props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-      ? 'Query field'
-      : 'Document field';
   const valuePlaceholder =
     props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
       ? 'Specify a query field'
       : 'Define a document field';
-  const valueHelpText = `Specify a ${
-    props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST ? 'query' : 'document'
-  } field or define JSONPath to transform the ${
-    props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST ? 'query' : 'document'
-  } to map to a model input field.${
-    props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE
-      ? ` Or, if you'd like to include data from the the original query request, prefix your mapping with "${REQUEST_PREFIX}" or "${REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR}" - for example, "_request.query.match.my_field"`
-      : ''
-  }`;
   const valueOptions =
     props.context === PROCESSOR_CONTEXT.INGEST
       ? docFields
@@ -256,7 +244,16 @@ export function ModelInputs(props: ModelInputsProps) {
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
                               <EuiText size="s" color="subdued">
-                                {keyTitle}
+                                {`Name`}
+                              </EuiText>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                          <EuiFlexGroup direction="row" gutterSize="xs">
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {`Input type`}
                               </EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
@@ -265,14 +262,8 @@ export function ModelInputs(props: ModelInputsProps) {
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
                               <EuiText size="s" color="subdued">
-                                {valueTitle}
+                                Value
                               </EuiText>
-                            </EuiFlexItem>
-                            <EuiFlexItem grow={false}>
-                              <EuiIconTip
-                                content={valueHelpText}
-                                position="right"
-                              />
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
@@ -317,6 +308,7 @@ export function ModelInputs(props: ModelInputsProps) {
                                             fieldPath={`${inputMapFieldPath}.${idx}.key`}
                                             options={keyOptions as any[]}
                                             placeholder={keyPlaceholder}
+                                            allowCreate={true}
                                           />
                                         ) : (
                                           <TextField
@@ -337,6 +329,16 @@ export function ModelInputs(props: ModelInputsProps) {
                                   </>
                                 </EuiFlexGroup>
                               </EuiFlexItem>
+                              <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                                <EuiFlexItem>
+                                  <SelectWithCustomOptions
+                                    fieldPath={`${inputMapFieldPath}.${idx}.value.transformType`}
+                                    options={TRANSFORM_OPTIONS}
+                                    placeholder={`Input type`}
+                                    allowCreate={false}
+                                  />
+                                </EuiFlexItem>
+                              </EuiFlexItem>
                               <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                                 <EuiFlexGroup direction="row" gutterSize="xs">
                                   <>
@@ -349,6 +351,7 @@ export function ModelInputs(props: ModelInputsProps) {
                                             placeholder={
                                               valuePlaceholder || 'Output'
                                             }
+                                            allowCreate={true}
                                           />
                                         ) : (
                                           <TextField

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -31,6 +31,7 @@ import {
   TRANSFORM_TYPE,
   EMPTY_INPUT_MAP_ENTRY,
   WorkflowConfig,
+  getCharacterLimitedString,
 } from '../../../../../../common';
 import { TextField, SelectWithCustomOptions } from '../../input_fields';
 import { AppState, getMappings, useAppDispatch } from '../../../../../store';
@@ -404,28 +405,122 @@ export function ModelInputs(props: ModelInputsProps) {
                                       <>
                                         {transformType ===
                                         TRANSFORM_TYPE.TEMPLATE ? (
-                                          <EuiSmallButton
-                                            style={{ width: '100px' }}
-                                            fill={false}
-                                            onClick={() =>
-                                              setIsTemplateModalOpen(true)
-                                            }
-                                            data-testid="configureTemplateButton"
-                                          >
-                                            Configure
-                                          </EuiSmallButton>
+                                          <>
+                                            {isEmpty(
+                                              getIn(
+                                                values,
+                                                `${inputMapFieldPath}.${idx}.value.value`
+                                              )
+                                            ) ? (
+                                              <EuiSmallButton
+                                                style={{ width: '100px' }}
+                                                fill={false}
+                                                onClick={() =>
+                                                  setIsTemplateModalOpen(true)
+                                                }
+                                                data-testid="configureTemplateButton"
+                                              >
+                                                Configure
+                                              </EuiSmallButton>
+                                            ) : (
+                                              <EuiFlexGroup
+                                                direction="row"
+                                                justifyContent="spaceAround"
+                                              >
+                                                <EuiFlexItem>
+                                                  <EuiText
+                                                    size="s"
+                                                    color="subdued"
+                                                    style={{
+                                                      marginTop: '4px',
+                                                      whiteSpace: 'nowrap',
+                                                      overflow: 'hidden',
+                                                    }}
+                                                  >
+                                                    {getCharacterLimitedString(
+                                                      getIn(
+                                                        values,
+                                                        `${inputMapFieldPath}.${idx}.value.value`
+                                                      ),
+                                                      15
+                                                    )}
+                                                  </EuiText>
+                                                </EuiFlexItem>
+                                                <EuiFlexItem grow={false}>
+                                                  <EuiSmallButtonIcon
+                                                    aria-label="edit"
+                                                    iconType="pencil"
+                                                    disabled={false}
+                                                    color={'primary'}
+                                                    onClick={() => {
+                                                      setIsTemplateModalOpen(
+                                                        true
+                                                      );
+                                                    }}
+                                                  />
+                                                </EuiFlexItem>
+                                              </EuiFlexGroup>
+                                            )}
+                                          </>
                                         ) : transformType ===
                                           TRANSFORM_TYPE.EXPRESSION ? (
-                                          <EuiSmallButton
-                                            style={{ width: '100px' }}
-                                            fill={false}
-                                            onClick={() =>
-                                              setIsExpressionModalOpen(true)
-                                            }
-                                            data-testid="configureExpressionButton"
-                                          >
-                                            Configure
-                                          </EuiSmallButton>
+                                          <>
+                                            {isEmpty(
+                                              getIn(
+                                                values,
+                                                `${inputMapFieldPath}.${idx}.value.value`
+                                              )
+                                            ) ? (
+                                              <EuiSmallButton
+                                                style={{ width: '100px' }}
+                                                fill={false}
+                                                onClick={() =>
+                                                  setIsExpressionModalOpen(true)
+                                                }
+                                                data-testid="configureExpressionButton"
+                                              >
+                                                Configure
+                                              </EuiSmallButton>
+                                            ) : (
+                                              <EuiFlexGroup
+                                                direction="row"
+                                                justifyContent="spaceAround"
+                                              >
+                                                <EuiFlexItem>
+                                                  <EuiText
+                                                    size="s"
+                                                    color="subdued"
+                                                    style={{
+                                                      marginTop: '4px',
+                                                      whiteSpace: 'nowrap',
+                                                      overflow: 'hidden',
+                                                    }}
+                                                  >
+                                                    {getCharacterLimitedString(
+                                                      getIn(
+                                                        values,
+                                                        `${inputMapFieldPath}.${idx}.value.value`
+                                                      ),
+                                                      15
+                                                    )}
+                                                  </EuiText>
+                                                </EuiFlexItem>
+                                                <EuiFlexItem grow={false}>
+                                                  <EuiSmallButtonIcon
+                                                    aria-label="edit"
+                                                    iconType="pencil"
+                                                    disabled={false}
+                                                    color={'primary'}
+                                                    onClick={() => {
+                                                      setIsExpressionModalOpen(
+                                                        true
+                                                      );
+                                                    }}
+                                                  />
+                                                </EuiFlexItem>
+                                              </EuiFlexGroup>
+                                            )}
+                                          </>
                                         ) : isEmpty(transformType) ||
                                           transformType ===
                                             TRANSFORM_TYPE.STRING ||

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -39,7 +39,7 @@ import {
   parseModelInputs,
   sanitizeJSONPath,
 } from '../../../../../utils';
-import { ConfigureTemplateModal } from './modals/';
+import { ConfigureExpressionModal, ConfigureTemplateModal } from './modals/';
 
 interface ModelInputsProps {
   config: IProcessorConfig;
@@ -89,6 +89,9 @@ export function ModelInputs(props: ModelInputsProps) {
 
   // various modal states
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState<boolean>(
+    false
+  );
+  const [isExpressionModalOpen, setIsExpressionModalOpen] = useState<boolean>(
     false
   );
 
@@ -376,6 +379,19 @@ export function ModelInputs(props: ModelInputsProps) {
                                         }
                                       />
                                     )}
+                                    {isExpressionModalOpen && (
+                                      <ConfigureExpressionModal
+                                        config={props.config}
+                                        baseConfigPath={props.baseConfigPath}
+                                        uiConfig={props.uiConfig}
+                                        context={props.context}
+                                        fieldPath={`${inputMapFieldPath}.${idx}.value`}
+                                        modelInterface={modelInterface}
+                                        onClose={() =>
+                                          setIsExpressionModalOpen(false)
+                                        }
+                                      />
+                                    )}
                                     <EuiFlexItem>
                                       <>
                                         {transformType ===
@@ -390,10 +406,19 @@ export function ModelInputs(props: ModelInputsProps) {
                                           >
                                             Configure
                                           </EuiSmallButton>
+                                        ) : transformType ===
+                                          TRANSFORM_TYPE.EXPRESSION ? (
+                                          <EuiSmallButton
+                                            style={{ width: '100px' }}
+                                            fill={false}
+                                            onClick={() =>
+                                              setIsExpressionModalOpen(true)
+                                            }
+                                            data-testid="configureExpressionButton"
+                                          >
+                                            Configure
+                                          </EuiSmallButton>
                                         ) : isEmpty(transformType) ||
-                                          // TODO: add buttons & new modals to configure expressions & templates
-                                          transformType ===
-                                            TRANSFORM_TYPE.EXPRESSION ||
                                           transformType ===
                                             TRANSFORM_TYPE.STRING ||
                                           transformType ===

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -30,6 +30,7 @@ import {
   InputMapFormValue,
   TRANSFORM_TYPE,
   EMPTY_INPUT_MAP_ENTRY,
+  WorkflowConfig,
 } from '../../../../../../common';
 import { TextField, SelectWithCustomOptions } from '../../input_fields';
 import { AppState, getMappings, useAppDispatch } from '../../../../../store';
@@ -43,6 +44,7 @@ import { ConfigureTemplateModal } from './modals/';
 interface ModelInputsProps {
   config: IProcessorConfig;
   baseConfigPath: string;
+  uiConfig: WorkflowConfig;
   context: PROCESSOR_CONTEXT;
 }
 
@@ -363,6 +365,10 @@ export function ModelInputs(props: ModelInputsProps) {
                                      */}
                                     {isTemplateModalOpen && (
                                       <ConfigureTemplateModal
+                                        config={props.config}
+                                        baseConfigPath={props.baseConfigPath}
+                                        uiConfig={props.uiConfig}
+                                        context={props.context}
                                         fieldPath={`${inputMapFieldPath}.${idx}.value`}
                                         modelInterface={modelInterface}
                                         onClose={() =>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -9,6 +9,17 @@ import { isEmpty } from 'lodash';
 import { useSelector } from 'react-redux';
 import { flattie } from 'flattie';
 import {
+  EuiCompressedFormRow,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
+  EuiSmallButton,
+  EuiSmallButtonEmpty,
+  EuiSmallButtonIcon,
+  EuiText,
+} from '@elastic/eui';
+import {
   IProcessorConfig,
   IConfigField,
   PROCESSOR_CONTEXT,
@@ -20,25 +31,14 @@ import {
   TRANSFORM_TYPE,
   EMPTY_INPUT_MAP_ENTRY,
 } from '../../../../../../common';
-import { TextField } from '../../input_fields';
+import { TextField, SelectWithCustomOptions } from '../../input_fields';
 import { AppState, getMappings, useAppDispatch } from '../../../../../store';
 import {
   getDataSourceId,
   parseModelInputs,
   sanitizeJSONPath,
 } from '../../../../../utils';
-import {
-  EuiCompressedFormRow,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiPanel,
-  EuiSmallButton,
-  EuiSmallButtonEmpty,
-  EuiSmallButtonIcon,
-  EuiText,
-} from '@elastic/eui';
-import { SelectWithCustomOptions } from '../../input_fields/select_with_custom_options';
+import { ConfigureTemplateModal } from './modals/';
 
 interface ModelInputsProps {
   config: IProcessorConfig;
@@ -84,6 +84,11 @@ export function ModelInputs(props: ModelInputsProps) {
   const [modelInterface, setModelInterface] = useState<
     ModelInterface | undefined
   >(undefined);
+
+  // various modal states
+  const [isTemplateModalOpen, setIsTemplateModalOpen] = useState<boolean>(
+    false
+  );
 
   // on initial load of the models, update model interface states
   useEffect(() => {
@@ -356,17 +361,38 @@ export function ModelInputs(props: ModelInputsProps) {
                                      * Conditionally render the value form component based on the transform type.
                                      * It may be a button, dropdown, or simply freeform text.
                                      */}
+                                    {isTemplateModalOpen && (
+                                      <ConfigureTemplateModal
+                                        fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
+                                        modelInterface={modelInterface}
+                                        onClose={() =>
+                                          setIsTemplateModalOpen(false)
+                                        }
+                                      />
+                                    )}
                                     <EuiFlexItem>
                                       <>
-                                        {isEmpty(transformType) ||
-                                        // TODO: add buttons & new modals to configure expressions & templates
-                                        transformType ===
-                                          TRANSFORM_TYPE.EXPRESSION ||
-                                        transformType ===
-                                          TRANSFORM_TYPE.STRING ||
-                                        transformType ===
-                                          TRANSFORM_TYPE.TEMPLATE ||
-                                        isEmpty(valueOptions) ? (
+                                        {transformType ===
+                                        TRANSFORM_TYPE.TEMPLATE ? (
+                                          <EuiSmallButton
+                                            style={{ width: '100px' }}
+                                            fill={false}
+                                            onClick={() =>
+                                              setIsTemplateModalOpen(true)
+                                            }
+                                            data-testid="configureTemplateButton"
+                                          >
+                                            Configure
+                                          </EuiSmallButton>
+                                        ) : isEmpty(transformType) ||
+                                          // TODO: add buttons & new modals to configure expressions & templates
+                                          transformType ===
+                                            TRANSFORM_TYPE.EXPRESSION ||
+                                          transformType ===
+                                            TRANSFORM_TYPE.STRING ||
+                                          transformType ===
+                                            TRANSFORM_TYPE.TEMPLATE ||
+                                          isEmpty(valueOptions) ? (
                                           <TextField
                                             fullWidth={true}
                                             fieldPath={`${inputMapFieldPath}.${idx}.value.value`}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -48,8 +48,8 @@ interface ModelInputsProps {
 
 // Spacing between the input field columns
 const KEY_FLEX_RATIO = 3;
-const TYPE_FLEX_RATIO = 2;
-const VALUE_FLEX_RATIO = 5;
+const TYPE_FLEX_RATIO = 3;
+const VALUE_FLEX_RATIO = 4;
 
 const TRANSFORM_OPTIONS = Object.values(TRANSFORM_TYPE).map((type) => {
   return {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -363,7 +363,7 @@ export function ModelInputs(props: ModelInputsProps) {
                                      */}
                                     {isTemplateModalOpen && (
                                       <ConfigureTemplateModal
-                                        fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
+                                        fieldPath={`${inputMapFieldPath}.${idx}.value`}
                                         modelInterface={modelInterface}
                                         onClose={() =>
                                           setIsTemplateModalOpen(false)

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -46,7 +46,7 @@ interface ModelInputsProps {
   context: PROCESSOR_CONTEXT;
 }
 
-// Determining spacing between the input field columns
+// Spacing between the input field columns
 const KEY_FLEX_RATIO = 3;
 const TYPE_FLEX_RATIO = 2;
 const VALUE_FLEX_RATIO = 5;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -20,6 +20,7 @@ import {
   InputMapEntry,
   InputMapFormValue,
   TRANSFORM_TYPE,
+  EMPTY_INPUT_MAP_ENTRY,
 } from '../../../../../../common';
 import { TextField } from '../../input_fields';
 import { AppState, getMappings, useAppDispatch } from '../../../../../store';
@@ -35,6 +36,7 @@ import {
   EuiIcon,
   EuiIconTip,
   EuiPanel,
+  EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiText,
@@ -224,170 +226,190 @@ export function ModelInputs(props: ModelInputsProps) {
       : indexMappingFields;
 
   return (
-    <EuiPanel grow={true}>
-      <Field name={inputMapFieldPath} key={inputMapFieldPath}>
-        {({ field, form }: FieldProps) => {
-          return (
-            <EuiCompressedFormRow
-              fullWidth={true}
-              key={inputMapFieldPath}
-              error={
-                getIn(errors, field.name) !== undefined &&
-                getIn(errors, field.name).length > 0
-                  ? 'Invalid or missing mapping values'
-                  : false
-              }
-              isInvalid={
-                getIn(errors, field.name) !== undefined &&
-                getIn(errors, field.name).length > 0 &&
-                getIn(touched, field.name) !== undefined &&
-                getIn(touched, field.name).length > 0
-              }
-            >
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ marginBottom: '0px' }}>
-                  <EuiFlexGroup direction="row" gutterSize="xs">
-                    <EuiFlexItem grow={KEY_FLEX_RATIO}>
-                      <EuiFlexGroup direction="row" gutterSize="xs">
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="s" color="subdued">
-                            {keyTitle}
-                          </EuiText>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                      <EuiFlexGroup direction="row" gutterSize="xs">
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="s" color="subdued">
-                            {valueTitle}
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiIconTip
-                            content={valueHelpText}
-                            position="right"
-                          />
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-                {field.value?.map((mapEntry: InputMapEntry, idx: number) => {
-                  return (
-                    <EuiFlexItem key={idx}>
+    <Field name={inputMapFieldPath} key={inputMapFieldPath}>
+      {({ field, form }: FieldProps) => {
+        const populatedMap = field.value?.length !== 0;
+        return (
+          <>
+            {populatedMap ? (
+              <EuiPanel>
+                <EuiCompressedFormRow
+                  fullWidth={true}
+                  key={inputMapFieldPath}
+                  error={
+                    getIn(errors, field.name) !== undefined &&
+                    getIn(errors, field.name).length > 0
+                      ? 'Invalid or missing mapping values'
+                      : false
+                  }
+                  isInvalid={
+                    getIn(errors, field.name) !== undefined &&
+                    getIn(errors, field.name).length > 0 &&
+                    getIn(touched, field.name) !== undefined &&
+                    getIn(touched, field.name).length > 0
+                  }
+                >
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem style={{ marginBottom: '0px' }}>
                       <EuiFlexGroup direction="row" gutterSize="xs">
                         <EuiFlexItem grow={KEY_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
-                            <>
-                              <EuiFlexItem>
-                                <>
-                                  {/**
-                                   * We determine if there is an interface based on if there are key options or not,
-                                   * as the options would be derived from the underlying interface.
-                                   * And if so, these values should be static.
-                                   * So, we only display the static text with no mechanism to change it's value.
-                                   * Note we still allow more entries, if a user wants to override / add custom
-                                   * keys if there is some gaps in the model interface.
-                                   */}
-                                  {!isEmpty(keyOptions) &&
-                                  !isEmpty(
-                                    getIn(
-                                      values,
-                                      `${inputMapFieldPath}.${idx}.key`
-                                    )
-                                  ) ? (
-                                    <EuiText
-                                      size="s"
-                                      style={{ marginTop: '4px' }}
-                                    >
-                                      {getIn(
-                                        values,
-                                        `${inputMapFieldPath}.${idx}.key`
-                                      )}
-                                    </EuiText>
-                                  ) : !isEmpty(keyOptions) ? (
-                                    <SelectWithCustomOptions
-                                      fieldPath={`${inputMapFieldPath}.${idx}.key`}
-                                      options={keyOptions as any[]}
-                                      placeholder={keyPlaceholder}
-                                    />
-                                  ) : (
-                                    <TextField
-                                      fullWidth={true}
-                                      fieldPath={`${inputMapFieldPath}.${idx}.key`}
-                                      placeholder={keyPlaceholder}
-                                      showError={false}
-                                    />
-                                  )}
-                                </>
-                              </EuiFlexItem>
-                              <EuiFlexItem
-                                grow={false}
-                                style={{ marginTop: '10px' }}
-                              >
-                                <EuiIcon type={'sortLeft'} />
-                              </EuiFlexItem>
-                            </>
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {keyTitle}
+                              </EuiText>
+                            </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
-                            <>
-                              <EuiFlexItem>
-                                <>
-                                  {!isEmpty(valueOptions) ? (
-                                    <SelectWithCustomOptions
-                                      fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
-                                      options={valueOptions || []}
-                                      placeholder={valuePlaceholder || 'Output'}
-                                    />
-                                  ) : (
-                                    <TextField
-                                      fullWidth={true}
-                                      fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
-                                      placeholder={valuePlaceholder || 'Output'}
-                                      showError={false}
-                                    />
-                                  )}
-                                </>
-                              </EuiFlexItem>
-                              <EuiFlexItem grow={false}>
-                                <EuiSmallButtonIcon
-                                  iconType={'trash'}
-                                  color="danger"
-                                  aria-label="Delete"
-                                  onClick={() => {
-                                    deleteMapEntry(field.value, idx);
-                                  }}
-                                />
-                              </EuiFlexItem>
-                            </>
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {valueTitle}
+                              </EuiText>
+                            </EuiFlexItem>
+                            <EuiFlexItem grow={false}>
+                              <EuiIconTip
+                                content={valueHelpText}
+                                position="right"
+                              />
+                            </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
-                  );
-                })}
-                <EuiFlexItem grow={false}>
-                  <div>
-                    <EuiSmallButtonEmpty
-                      style={{ marginLeft: '-8px', marginTop: '0px' }}
-                      iconType={'plusInCircle'}
-                      iconSide="left"
-                      onClick={() => {
-                        addMapEntry(field.value);
-                      }}
-                    >
-                      {`Add input`}
-                    </EuiSmallButtonEmpty>
-                  </div>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiCompressedFormRow>
-          );
-        }}
-      </Field>
-    </EuiPanel>
+                    {field.value?.map(
+                      (mapEntry: InputMapEntry, idx: number) => {
+                        return (
+                          <EuiFlexItem key={idx}>
+                            <EuiFlexGroup direction="row" gutterSize="xs">
+                              <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                                <EuiFlexGroup direction="row" gutterSize="xs">
+                                  <>
+                                    <EuiFlexItem>
+                                      <>
+                                        {/**
+                                         * We determine if there is an interface based on if there are key options or not,
+                                         * as the options would be derived from the underlying interface.
+                                         * And if so, these values should be static.
+                                         * So, we only display the static text with no mechanism to change it's value.
+                                         * Note we still allow more entries, if a user wants to override / add custom
+                                         * keys if there is some gaps in the model interface.
+                                         */}
+                                        {!isEmpty(keyOptions) &&
+                                        !isEmpty(
+                                          getIn(
+                                            values,
+                                            `${inputMapFieldPath}.${idx}.key`
+                                          )
+                                        ) ? (
+                                          <EuiText
+                                            size="s"
+                                            style={{ marginTop: '4px' }}
+                                          >
+                                            {getIn(
+                                              values,
+                                              `${inputMapFieldPath}.${idx}.key`
+                                            )}
+                                          </EuiText>
+                                        ) : !isEmpty(keyOptions) ? (
+                                          <SelectWithCustomOptions
+                                            fieldPath={`${inputMapFieldPath}.${idx}.key`}
+                                            options={keyOptions as any[]}
+                                            placeholder={keyPlaceholder}
+                                          />
+                                        ) : (
+                                          <TextField
+                                            fullWidth={true}
+                                            fieldPath={`${inputMapFieldPath}.${idx}.key`}
+                                            placeholder={keyPlaceholder}
+                                            showError={false}
+                                          />
+                                        )}
+                                      </>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={false}
+                                      style={{ marginTop: '10px' }}
+                                    >
+                                      <EuiIcon type={'sortLeft'} />
+                                    </EuiFlexItem>
+                                  </>
+                                </EuiFlexGroup>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                                <EuiFlexGroup direction="row" gutterSize="xs">
+                                  <>
+                                    <EuiFlexItem>
+                                      <>
+                                        {!isEmpty(valueOptions) ? (
+                                          <SelectWithCustomOptions
+                                            fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
+                                            options={valueOptions || []}
+                                            placeholder={
+                                              valuePlaceholder || 'Output'
+                                            }
+                                          />
+                                        ) : (
+                                          <TextField
+                                            fullWidth={true}
+                                            fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
+                                            placeholder={
+                                              valuePlaceholder || 'Output'
+                                            }
+                                            showError={false}
+                                          />
+                                        )}
+                                      </>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                      <EuiSmallButtonIcon
+                                        iconType={'trash'}
+                                        color="danger"
+                                        aria-label="Delete"
+                                        onClick={() => {
+                                          deleteMapEntry(field.value, idx);
+                                        }}
+                                      />
+                                    </EuiFlexItem>
+                                  </>
+                                </EuiFlexGroup>
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                        );
+                      }
+                    )}
+                    <EuiFlexItem grow={false}>
+                      <div>
+                        <EuiSmallButtonEmpty
+                          style={{ marginLeft: '-8px', marginTop: '0px' }}
+                          iconType={'plusInCircle'}
+                          iconSide="left"
+                          onClick={() => {
+                            addMapEntry(field.value);
+                          }}
+                        >
+                          {`Add input`}
+                        </EuiSmallButtonEmpty>
+                      </div>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiCompressedFormRow>
+              </EuiPanel>
+            ) : (
+              <EuiSmallButton
+                style={{ width: '100px' }}
+                onClick={() => {
+                  setFieldValue(field.name, [EMPTY_INPUT_MAP_ENTRY]);
+                }}
+              >
+                {'Configure'}
+              </EuiSmallButton>
+            )}
+          </>
+        );
+      }}
+    </Field>
   );
 }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -20,8 +20,11 @@ import {
   EuiCompressedFormRow,
 } from '@elastic/eui';
 import {
+  EMPTY_INPUT_MAP_ENTRY,
   IMAGE_FIELD_PATTERN,
   IndexMappings,
+  InputMapArrayFormValue,
+  InputMapFormValue,
   LABEL_FIELD_PATTERN,
   MODEL_ID_PATTERN,
   MapArrayFormValue,
@@ -30,6 +33,7 @@ import {
   PROCESSOR_TYPE,
   QuickConfigureFields,
   TEXT_FIELD_PATTERN,
+  TRANSFORM_TYPE,
   VECTOR,
   VECTOR_FIELD_PATTERN,
   WORKFLOW_NAME_REGEXP,
@@ -255,17 +259,23 @@ function updateIngestProcessors(
           field.value = { id: fields.modelId };
         }
         if (field.id === 'input_map') {
-          const inputMap = generateMapFromModelInputs(modelInterface);
+          const inputMap = generateInputMapFromModelInputs(modelInterface);
           if (fields.textField) {
             if (inputMap.length > 0) {
               inputMap[0] = {
                 ...inputMap[0],
-                value: fields.textField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.textField,
+                },
               };
             } else {
               inputMap.push({
                 key: '',
-                value: fields.textField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.textField,
+                },
               });
             }
           }
@@ -273,16 +283,22 @@ function updateIngestProcessors(
             if (inputMap.length > 1) {
               inputMap[1] = {
                 ...inputMap[1],
-                value: fields.imageField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.imageField,
+                },
               };
             } else {
               inputMap.push({
                 key: '',
-                value: fields.imageField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.imageField,
+                },
               });
             }
           }
-          field.value = [inputMap] as MapArrayFormValue;
+          field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
           const outputMap = generateMapFromModelOutputs(modelInterface);
@@ -328,19 +344,25 @@ function updateSearchRequestProcessors(
           field.value = { id: fields.modelId };
         }
         if (field.id === 'input_map') {
-          const inputMap = generateMapFromModelInputs(modelInterface);
+          const inputMap = generateInputMapFromModelInputs(modelInterface);
           if (inputMap.length > 0) {
             inputMap[0] = {
               ...inputMap[0],
-              value: defaultQueryValue,
+              value: {
+                transformType: TRANSFORM_TYPE.FIELD,
+                value: defaultQueryValue,
+              },
             };
           } else {
             inputMap.push({
               key: '',
-              value: defaultQueryValue,
+              value: {
+                transformType: TRANSFORM_TYPE.FIELD,
+                value: defaultQueryValue,
+              },
             });
           }
-          field.value = [inputMap] as MapArrayFormValue;
+          field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
           const outputMap = generateMapFromModelOutputs(modelInterface);
@@ -392,21 +414,27 @@ function updateSearchResponseProcessors(
           field.value = { id: fields.modelId };
         }
         if (field.id === 'input_map') {
-          const inputMap = generateMapFromModelInputs(modelInterface);
+          const inputMap = generateInputMapFromModelInputs(modelInterface);
           if (fields.textField) {
             if (inputMap.length > 0) {
               inputMap[0] = {
                 ...inputMap[0],
-                value: fields.textField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.textField,
+                },
               };
             } else {
               inputMap.push({
                 key: '',
-                value: fields.textField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.textField,
+                },
               });
             }
           }
-          field.value = [inputMap] as MapArrayFormValue;
+          field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
           const outputMap = generateMapFromModelOutputs(modelInterface);
@@ -526,16 +554,16 @@ function injectPlaceholderValues(
 
 // generate a set of mappings s.t. each key is
 // a unique model input.
-function generateMapFromModelInputs(
+function generateInputMapFromModelInputs(
   modelInterface?: ModelInterface
-): MapFormValue {
-  const inputMap = [] as MapFormValue;
+): InputMapFormValue {
+  const inputMap = [] as InputMapFormValue;
   if (modelInterface) {
     const modelInputs = parseModelInputs(modelInterface);
     modelInputs.forEach((modelInput) => {
       inputMap.push({
+        ...EMPTY_INPUT_MAP_ENTRY,
         key: modelInput.label,
-        value: '',
       });
     });
   }

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -16,7 +16,6 @@ import {
   ConfigFieldValue,
   ModelFormValue,
   SearchIndexConfig,
-  TRANSFORM_TYPE,
 } from '../../common';
 
 /*
@@ -148,7 +147,7 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
       return '[]';
     }
     case 'mapArray':
-    case 'transformArray': {
+    case 'inputMapArray': {
       return [];
     }
     case 'boolean': {
@@ -156,12 +155,6 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     }
     case 'number': {
       return 0;
-    }
-    case 'transform': {
-      return {
-        transformType: TRANSFORM_TYPE.FIELD,
-        value: '',
-      };
     }
   }
 }

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -16,6 +16,7 @@ import {
   ConfigFieldValue,
   ModelFormValue,
   SearchIndexConfig,
+  TRANSFORM_TYPE,
 } from '../../common';
 
 /*
@@ -146,7 +147,8 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     case 'jsonArray': {
       return '[]';
     }
-    case 'mapArray': {
+    case 'mapArray':
+    case 'transformArray': {
       return [];
     }
     case 'boolean': {
@@ -154,6 +156,12 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
     }
     case 'number': {
       return 0;
+    }
+    case 'transform': {
+      return {
+        transformType: TRANSFORM_TYPE.FIELD,
+        value: '',
+      };
     }
   }
 }

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -200,7 +200,10 @@ export function getFieldSchema(
             key: defaultStringSchema.required(),
             value: yup.object().shape({
               transformType: defaultStringSchema.required(),
-              value: defaultStringSchema.required(),
+              value: yup
+                .string()
+                .min(1, 'Too short')
+                .max(MAX_JSON_STRING_LENGTH, 'Too long'),
             }),
           })
         )

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -18,6 +18,7 @@ import {
   MAX_DOCS,
   MAX_STRING_LENGTH,
   MAX_JSON_STRING_LENGTH,
+  MAX_TEMPLATE_STRING_LENGTH,
 } from '../../common';
 
 /*
@@ -203,7 +204,7 @@ export function getFieldSchema(
               value: yup
                 .string()
                 .min(1, 'Too short')
-                .max(MAX_JSON_STRING_LENGTH, 'Too long'),
+                .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long'),
             }),
           })
         )

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -205,6 +205,12 @@ export function getFieldSchema(
                 .string()
                 .min(1, 'Too short')
                 .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long'),
+              nestedVars: yup.array().of(
+                yup.object().shape({
+                  name: defaultStringSchema.required(),
+                  value: defaultStringSchema.required(),
+                })
+              ),
             }),
           })
         )

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -208,7 +208,7 @@ export function getFieldSchema(
               nestedVars: yup.array().of(
                 yup.object().shape({
                   name: defaultStringSchema.required(),
-                  value: defaultStringSchema.required(),
+                  transform: defaultStringSchema.required(),
                 })
               ),
             }),

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -192,6 +192,29 @@ export function getFieldSchema(
       );
       break;
     }
+    case 'transform': {
+      yup.object().shape({
+        key: defaultStringSchema.required(),
+        value: yup.object().shape({
+          transformType: defaultStringSchema.required(),
+          value: defaultStringSchema.required(),
+        }),
+      });
+
+      break;
+    }
+    case 'transformArray': {
+      baseSchema = yup.array().of(
+        yup.object().shape({
+          key: defaultStringSchema.required(),
+          value: yup.object().shape({
+            transformType: defaultStringSchema.required(),
+            value: defaultStringSchema.required(),
+          }),
+        })
+      );
+      break;
+    }
     case 'boolean': {
       baseSchema = yup.boolean();
       break;

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -171,7 +171,6 @@ export function getFieldSchema(
             }
           }
         );
-
       break;
     }
     case 'jsonString': {
@@ -192,26 +191,19 @@ export function getFieldSchema(
       );
       break;
     }
-    case 'transform': {
-      yup.object().shape({
-        key: defaultStringSchema.required(),
-        value: yup.object().shape({
-          transformType: defaultStringSchema.required(),
-          value: defaultStringSchema.required(),
-        }),
-      });
-
-      break;
-    }
-    case 'transformArray': {
+    // an array of an array of transforms.
+    // this format comes from the ML inference processor input map.
+    case 'inputMapArray': {
       baseSchema = yup.array().of(
-        yup.object().shape({
-          key: defaultStringSchema.required(),
-          value: yup.object().shape({
-            transformType: defaultStringSchema.required(),
-            value: defaultStringSchema.required(),
-          }),
-        })
+        yup.array().of(
+          yup.object().shape({
+            key: defaultStringSchema.required(),
+            value: yup.object().shape({
+              transformType: defaultStringSchema.required(),
+              value: defaultStringSchema.required(),
+            }),
+          })
+        )
       );
       break;
     }
@@ -221,6 +213,7 @@ export function getFieldSchema(
     }
     case 'number': {
       baseSchema = yup.number();
+      break;
     }
   }
 

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -25,7 +25,6 @@ import {
   SearchProcessor,
   IngestConfig,
   SearchConfig,
-  MapFormValue,
   MapEntry,
   TEXT_CHUNKING_ALGORITHM,
   SHARED_OPTIONAL_FIELDS,
@@ -33,6 +32,8 @@ import {
   DELIMITER_OPTIONAL_FIELDS,
   IngestPipelineConfig,
   SearchPipelineConfig,
+  InputMapFormValue,
+  MapFormValue,
 } from '../../common';
 import { processorConfigToFormik } from './config_to_form_utils';
 import { sanitizeJSONPath } from './utils';
@@ -184,7 +185,8 @@ export function processorConfigsToTemplateProcessors(
         // process input/output maps
         if (input_map?.length > 0) {
           processor.ml_inference.input_map = input_map.map(
-            (mapFormValue: MapFormValue) => mergeMapIntoSingleObj(mapFormValue)
+            (inputMapFormValue: InputMapFormValue) =>
+              mergeInputMapIntoSingleObj(inputMapFormValue)
           );
         }
 
@@ -442,7 +444,7 @@ export function reduceToTemplate(workflow: Workflow): WorkflowTemplate {
 
 // Helper fn to merge the form map (an arr of objs) into a single obj, such that each key
 // is an obj property, and each value is a property value. Used to format into the
-// expected inputs for input_maps and output_maps of the ML inference processors.
+// expected inputs for processor configurations
 function mergeMapIntoSingleObj(
   mapFormValue: MapFormValue,
   reverse: boolean = false
@@ -457,6 +459,30 @@ function mergeMapIntoSingleObj(
       : {
           ...curMap,
           [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(mapEntry.value),
+        };
+  });
+  return curMap;
+}
+
+// Same as mergeMapIntoSingleObj, but specified for the ML processor input map format.
+function mergeInputMapIntoSingleObj(
+  mapFormValue: InputMapFormValue,
+  reverse: boolean = false
+): {} {
+  let curMap = {} as MapEntry;
+  mapFormValue.forEach((mapEntry) => {
+    curMap = reverse
+      ? {
+          ...curMap,
+          [sanitizeJSONPath(mapEntry.value.value)]: sanitizeJSONPath(
+            mapEntry.key
+          ),
+        }
+      : {
+          ...curMap,
+          [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(
+            mapEntry.value.value
+          ),
         };
   });
   return curMap;

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -493,6 +493,24 @@ function processModelInputs(
           mapEntry.value.value
         ),
       };
+      // template with dynamic nested vars. Add the nested vars as input map entries,
+      // and add the static template itself to the model config.
+    } else if (
+      mapEntry.value.transformType === TRANSFORM_TYPE.TEMPLATE &&
+      !isEmpty(mapEntry.value.nestedVars)
+    ) {
+      mapEntry.value.nestedVars?.forEach((nestedVar) => {
+        inputMap = {
+          ...inputMap,
+          [sanitizeJSONPath(nestedVar.name)]: sanitizeJSONPath(
+            nestedVar.transform
+          ),
+        };
+      });
+      modelConfig = {
+        ...modelConfig,
+        [mapEntry.key]: mapEntry.value.value,
+      };
       // static data
     } else {
       modelConfig = {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -28,6 +28,8 @@ import {
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
 import {
+  InputMapEntry,
+  InputMapFormValue,
   MDSQueryParams,
   MapEntry,
   ModelInputMap,
@@ -188,7 +190,7 @@ export function unwrapTransformedDocs(
 // We follow the same logic here to generate consistent results.
 export function generateTransform(
   input: {} | [],
-  map: MapFormValue,
+  map: InputMapEntry[],
   context: PROCESSOR_CONTEXT,
   transformContext: TRANSFORM_CONTEXT,
   queryContext?: {}
@@ -198,7 +200,7 @@ export function generateTransform(
     try {
       const transformedResult = getTransformedResult(
         input,
-        mapEntry.value,
+        mapEntry.value.value,
         context,
         transformContext,
         queryContext
@@ -218,7 +220,7 @@ export function generateTransform(
 // and the input is an array.
 export function generateArrayTransform(
   input: [],
-  map: MapFormValue,
+  map: InputMapEntry[],
   context: PROCESSOR_CONTEXT,
   transformContext: TRANSFORM_CONTEXT,
   queryContext?: {}
@@ -230,8 +232,8 @@ export function generateArrayTransform(
       // prefix, parse the query context, instead of the other input.
       let transformedResult;
       if (
-        (mapEntry.value.startsWith(REQUEST_PREFIX) ||
-          mapEntry.value.startsWith(
+        (mapEntry.value.value.startsWith(REQUEST_PREFIX) ||
+          mapEntry.value.value.startsWith(
             REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR
           )) &&
         queryContext !== undefined &&
@@ -239,7 +241,7 @@ export function generateArrayTransform(
       ) {
         transformedResult = getTransformedResult(
           {},
-          mapEntry.value,
+          mapEntry.value.value,
           context,
           transformContext,
           queryContext
@@ -248,7 +250,7 @@ export function generateArrayTransform(
         transformedResult = input.map((inputEntry) =>
           getTransformedResult(
             inputEntry,
-            mapEntry.value,
+            mapEntry.value.value,
             context,
             transformContext,
             queryContext


### PR DESCRIPTION
### Description

Continuation of #493. Opening to a feature branch so main stays stable. This PR breaks the advanced transform modals entirely.

This PR completes the new UX flows for configuring input transforms. At a high level, this adds support for:
- toggling between different transform types (static value vs. field vs. JSONPath transform vs. template)
- configuring JSONPath expressions / transforms via new modal
- configuring templates (and any sub-transform mappings) via new modal

Implementation details:
- updates the schema for the input map - this means changes in the UI config, Formik form, and yup schema to be compatible. Basically, we introduce a new field for each input map entry, called `transformType`, which allows dynamic rendering of different form components based on the type selected. For example, selecting 'Field' will offer a dropdown of the available document or query fields. Selecting 'String' will show a freeform textbox.
- refactoring and re-creating a lot of the existing `MapField` component logic inside of the newly-refactored `ModelInputs` component, but entirely customized for the input map, since it requires too much custom logic to remain a generic component, and was getting overloaded with props anyways. _Note: later on, we will likely clean up all of these props, as the generic form is still used for other processors, such as the text chunking processor's `field_map` field_. Also, copies over some of the logic from `MapArrayField` to dynamically render a 'Configure' button if the map is empty.
- adds new `ConfigureExpressionModal` to configure the JSONPath expression in a dedicated modal. Copies over some of the data fetching & transform logic from the existing `InputTransformModal`, but now it is just at a per-field level.
- adds new `ConfigureTemplateModal` to configure a template, as well as any sub-transform variables that can be injected in the template. Copies over some of the data fetching and transform logic from the `InputTransformModal`, and `ConfigurePromptModal`.
- updates the `QuickConfigureModal` to support the new config such that quick-configure values are populated in the input map appropriately
- changes in the conversion util fns (config -> form, config -> schema, etc.) to account for the schema changes. Adds logic to parse out some of the values and bucket them into `model_config` fields (if static), or `input_map` values (if dynamic). Takes any transforms defined under templates and adds them to the underlying `input_map`.
- additions to constants and interfaces to account for the schema changes

Testing
- confirmed underlying ML processor configs handle all new transform types successfully
- confirmed configs can build and produce working ingest / search pipelines

Demo video:

[screen-capture (7).webm](https://github.com/user-attachments/assets/8d5b7ceb-b0f5-402a-8ca2-713c068ba6ae)

[screen-capture (7).webm](https://github.com/user-attachments/assets/5fec8cd0-349e-45ae-a28f-cb5f50ffe8eb)


### Issues Resolved

Makes progress on #491 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
