### PR TITLE
Adding experimental badge in header in Workflows list page

### DIFF
--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -39,6 +39,7 @@ import {
 import { prettifyErrorMessage } from '../../../common/utils';
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { ExperimentalBadge } from '../../general_components';
+import { TopNavControlData } from '../../../../../src/plugins/navigation/public';
 
 export interface WorkflowsRouterProps {}
 
@@ -88,7 +89,7 @@ export function Workflows(props: WorkflowsProps) {
     chrome: { setBreadcrumbs },
   } = getCore();
   const { HeaderControl } = getNavigationUI();
-  const { setAppDescriptionControls } = getApplication();
+  const { setAppDescriptionControls, setAppCenterControls } = getApplication();
 
   // import modal state
   const [isImportModalOpen, setIsImportModalOpen] = useState<boolean>(false);
@@ -202,6 +203,23 @@ export function Workflows(props: WorkflowsProps) {
       );
     }, [getSavedObjectsClient, getNotifications(), props.setActionMenu]);
   }
+
+  const experimentalBadgeInHeader = (
+    <HeaderControl
+      setMountPoint={setAppCenterControls}
+      controls={[
+        {
+          renderComponent: (
+            <ExperimentalBadge
+              popoverEnabled={true}
+              popoverAnchorPosition="downLeft"
+            />
+          ),
+        } as TopNavControlData,
+      ]}
+    />
+  );
+
   const DESCRIPTION = `Design, experiment, and prototype your solutions with ${PLUGIN_NAME}. Build your search and last mile 
   ingestion flows with a visual interface. Experiment with different configurations with prototyping tools and launch them 
   into your environment.`;
@@ -244,6 +262,7 @@ export function Workflows(props: WorkflowsProps) {
         />
       )}
       {dataSourceEnabled && renderDataSourceComponent}
+      {USE_NEW_HOME_PAGE && experimentalBadgeInHeader}
       <EuiPage>
         <EuiPageBody>
           <EuiPageHeader


### PR DESCRIPTION
### Description

- Adding experimental badge in header in Workflows list page


New home page with MDS enabled.
<img width="1352" alt="Screenshot 2024-11-21 at 10 10 15 AM" src="https://github.com/user-attachments/assets/6a0ab1b6-e591-42fd-a75d-f25e6b1e3a14">

New home page with no MDS.
<img width="1352" alt="Screenshot 2024-11-21 at 10 45 37 AM" src="https://github.com/user-attachments/assets/00ee7af8-340d-4cad-bf8f-c763484faf14">
<img width="1352" alt="Screenshot 2024-11-21 at 10 54 34 AM" src="https://github.com/user-attachments/assets/a7061523-26b2-4991-a52b-9cb1835a3070">


Old home page with MDS enabled. (No changes here)
<img width="1352" alt="Screenshot 2024-11-21 at 10 42 36 AM" src="https://github.com/user-attachments/assets/a6afb9bc-ea8a-4763-a007-9e74e90ae013">

Old home page with no MDS. (No changes here)
<img width="1352" alt="Screenshot 2024-11-21 at 10 43 18 AM" src="https://github.com/user-attachments/assets/acfbe564-f544-4950-a08b-eb22b2a9c301">




### Issues Resolved
- Related to https://github.com/opensearch-project/dashboards-flow-framework/issues/461

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
