### PR TITLE
Add kamahuan as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dbwiddis @owaiskazi19 @joshpalis @ohltyler @amitgalitz @jackiehanyang @minalsha @saimedhi
+* @dbwiddis @owaiskazi19 @joshpalis @ohltyler @amitgalitz @jackiehanyang @minalsha @saimedhi @kamahuan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,3 +14,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Dan Widdis                | [dbwiddis](https://github.com/dbwiddis)           | Amazon      |
 | Minal Shah                | [minalsha](https://github.com/minalsha)           | Amazon      |
 | Sai Medhini Reddy Maryada | [saimedhi](https://github.com/saimedhi)           | Amazon      |
+| Kama Huang                | [kamahuan](https://github.com/kamahuan)           | Amazon      |


### PR DESCRIPTION
### Description

Add kamahuan as maintainer

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
