### PR TITLE
hide ML presets for version2.17 and before

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -128,6 +128,9 @@ export enum PROCESSOR_TYPE {
   NORMALIZATION = 'normalization-processor',
   COLLAPSE = 'collapse',
   RERANK = 'rerank',
+  TEXT_EMBEDDING = 'text-embedding-processor',
+  TEXT_IMAGE_EMBEDDING = 'text-image-embedding-processor',
+  
 }
 
 export enum MODEL_TYPE {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -6,24 +6,57 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsList } from '../processors_list';
-import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
+import {
+  PROCESSOR_CONTEXT,
+  PROCESSOR_TYPE,
+  WorkflowConfig,
+} from '../../../../../common';
 import { ProcessorsTitle } from '../../../../general_components';
+import { useState, useEffect } from 'react';
 
 interface EnrichDataProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
+  beforeVersion217: boolean;
 }
 
 /**
  * Base component for configuring any data enrichment
  */
 export function EnrichData(props: EnrichDataProps) {
+  const { uiConfig, setUiConfig } = props;
+  const beforeVersion217 = true;
+  const initialProcessorCount = uiConfig.ingest.enrich.processors?.filter(
+    (processor) => processor.type !== PROCESSOR_TYPE.ML
+  ).length;
+  const [processorCount, setProcessorCount] = useState<number>(
+    initialProcessorCount
+  );
+
+  useEffect(() => {
+    var processors = uiConfig.ingest.enrich.processors;
+    if (beforeVersion217) {
+      processors = uiConfig.ingest.enrich.processors.filter(
+        (processor) => processor.type !== PROCESSOR_TYPE.ML
+      );
+    }
+    setProcessorCount(processors.length);
+
+    setUiConfig({
+      ...uiConfig,
+      ingest: {
+        ...uiConfig.ingest,
+        enrich: {
+          ...uiConfig.ingest.enrich,
+          processors: processors,
+        },
+      },
+    });
+  }, [beforeVersion217]);
+
   return (
     <EuiFlexGroup direction="column">
-      <ProcessorsTitle
-        title="Enrich data"
-        processorCount={props.uiConfig.ingest.enrich.processors?.length || 0}
-      />
+      <ProcessorsTitle title="Enrich data" processorCount={processorCount} />
       <EuiFlexItem>
         <ProcessorsList
           uiConfig={props.uiConfig}

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -16,6 +16,7 @@ interface IngestInputsProps {
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   workflow: Workflow | undefined;
   lastIngested: number | undefined;
+  beforeVersion217: boolean;
 }
 
 /**
@@ -36,7 +37,11 @@ export function IngestInputs(props: IngestInputsProps) {
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EnrichData uiConfig={props.uiConfig} setUiConfig={props.setUiConfig} />
+        <EnrichData
+          uiConfig={props.uiConfig}
+          setUiConfig={props.setUiConfig}
+          beforeVersion217={props.beforeVersion217}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />

--- a/public/pages/workflows/new_workflow/new_workflow.test.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.test.tsx
@@ -52,14 +52,23 @@ describe('NewWorkflow', () => {
     jest.spyOn(ReactReduxHooks, 'useAppDispatch').mockReturnValue(mockDispatch);
   });
 
-  test('renders the preset workflow names & descriptions', () => {
+  test('renders the preset workflow names & descriptions when version is before 2.17', () => {
     const presetWorkflows = loadPresetWorkflowTemplates();
+    const allowedPresets = [
+      'Semantic Search',
+      'Hybrid Search',
+      'Multimodal Search',
+    ];
     const { getByPlaceholderText, getAllByText } = renderWithRouter();
     expect(getByPlaceholderText('Search')).toBeInTheDocument();
-    presetWorkflows.forEach((workflow) => {
-      expect(getAllByText(workflow.name)).toHaveLength(1);
-      expect(getAllByText(workflow.description)).toHaveLength(1);
+    allowedPresets.forEach((workflowName) => {
+      expect(getAllByText(workflowName)).toHaveLength(1);
     });
+    presetWorkflows
+      .filter((workflow) => !allowedPresets.includes(workflow.name))
+      .forEach((workflow) => {
+        expect(() => getAllByText(workflow.name)).toThrow();
+      });
   });
 
   test('renders the quick configure for preset workflow templates', async () => {

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -67,15 +67,33 @@ export function NewWorkflow(props: NewWorkflowProps) {
 
   // initial hook to populate all workflows
   // enrich them with dynamically-generated UI flows based on use case
+
+  const beforeVersion217 = true;
   useEffect(() => {
     if (presetWorkflows) {
+      const ALLOWED_PRESETS_FOR_BEFORE_217 = [
+        'Semantic Search',
+        'Hybrid Search',
+        'Multimodal Search',
+      ];
+
+      let filteredPresets = presetWorkflows;
+
+      if (beforeVersion217) {
+        filteredPresets = presetWorkflows.filter(
+          (presetWorkflow) =>
+            presetWorkflow.name &&
+            ALLOWED_PRESETS_FOR_BEFORE_217.includes(presetWorkflow.name)
+        );
+      }
+
       setAllWorkflows(
-        presetWorkflows.map((presetWorkflow) =>
+        filteredPresets.map((presetWorkflow) =>
           enrichPresetWorkflowWithUiMetadata(presetWorkflow)
         )
       );
     }
-  }, [presetWorkflows]);
+  }, [presetWorkflows, beforeVersion217]);
 
   // initial hook to populate filtered workflows
   useEffect(() => {

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -29,7 +29,6 @@ import {
 import { getCore, getDataSourceEnabled } from '../services';
 import {
   MDSQueryParams,
-  MapEntry,
   ModelInputMap,
   ModelOutputMap,
 } from '../../common/interfaces';


### PR DESCRIPTION
### Description

[Hide ML processor presets and expose only neural processor presets for version <= 2.17]

### Issues Resolved

Currently we are building for versions 2.19+ and support latest processors, including ML processors and core processors. For versions before 2.17, we need to hide all the ML processor related presets, and expose only neural processor related presets. These includes: `Hybrid Search, Semantic Search and Multimodal search`. For versions greater than 2.19+, we will keep all the current presets we have.

Clarification:
The ML processor presets include `Semantic Search, Hybrid Search, RAG, Multimodal Search, Sentiment Analysis`. The Neural processor presets include `Hybrid Search, Semantic Search and Multimodal Search`. However, although neural processor presets share the same name and use case, they are separate standalone presets using neural search processors.

Mark this PR as `DRAFT` because I am still figuring out how to get the Open Search backend version from the flow framework plugin.

### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
