### PR TITLE
Support different output transform types

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -475,6 +475,7 @@ export enum TRANSFORM_TYPE {
   EXPRESSION = 'Expression',
   TEMPLATE = 'Template',
 }
+export const NO_TRANSFORMATION = 'No transformation';
 export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
@@ -508,6 +509,7 @@ export const EMPTY_INPUT_MAP_ENTRY = {
     value: '',
   },
 } as InputMapEntry;
+export const EMPTY_OUTPUT_MAP_ENTRY = EMPTY_INPUT_MAP_ENTRY;
 export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
   'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
 export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -138,47 +138,48 @@ export type WorkflowSchemaObj = {
 };
 export type WorkflowSchema = ObjectSchema<WorkflowSchemaObj>;
 
-// Form / schema interfaces for the ingest docs sub-form
+/**
+ ********** MODAL SUB-FORM TYPES/INTERFACES **********
+ We persist sub-forms in the form modals s.t. data is only
+ saved back to the parent form if the user explicitly saves.
+
+ We define the structure of the forms here.
+ */
+
+// Ingest docs modal
 export type IngestDocsFormValues = {
   docs: FormikValues;
 };
-export type IngestDocsSchema = WorkflowSchema;
 
-// Form / schema interfaces for the request query sub-form
+// Search request modal
 export type RequestFormValues = {
   request: ConfigFieldValue;
 };
-export type RequestSchema = WorkflowSchema;
 
-// Form / schema interfaces for the input transform sub-form
+// Input transform modal
 export type InputTransformFormValues = {
   input_map: InputMapArrayFormValue;
   one_to_one: ConfigFieldValue;
 };
-export type InputTransformSchema = WorkflowSchema;
 
-// Form / schema interfaces for the output transform sub-form
+// Output transform modal
 export type OutputTransformFormValues = {
   output_map: MapArrayFormValue;
   full_response_path: ConfigFieldValue;
 };
-export type OutputTransformSchema = WorkflowSchema;
 
-// Form / schema interfaces for the template sub-form
+// Configure template modal
 export type TemplateFormValues = Omit<Transform, 'transformType'>;
-export type TemplateSchema = WorkflowSchema;
 
-// Form / schema interfaces for the expression/transform sub-form
+// Configure expression modal
 export type ExpressionFormValues = {
   expression: string;
 };
-export type ExpressionSchema = WorkflowSchema;
 
-// Form / schema interfaces for the multi-expression/transform sub-form
+// Configure multi-expression modal
 export type MultiExpressionFormValues = {
   expressions: ExpressionVar[];
 };
-export type MultiExpressionSchema = ArraySchema<any, AnyObject, '', ''>;
 
 /**
  ********** WORKSPACE TYPES/INTERFACES **********

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -37,7 +37,8 @@ export type ConfigFieldType =
   | 'mapArray'
   | 'boolean'
   | 'number'
-  | 'inputMapArray';
+  | 'inputMapArray'
+  | 'outputMapArray';
 
 export type ConfigFieldValue = string | {};
 
@@ -119,10 +120,13 @@ export type InputMapEntry = {
   key: string;
   value: Transform;
 };
+export type OutputMapEntry = InputMapEntry;
 
 export type InputMapFormValue = InputMapEntry[];
+export type OutputMapFormValue = OutputMapEntry[];
 
 export type InputMapArrayFormValue = InputMapFormValue[];
+export type OutputMapArrayFormValue = OutputMapFormValue[];
 
 export type WorkflowFormValues = {
   ingest: FormikValues;

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { Node, Edge } from 'reactflow';
 import { FormikValues } from 'formik';
-import { ObjectSchema } from 'yup';
+import { AnyObject, ArraySchema, ObjectSchema } from 'yup';
 import {
   COMPONENT_CLASS,
   PROCESSOR_TYPE,
@@ -103,7 +103,7 @@ export type MapFormValue = MapEntry[];
 
 export type MapArrayFormValue = MapFormValue[];
 
-export type TemplateVar = {
+export type ExpressionVar = {
   name: string;
   transform: string;
 };
@@ -113,7 +113,7 @@ export type Transform = {
   value?: string;
   // Templates may persist their own set of nested transforms
   // to be dynamically injected into the template
-  nestedVars?: TemplateVar[];
+  nestedVars?: ExpressionVar[];
 };
 
 export type InputMapEntry = {
@@ -173,6 +173,12 @@ export type ExpressionFormValues = {
   expression: string;
 };
 export type ExpressionSchema = WorkflowSchema;
+
+// Form / schema interfaces for the multi-expression/transform sub-form
+export type MultiExpressionFormValues = {
+  expressions: ExpressionVar[];
+};
+export type MultiExpressionSchema = ArraySchema<any, AnyObject, '', ''>;
 
 /**
  ********** WORKSPACE TYPES/INTERFACES **********

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -110,7 +110,7 @@ export type TemplateVar = {
 
 export type Transform = {
   transformType: TRANSFORM_TYPE;
-  value: string;
+  value?: string;
   // Templates may persist their own set of nested transforms
   // to be dynamically injected into the template
   nestedVars?: TemplateVar[];

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { Node, Edge } from 'reactflow';
 import { FormikValues } from 'formik';
-import { AnyObject, ArraySchema, ObjectSchema } from 'yup';
+import { ObjectSchema } from 'yup';
 import {
   COMPONENT_CLASS,
   PROCESSOR_TYPE,

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -26,7 +26,7 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'output_map',
-        type: 'mapArray',
+        type: 'outputMapArray',
       },
     ];
     this.optionalFields = [

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -31,7 +31,6 @@ import {
   IConfigField,
   IndexMappings,
   IngestDocsFormValues,
-  IngestDocsSchema,
   isVectorSearchUseCase,
   SearchHit,
   SOURCE_OPTIONS,
@@ -78,7 +77,7 @@ export function SourceDataModal(props: SourceDataProps) {
     docs: getFieldSchema({
       type: 'jsonArray',
     } as IConfigField),
-  }) as IngestDocsSchema;
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempDocs, setTempDocs] = useState<string>('[]');

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -419,6 +419,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             baseConfigPath={props.baseConfigPath}
             uiConfig={props.uiConfig}
             context={props.context}
+            isDataFetchingAvailable={isInputPreviewAvailable}
           />
           <EuiSpacer size="l" />
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
@@ -454,6 +455,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             baseConfigPath={props.baseConfigPath}
             uiConfig={props.uiConfig}
             context={props.context}
+            isDataFetchingAvailable={isOutputPreviewAvailable}
           />
           <EuiSpacer size="s" />
           {inputMapValue.length !== outputMapValue.length &&

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -29,12 +29,13 @@ import {
   ModelInterface,
   IndexMappings,
   PROMPT_FIELD,
-  MapArrayFormValue,
-  MapEntry,
-  MapFormValue,
   EMPTY_INPUT_MAP_ENTRY,
   REQUEST_PREFIX,
   REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
+  OutputMapEntry,
+  OutputMapFormValue,
+  OutputMapArrayFormValue,
+  EMPTY_OUTPUT_MAP_ENTRY,
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
@@ -154,11 +155,11 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     const modelOutputsAsForm = [
       parseModelOutputs(newModelInterface).map((modelOutput) => {
         return {
+          ...EMPTY_OUTPUT_MAP_ENTRY,
           key: modelOutput.label,
-          value: '',
-        } as MapEntry;
-      }) as MapFormValue,
-    ] as MapArrayFormValue;
+        } as OutputMapEntry;
+      }) as OutputMapFormValue,
+    ] as OutputMapArrayFormValue;
 
     setFieldValue(inputMapFieldPath, modelInputsAsForm);
     setFieldValue(outputMapFieldPath, modelOutputsAsForm);
@@ -451,6 +452,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           <ModelOutputs
             config={props.config}
             baseConfigPath={props.baseConfigPath}
+            uiConfig={props.uiConfig}
             context={props.context}
           />
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -463,7 +463,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
               <EuiSmallButtonEmpty
                 onClick={props.onClose}
                 color="primary"
-                data-testid="closeTemplateButton"
+                data-testid="closeExpressionButton"
               >
                 Cancel
               </EuiSmallButtonEmpty>
@@ -480,7 +480,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                 isDisabled={tempErrors} // blocking update until valid input is given
                 fill={true}
                 color="primary"
-                data-testid="updateTemplateButton"
+                data-testid="updateExpressionButton"
               >
                 Save
               </EuiSmallButton>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -74,7 +74,7 @@ const VALUE_FLEX_RATIO = 4;
 const MAX_INPUT_DOCS = 10;
 
 /**
- * A modal to configure a JSONPath expression / transform.
+ * A modal to configure a JSONPath expression / transform. Used for configuring model input transforms.
  */
 export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
   const dispatch = useAppDispatch();

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -24,7 +24,6 @@ import {
 import {
   customStringify,
   ExpressionFormValues,
-  ExpressionSchema,
   IngestPipelineConfig,
   InputMapEntry,
   IProcessorConfig,
@@ -94,7 +93,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
       .min(1, 'Too short')
       .max(MAX_STRING_LENGTH, 'Too long')
       .required('Required') as yup.Schema,
-  }) as ExpressionSchema;
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempExpression, setTempExpression] = useState<string>('');

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -62,6 +62,7 @@ interface ConfigureExpressionModalProps {
   modelInputFieldName: string;
   fieldPath: string;
   modelInterface: ModelInterface | undefined;
+  isDataFetchingAvailable: boolean;
   onClose: () => void;
 }
 
@@ -264,7 +265,11 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                           <EuiSmallButton
                             style={{ width: '100px' }}
                             isLoading={isFetching}
-                            disabled={onIngestAndNoDocs || onSearchAndNoQuery}
+                            disabled={
+                              onIngestAndNoDocs ||
+                              onSearchAndNoQuery ||
+                              !props.isDataFetchingAvailable
+                            }
                             onClick={async () => {
                               setIsFetching(true);
                               switch (props.context) {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -206,7 +206,6 @@ export function ConfigureMultiExpressionModal(
 
         // update tempErrors if errors detected
         useEffect(() => {
-          console.log('formik errors: ', formikProps.errors);
           setTempErrors(!isEmpty(formikProps.errors));
         }, [formikProps.errors]);
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -30,7 +30,6 @@ import {
   MAX_STRING_LENGTH,
   ModelInterface,
   MultiExpressionFormValues,
-  MultiExpressionSchema,
   OutputMapEntry,
   PROCESSOR_CONTEXT,
   SearchHit,
@@ -89,25 +88,27 @@ export function ConfigureMultiExpressionModal(
   const expressionsFormValues = {
     expressions: [],
   } as MultiExpressionFormValues;
-  const expressionsFormSchema = yup
-    .array()
-    .of(
-      yup.object({
-        name: yup
-          .string()
-          .trim()
-          .min(1, 'Too short')
-          .max(MAX_STRING_LENGTH, 'Too long')
-          .required('Required') as yup.Schema,
-        transform: yup
-          .string()
-          .trim()
-          .min(1, 'Too short')
-          .max(MAX_STRING_LENGTH, 'Too long')
-          .required('Required') as yup.Schema,
-      })
-    )
-    .min(1) as MultiExpressionSchema;
+  const expressionsFormSchema = yup.object({
+    expressions: yup
+      .array()
+      .of(
+        yup.object({
+          name: yup
+            .string()
+            .trim()
+            .min(1, 'Too short')
+            .max(MAX_STRING_LENGTH, 'Too long')
+            .required('Required') as yup.Schema,
+          transform: yup
+            .string()
+            .trim()
+            .min(1, 'Too short')
+            .max(MAX_STRING_LENGTH, 'Too long')
+            .required('Required') as yup.Schema,
+        })
+      )
+      .min(1),
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempExpressions, setTempExpressions] = useState<ExpressionVar[]>([]);
@@ -205,6 +206,7 @@ export function ConfigureMultiExpressionModal(
 
         // update tempErrors if errors detected
         useEffect(() => {
+          console.log('formik errors: ', formikProps.errors);
           setTempErrors(!isEmpty(formikProps.errors));
         }, [formikProps.errors]);
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -20,6 +20,7 @@ import {
   EuiText,
   EuiSmallButtonEmpty,
   EuiSpacer,
+  EuiSmallButtonIcon,
 } from '@elastic/eui';
 import {
   customStringify,
@@ -205,6 +206,27 @@ export function ConfigureMultiExpressionModal(
           setTempErrors(!isEmpty(formikProps.errors));
         }, [formikProps.errors]);
 
+        // Adding an input var to the end of the existing arr
+        function addExpression(curExpressions: ExpressionVar[]): void {
+          const updatedExpressions = [
+            ...curExpressions,
+            { name: '', transform: '' } as ExpressionVar,
+          ];
+          formikProps.setFieldValue(`expressions`, updatedExpressions);
+          formikProps.setFieldTouched(`expressions`, true);
+        }
+
+        // Deleting an input var
+        function deleteExpression(
+          expressions: ExpressionVar[],
+          idxToDelete: number
+        ): void {
+          const updatedExpressions = [...expressions];
+          updatedExpressions.splice(idxToDelete, 1);
+          formikProps.setFieldValue('expressions', updatedExpressions);
+          formikProps.setFieldTouched('expressions', true);
+        }
+
         return (
           <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
             <EuiModalHeader>
@@ -217,7 +239,7 @@ export function ConfigureMultiExpressionModal(
                 <EuiFlexItem grow={5}>
                   <EuiFlexGroup direction="column" gutterSize="xs">
                     <EuiFlexItem grow={false}>
-                      <EuiFlexGroup direction="row" gutterSize="m">
+                      <EuiFlexGroup direction="row" gutterSize="s">
                         <EuiFlexItem grow={KEY_FLEX_RATIO}>
                           <EuiText size="s" color="subdued">
                             {`Expressions`}
@@ -230,27 +252,75 @@ export function ConfigureMultiExpressionModal(
                         </EuiFlexItem>
                       </EuiFlexGroup>
                       <EuiSpacer size="s" />
-                      <EuiFlexGroup direction="row" gutterSize="m">
-                        <EuiFlexItem grow={KEY_FLEX_RATIO}>
-                          {/**
-                           * TODO: change this to dynamic arr with minimum one entry
-                           */}
-                          <TextField
-                            fullWidth={true}
-                            fieldPath={`expressions.0.transform`}
-                            placeholder={`$.data`}
-                            showError={true}
-                          />
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                          <TextField
-                            fullWidth={true}
-                            fieldPath={`expressions.0.name`}
-                            placeholder={`New document field`}
-                            showError={true}
-                          />
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
+                      {formikProps.values.expressions?.map(
+                        (expression, idx) => {
+                          return (
+                            <div key={idx}>
+                              <EuiFlexGroup
+                                key={idx}
+                                direction="row"
+                                justifyContent="spaceAround"
+                                gutterSize="s"
+                              >
+                                <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                                  <TextField
+                                    fullWidth={true}
+                                    fieldPath={`expressions.${idx}.transform`}
+                                    placeholder={`Transform`}
+                                    showError={true}
+                                  />
+                                </EuiFlexItem>
+                                <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                                  <EuiFlexGroup
+                                    direction="row"
+                                    justifyContent="spaceAround"
+                                    gutterSize="xs"
+                                  >
+                                    <EuiFlexItem>
+                                      <TextField
+                                        fullWidth={true}
+                                        fieldPath={`expressions.${idx}.name`}
+                                        placeholder={`New document field`}
+                                        showError={true}
+                                      />
+                                    </EuiFlexItem>
+                                    {idx > 0 && (
+                                      <EuiFlexItem grow={false}>
+                                        <EuiSmallButtonIcon
+                                          iconType={'trash'}
+                                          color="danger"
+                                          aria-label="Delete"
+                                          onClick={() => {
+                                            deleteExpression(
+                                              formikProps.values.expressions ||
+                                                [],
+                                              idx
+                                            );
+                                          }}
+                                        />
+                                      </EuiFlexItem>
+                                    )}
+                                  </EuiFlexGroup>
+                                </EuiFlexItem>
+                              </EuiFlexGroup>
+                              <EuiSpacer size="s" />
+                            </div>
+                          );
+                        }
+                      )}
+                      <EuiSmallButtonEmpty
+                        style={{
+                          marginLeft: '-8px',
+                          width: '125px',
+                        }}
+                        iconType={'plusInCircle'}
+                        iconSide="left"
+                        onClick={() => {
+                          addExpression(formikProps.values.expressions || []);
+                        }}
+                      >
+                        {`Add expression`}
+                      </EuiSmallButtonEmpty>
                       <EuiSpacer size="s" />
                     </EuiFlexItem>
                   </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -64,6 +64,7 @@ interface ConfigureMultiExpressionModalProps {
   fieldPath: string;
   modelInterface: ModelInterface | undefined;
   outputMapFieldPath: string;
+  isDataFetchingAvailable: boolean;
   onClose: () => void;
 }
 
@@ -72,7 +73,8 @@ const KEY_FLEX_RATIO = 6;
 const VALUE_FLEX_RATIO = 4;
 
 /**
- * A modal to configure multiple JSONPath expression / transforms.
+ * A modal to configure multiple JSONPath expression / transforms. Used for parsing out
+ * model outputs, which can be arbitrarily complex / nested.
  */
 export function ConfigureMultiExpressionModal(
   props: ConfigureMultiExpressionModalProps
@@ -247,7 +249,9 @@ export function ConfigureMultiExpressionModal(
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                           <EuiText size="s" color="subdued">
-                            {`New document field`}
+                            {props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
+                              ? `New query field`
+                              : `New document field`}
                           </EuiText>
                         </EuiFlexItem>
                       </EuiFlexGroup>
@@ -280,7 +284,12 @@ export function ConfigureMultiExpressionModal(
                                       <TextField
                                         fullWidth={true}
                                         fieldPath={`expressions.${idx}.name`}
-                                        placeholder={`New document field`}
+                                        placeholder={
+                                          props.context ===
+                                          PROCESSOR_CONTEXT.SEARCH_REQUEST
+                                            ? `New query field`
+                                            : `New document field`
+                                        }
                                         showError={true}
                                       />
                                     </EuiFlexItem>
@@ -311,7 +320,7 @@ export function ConfigureMultiExpressionModal(
                       <EuiSmallButtonEmpty
                         style={{
                           marginLeft: '-8px',
-                          width: '125px',
+                          width: '150px',
                         }}
                         iconType={'plusInCircle'}
                         iconSide="left"
@@ -339,7 +348,11 @@ export function ConfigureMultiExpressionModal(
                           <EuiSmallButton
                             style={{ width: '100px' }}
                             isLoading={isFetching}
-                            disabled={onIngestAndNoDocs || onSearchAndNoQuery}
+                            disabled={
+                              onIngestAndNoDocs ||
+                              onSearchAndNoQuery ||
+                              !props.isDataFetchingAvailable
+                            }
                             onClick={async () => {
                               setIsFetching(true);
                               switch (props.context) {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -82,7 +82,8 @@ const MAX_INPUT_DOCS = 10;
 
 /**
  * A modal to configure a prompt template. Can manually configure, include placeholder values
- * using other model inputs, and/or select from a presets library.
+ * using other model inputs, and/or select from a presets library. Used for configuring model
+ * input transforms.
  */
 export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
   const dispatch = useAppDispatch();

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -166,11 +166,11 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {
-    const nestedVarsAsInputMap = tempNestedVars?.map((ExpressionVar) => {
+    const nestedVarsAsInputMap = tempNestedVars?.map((expressionVar) => {
       return {
-        key: ExpressionVar.name,
+        key: expressionVar.name,
         value: {
-          value: ExpressionVar.transform,
+          value: expressionVar.transform,
         },
       } as InputMapEntry;
     });
@@ -198,7 +198,6 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                 TRANSFORM_CONTEXT.INPUT,
                 queryObj
               );
-
         setTransformedInput(customStringify(output));
       } catch {}
     } else {
@@ -395,7 +394,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                       </EuiFlexGroup>
                       <EuiSpacer size="s" />
                       {formikProps.values.nestedVars?.map(
-                        (ExpressionVar, idx) => {
+                        (expressionVar, idx) => {
                           return (
                             <div key={idx}>
                               <EuiFlexGroup

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -67,9 +67,9 @@ interface ConfigureTemplateModalProps {
   config: IProcessorConfig;
   context: PROCESSOR_CONTEXT;
   baseConfigPath: string;
-
   fieldPath: string;
   modelInterface: ModelInterface | undefined;
+  isDataFetchingAvailable: boolean;
   onClose: () => void;
 }
 
@@ -510,7 +510,11 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                           <EuiSmallButton
                             style={{ width: '100px' }}
                             isLoading={isFetching}
-                            disabled={onIngestAndNoDocs || onSearchAndNoQuery}
+                            disabled={
+                              onIngestAndNoDocs ||
+                              onSearchAndNoQuery ||
+                              !props.isDataFetchingAvailable
+                            }
                             onClick={async () => {
                               setIsFetching(true);
                               switch (props.context) {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -39,7 +39,6 @@ import {
   SearchHit,
   SimulateIngestPipelineResponse,
   TemplateFormValues,
-  TemplateSchema,
   ExpressionVar,
   TRANSFORM_CONTEXT,
   WorkflowConfig,
@@ -119,8 +118,8 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
           .max(MAX_STRING_LENGTH, 'Too long')
           .required('Required') as yup.Schema,
       })
-    ) as yup.Schema,
-  }) as TemplateSchema;
+    ),
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempTemplate, setTempTemplate] = useState<string>('');

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -744,13 +744,12 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
 
 // small util fn to get the full placeholder string to be
 // inserted into the template. String conversion is required
-// if the input is an array, for example. Also, all values
+// if the input is an array, so default to toString() for
+// all types. Also, all values
 // should be prepended with "parameters.", as all inputs
 // will be nested under a base parameters obj.
-function getPlaceholderString(label: string, type?: string) {
-  return type === 'array'
-    ? `\$\{parameters.${label}.toString()\}`
-    : `\$\{parameters.${label}\}`;
+function getPlaceholderString(label: string) {
+  return `\$\{parameters.${label}.toString()\}`;
 }
 
 function injectValuesIntoTemplate(

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/index.ts
@@ -9,3 +9,4 @@ export * from './configure_prompt_modal';
 export * from './override_query_modal';
 export * from './configure_template_modal';
 export * from './configure_expression_modal';
+export * from './configure_multi_expression_modal';

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/input_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/input_transform_modal.tsx
@@ -36,7 +36,6 @@ import {
   IProcessorConfig,
   IngestPipelineConfig,
   InputTransformFormValues,
-  InputTransformSchema,
   MapArrayFormValue,
   ModelInterface,
   PROCESSOR_CONTEXT,
@@ -110,7 +109,7 @@ export function InputTransformModal(props: InputTransformModalProps) {
       } as IConfigField,
       true
     ),
-  }) as InputTransformSchema;
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempErrors, setTempErrors] = useState<boolean>(false);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/output_transform_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/output_transform_modal.tsx
@@ -37,7 +37,6 @@ import {
   MapFormValue,
   ModelInterface,
   OutputTransformFormValues,
-  OutputTransformSchema,
   PROCESSOR_CONTEXT,
   SearchHit,
   SearchPipelineConfig,
@@ -103,7 +102,7 @@ export function OutputTransformModal(props: OutputTransformModalProps) {
       } as IConfigField,
       true
     ),
-  }) as OutputTransformSchema;
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempErrors, setTempErrors] = useState<boolean>(false);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -47,6 +47,7 @@ interface ModelInputsProps {
   baseConfigPath: string;
   uiConfig: WorkflowConfig;
   context: PROCESSOR_CONTEXT;
+  isDataFetchingAvailable: boolean;
 }
 
 // Spacing between the input field columns
@@ -379,6 +380,9 @@ export function ModelInputs(props: ModelInputsProps) {
                                         context={props.context}
                                         fieldPath={`${inputMapFieldPath}.${idx}.value`}
                                         modelInterface={modelInterface}
+                                        isDataFetchingAvailable={
+                                          props.isDataFetchingAvailable
+                                        }
                                         onClose={() =>
                                           setIsTemplateModalOpen(false)
                                         }
@@ -396,6 +400,9 @@ export function ModelInputs(props: ModelInputsProps) {
                                           values,
                                           `${inputMapFieldPath}.${idx}.key`
                                         )}
+                                        isDataFetchingAvailable={
+                                          props.isDataFetchingAvailable
+                                        }
                                         onClose={() =>
                                           setIsExpressionModalOpen(false)
                                         }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -303,6 +303,8 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                           values,
                                           `${outputMapFieldPath}.${idx}.key`
                                         )}
+                                        // pass the full output map field path arr
+                                        outputMapFieldPath={`${props.baseConfigPath}.${props.config.id}.output_map`}
                                         onClose={() =>
                                           setIsExpressionsModalOpen(false)
                                         }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -44,6 +44,7 @@ interface ModelOutputsProps {
   baseConfigPath: string;
   uiConfig: WorkflowConfig;
   context: PROCESSOR_CONTEXT;
+  isDataFetchingAvailable: boolean;
 }
 
 // Spacing between the output field columns
@@ -191,7 +192,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                 {props.context ===
                                 PROCESSOR_CONTEXT.SEARCH_REQUEST
                                   ? 'Query field'
-                                  : 'New document field'}
+                                  : 'New document field(s)'}
                               </EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
@@ -306,6 +307,9 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                         )}
                                         // pass the full output map field path arr
                                         outputMapFieldPath={`${props.baseConfigPath}.${props.config.id}.output_map`}
+                                        isDataFetchingAvailable={
+                                          props.isDataFetchingAvailable
+                                        }
                                         onClose={() =>
                                           setIsExpressionsModalOpen(false)
                                         }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -361,15 +361,18 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                                         idx,
                                                         arr
                                                       ) => {
-                                                        return `${getCharacterLimitedString(
-                                                          expression.transform ||
-                                                            '',
-                                                          15
-                                                        )}${
-                                                          idx !== arr.length - 1
-                                                            ? `,\n`
-                                                            : ''
-                                                        }`;
+                                                        return idx < 2
+                                                          ? `${getCharacterLimitedString(
+                                                              expression.transform ||
+                                                                '',
+                                                              15
+                                                            )}${
+                                                              idx === 0 &&
+                                                              arr.length > 1
+                                                                ? `,\n`
+                                                                : ''
+                                                            }`
+                                                          : '';
                                                       }
                                                     )}
                                                   </EuiText>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { getIn, useFormikContext } from 'formik';
+import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
 import { useSelector } from 'react-redux';
 import {
@@ -13,34 +13,83 @@ import {
   PROCESSOR_CONTEXT,
   WorkflowFormValues,
   ModelInterface,
+  WorkflowConfig,
+  OutputMapEntry,
+  TRANSFORM_TYPE,
+  NO_TRANSFORMATION,
+  getCharacterLimitedString,
+  OutputMapFormValue,
+  EMPTY_OUTPUT_MAP_ENTRY,
 } from '../../../../../../common';
-import { MapArrayField } from '../../input_fields';
+import { SelectWithCustomOptions, TextField } from '../../input_fields';
 
 import { AppState } from '../../../../../store';
 import { parseModelOutputs } from '../../../../../utils';
+import {
+  EuiCompressedFormRow,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
+  EuiSmallButton,
+  EuiSmallButtonEmpty,
+  EuiSmallButtonIcon,
+  EuiText,
+} from '@elastic/eui';
+import { ConfigureExpressionModal } from './modals';
 
 interface ModelOutputsProps {
   config: IProcessorConfig;
   baseConfigPath: string;
+  uiConfig: WorkflowConfig;
   context: PROCESSOR_CONTEXT;
 }
+
+// Spacing between the output field columns
+const KEY_FLEX_RATIO = 3;
+const TYPE_FLEX_RATIO = 3;
+const VALUE_FLEX_RATIO = 4;
+
+const TRANSFORM_OPTIONS = [
+  {
+    label: TRANSFORM_TYPE.FIELD,
+  },
+  {
+    label: TRANSFORM_TYPE.EXPRESSION,
+  },
+  {
+    label: NO_TRANSFORMATION,
+  },
+];
 
 /**
  * Base component to configure ML outputs.
  */
 export function ModelOutputs(props: ModelOutputsProps) {
   const { models } = useSelector((state: AppState) => state.ml);
-  const { values } = useFormikContext<WorkflowFormValues>();
+  const {
+    errors,
+    values,
+    touched,
+    setFieldValue,
+    setFieldTouched,
+  } = useFormikContext<WorkflowFormValues>();
 
   // get some current form & config values
   const modelField = props.config.fields.find(
     (field) => field.type === 'model'
   ) as IConfigField;
   const modelFieldPath = `${props.baseConfigPath}.${props.config.id}.${modelField.id}`;
-  const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.output_map`;
+  // Assuming no more than one set of output map entries.
+  const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.output_map.0`;
   const fullResponsePath = getIn(
     values,
     `${props.baseConfigPath}.${props.config.id}.full_response_path`
+  );
+
+  // various modal states
+  const [isExpressionModalOpen, setIsExpressionModalOpen] = useState<boolean>(
+    false
   );
 
   // model interface state
@@ -58,28 +107,332 @@ export function ModelOutputs(props: ModelOutputsProps) {
     }
   }, [models]);
 
+  // Adding a map entry to the end of the existing arr
+  function addMapEntry(curEntries: OutputMapFormValue): void {
+    const updatedEntries = [
+      ...curEntries,
+      {
+        key: '',
+        value: {
+          transformType: '' as TRANSFORM_TYPE,
+          value: '',
+        },
+      } as OutputMapEntry,
+    ];
+    setFieldValue(outputMapFieldPath, updatedEntries);
+    setFieldTouched(outputMapFieldPath, true);
+  }
+
+  // Deleting a map entry
+  function deleteMapEntry(
+    curEntries: OutputMapFormValue,
+    entryIndexToDelete: number
+  ): void {
+    const updatedEntries = [...curEntries];
+    updatedEntries.splice(entryIndexToDelete, 1);
+    setFieldValue(outputMapFieldPath, updatedEntries);
+    setFieldTouched(outputMapFieldPath, true);
+  }
+
+  const keyOptions = fullResponsePath
+    ? undefined
+    : parseModelOutputs(modelInterface, false);
+
   return (
-    <MapArrayField
-      fieldPath={outputMapFieldPath}
-      keyTitle="Name"
-      keyPlaceholder="Name"
-      keyHelpText={`Specify a model output field or define JSONPath to transform the model output to map to a new document field.`}
-      keyOptions={
-        fullResponsePath ? undefined : parseModelOutputs(modelInterface, false)
-      }
-      valueTitle={
-        props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-          ? 'Query field'
-          : 'New document field'
-      }
-      valuePlaceholder={
-        props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
-          ? 'Specify a query field'
-          : 'Define a document field'
-      }
-      addMapEntryButtonText="Add output"
-      addMapButtonText="Add output group (Advanced)"
-      mappingDirection="sortRight"
-    />
+    <Field name={outputMapFieldPath} key={outputMapFieldPath}>
+      {({ field, form }: FieldProps) => {
+        const populatedMap = field.value?.length !== 0;
+        return (
+          <>
+            {populatedMap ? (
+              <EuiPanel>
+                <EuiCompressedFormRow
+                  fullWidth={true}
+                  key={outputMapFieldPath}
+                  error={
+                    getIn(errors, field.name) !== undefined &&
+                    getIn(errors, field.name).length > 0
+                      ? 'Invalid or missing mapping values'
+                      : false
+                  }
+                  isInvalid={
+                    getIn(errors, field.name) !== undefined &&
+                    getIn(errors, field.name).length > 0 &&
+                    getIn(touched, field.name) !== undefined &&
+                    getIn(touched, field.name).length > 0
+                  }
+                >
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem style={{ marginBottom: '0px' }}>
+                      <EuiFlexGroup direction="row" gutterSize="xs">
+                        <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                          <EuiFlexGroup direction="row" gutterSize="xs">
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {`Name`}
+                              </EuiText>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                          <EuiFlexGroup direction="row" gutterSize="xs">
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {`Output transform`}
+                              </EuiText>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                          <EuiFlexGroup direction="row" gutterSize="xs">
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="s" color="subdued">
+                                {props.context ===
+                                PROCESSOR_CONTEXT.SEARCH_REQUEST
+                                  ? 'Query field'
+                                  : 'New document field'}
+                              </EuiText>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    {field.value?.map(
+                      (mapEntry: OutputMapEntry, idx: number) => {
+                        // TODO: can I get this from mapEntry directly
+                        const transformType = getIn(
+                          values,
+                          `${outputMapFieldPath}.${idx}.value.transformType`
+                        );
+                        return (
+                          <EuiFlexItem key={idx}>
+                            <EuiFlexGroup direction="row" gutterSize="xs">
+                              <EuiFlexItem grow={KEY_FLEX_RATIO}>
+                                <EuiFlexGroup direction="row" gutterSize="xs">
+                                  <>
+                                    <EuiFlexItem>
+                                      <>
+                                        {/**
+                                         * We determine if there is an interface based on if there are key options or not,
+                                         * as the options would be derived from the underlying interface.
+                                         * And if so, these values should be static.
+                                         * So, we only display the static text with no mechanism to change it's value.
+                                         * Note we still allow more entries, if a user wants to override / add custom
+                                         * keys if there is some gaps in the model interface.
+                                         */}
+                                        {!isEmpty(keyOptions) &&
+                                        !isEmpty(
+                                          getIn(
+                                            values,
+                                            `${outputMapFieldPath}.${idx}.key`
+                                          )
+                                        ) ? (
+                                          <EuiText
+                                            size="s"
+                                            style={{ marginTop: '4px' }}
+                                          >
+                                            {getIn(
+                                              values,
+                                              `${outputMapFieldPath}.${idx}.key`
+                                            )}
+                                          </EuiText>
+                                        ) : !isEmpty(keyOptions) ? (
+                                          <SelectWithCustomOptions
+                                            fieldPath={`${outputMapFieldPath}.${idx}.key`}
+                                            options={keyOptions as any[]}
+                                            placeholder={`Name`}
+                                            allowCreate={true}
+                                          />
+                                        ) : (
+                                          <TextField
+                                            fullWidth={true}
+                                            fieldPath={`${outputMapFieldPath}.${idx}.key`}
+                                            placeholder={`Name`}
+                                            showError={false}
+                                          />
+                                        )}
+                                      </>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={false}
+                                      style={{ marginTop: '10px' }}
+                                    >
+                                      <EuiIcon type={'sortLeft'} />
+                                    </EuiFlexItem>
+                                  </>
+                                </EuiFlexGroup>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                                <EuiFlexItem>
+                                  <SelectWithCustomOptions
+                                    fieldPath={`${outputMapFieldPath}.${idx}.value.transformType`}
+                                    options={TRANSFORM_OPTIONS}
+                                    placeholder={`Output transform`}
+                                    allowCreate={false}
+                                    onChange={() => {
+                                      // If the transform type changes, clear any set value and/or nested vars,
+                                      // as it will likely not make sense under other types/contexts.
+                                      setFieldValue(
+                                        `${outputMapFieldPath}.${idx}.value.value`,
+                                        ''
+                                      );
+                                      setFieldValue(
+                                        `${outputMapFieldPath}.${idx}.value.nestedVars`,
+                                        []
+                                      );
+                                    }}
+                                  />
+                                </EuiFlexItem>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={VALUE_FLEX_RATIO}>
+                                <EuiFlexGroup direction="row" gutterSize="xs">
+                                  <>
+                                    {/**
+                                     * Conditionally render the value form component based on the transform type.
+                                     * It may be a button, dropdown, or simply freeform text.
+                                     */}
+                                    {isExpressionModalOpen && (
+                                      <ConfigureExpressionModal
+                                        config={props.config}
+                                        baseConfigPath={props.baseConfigPath}
+                                        uiConfig={props.uiConfig}
+                                        context={props.context}
+                                        fieldPath={`${outputMapFieldPath}.${idx}.value`}
+                                        modelInterface={modelInterface}
+                                        modelInputFieldName={getIn(
+                                          values,
+                                          `${outputMapFieldPath}.${idx}.key`
+                                        )}
+                                        onClose={() =>
+                                          setIsExpressionModalOpen(false)
+                                        }
+                                      />
+                                    )}
+                                    <EuiFlexItem>
+                                      <>
+                                        {transformType ===
+                                        TRANSFORM_TYPE.EXPRESSION ? (
+                                          <>
+                                            {isEmpty(
+                                              getIn(
+                                                values,
+                                                `${outputMapFieldPath}.${idx}.value.value`
+                                              )
+                                            ) ? (
+                                              <EuiSmallButton
+                                                style={{ width: '100px' }}
+                                                fill={false}
+                                                onClick={() =>
+                                                  setIsExpressionModalOpen(true)
+                                                }
+                                                data-testid="configureExpressionButton"
+                                              >
+                                                Configure
+                                              </EuiSmallButton>
+                                            ) : (
+                                              <EuiFlexGroup
+                                                direction="row"
+                                                justifyContent="spaceAround"
+                                              >
+                                                <EuiFlexItem>
+                                                  <EuiText
+                                                    size="s"
+                                                    color="subdued"
+                                                    style={{
+                                                      marginTop: '4px',
+                                                      whiteSpace: 'nowrap',
+                                                      overflow: 'hidden',
+                                                    }}
+                                                  >
+                                                    {getCharacterLimitedString(
+                                                      getIn(
+                                                        values,
+                                                        `${outputMapFieldPath}.${idx}.value.value`
+                                                      ),
+                                                      15
+                                                    )}
+                                                  </EuiText>
+                                                </EuiFlexItem>
+                                                <EuiFlexItem grow={false}>
+                                                  <EuiSmallButtonIcon
+                                                    aria-label="edit"
+                                                    iconType="pencil"
+                                                    disabled={false}
+                                                    color={'primary'}
+                                                    onClick={() => {
+                                                      setIsExpressionModalOpen(
+                                                        true
+                                                      );
+                                                    }}
+                                                  />
+                                                </EuiFlexItem>
+                                              </EuiFlexGroup>
+                                            )}
+                                          </>
+                                        ) : transformType ===
+                                          TRANSFORM_TYPE.FIELD ? (
+                                          <TextField
+                                            fullWidth={true}
+                                            fieldPath={`${outputMapFieldPath}.${idx}.value.value`}
+                                            placeholder={
+                                              props.context ===
+                                              PROCESSOR_CONTEXT.SEARCH_REQUEST
+                                                ? 'Specify a query field'
+                                                : 'Define a document field'
+                                            }
+                                            showError={false}
+                                          />
+                                        ) : undefined}
+                                      </>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                      <EuiSmallButtonIcon
+                                        iconType={'trash'}
+                                        color="danger"
+                                        aria-label="Delete"
+                                        onClick={() => {
+                                          deleteMapEntry(field.value, idx);
+                                        }}
+                                      />
+                                    </EuiFlexItem>
+                                  </>
+                                </EuiFlexGroup>
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                        );
+                      }
+                    )}
+                    <EuiFlexItem grow={false}>
+                      <div>
+                        <EuiSmallButtonEmpty
+                          style={{ marginLeft: '-8px', marginTop: '0px' }}
+                          iconType={'plusInCircle'}
+                          iconSide="left"
+                          onClick={() => {
+                            addMapEntry(field.value);
+                          }}
+                        >
+                          {`Add output`}
+                        </EuiSmallButtonEmpty>
+                      </div>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiCompressedFormRow>
+              </EuiPanel>
+            ) : (
+              <EuiSmallButton
+                style={{ width: '100px' }}
+                onClick={() => {
+                  setFieldValue(field.name, [EMPTY_OUTPUT_MAP_ENTRY]);
+                }}
+              >
+                {'Configure'}
+              </EuiSmallButton>
+            )}
+          </>
+        );
+      }}
+    </Field>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -36,7 +36,7 @@ import {
   EuiSmallButtonIcon,
   EuiText,
 } from '@elastic/eui';
-import { ConfigureExpressionModal } from './modals';
+import { ConfigureMultiExpressionModal } from './modals';
 
 interface ModelOutputsProps {
   config: IProcessorConfig;
@@ -88,7 +88,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
   );
 
   // various modal states
-  const [isExpressionModalOpen, setIsExpressionModalOpen] = useState<boolean>(
+  const [isExpressionsModalOpen, setIsExpressionsModalOpen] = useState<boolean>(
     false
   );
 
@@ -291,8 +291,8 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                      * Conditionally render the value form component based on the transform type.
                                      * It may be a button, dropdown, or simply freeform text.
                                      */}
-                                    {isExpressionModalOpen && (
-                                      <ConfigureExpressionModal
+                                    {isExpressionsModalOpen && (
+                                      <ConfigureMultiExpressionModal
                                         config={props.config}
                                         baseConfigPath={props.baseConfigPath}
                                         uiConfig={props.uiConfig}
@@ -304,7 +304,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                           `${outputMapFieldPath}.${idx}.key`
                                         )}
                                         onClose={() =>
-                                          setIsExpressionModalOpen(false)
+                                          setIsExpressionsModalOpen(false)
                                         }
                                       />
                                     )}
@@ -323,9 +323,11 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                                 style={{ width: '100px' }}
                                                 fill={false}
                                                 onClick={() =>
-                                                  setIsExpressionModalOpen(true)
+                                                  setIsExpressionsModalOpen(
+                                                    true
+                                                  )
                                                 }
-                                                data-testid="configureExpressionButton"
+                                                data-testid="configureExpressionsButton"
                                               >
                                                 Configure
                                               </EuiSmallButton>
@@ -360,7 +362,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                                     disabled={false}
                                                     color={'primary'}
                                                     onClick={() => {
-                                                      setIsExpressionModalOpen(
+                                                      setIsExpressionsModalOpen(
                                                         true
                                                       );
                                                     }}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -20,6 +20,7 @@ import {
   getCharacterLimitedString,
   OutputMapFormValue,
   EMPTY_OUTPUT_MAP_ENTRY,
+  ExpressionVar,
 } from '../../../../../../common';
 import { SelectWithCustomOptions, TextField } from '../../input_fields';
 
@@ -318,7 +319,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                             {isEmpty(
                                               getIn(
                                                 values,
-                                                `${outputMapFieldPath}.${idx}.value.value`
+                                                `${outputMapFieldPath}.${idx}.value.nestedVars`
                                               )
                                             ) ? (
                                               <EuiSmallButton
@@ -344,16 +345,28 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                                     color="subdued"
                                                     style={{
                                                       marginTop: '4px',
-                                                      whiteSpace: 'nowrap',
-                                                      overflow: 'hidden',
+                                                      whiteSpace: 'pre-wrap',
                                                     }}
                                                   >
-                                                    {getCharacterLimitedString(
-                                                      getIn(
-                                                        values,
-                                                        `${outputMapFieldPath}.${idx}.value.value`
-                                                      ),
-                                                      15
+                                                    {(getIn(
+                                                      values,
+                                                      `${outputMapFieldPath}.${idx}.value.nestedVars`
+                                                    ) as ExpressionVar[]).map(
+                                                      (
+                                                        expression,
+                                                        idx,
+                                                        arr
+                                                      ) => {
+                                                        return `${getCharacterLimitedString(
+                                                          expression.transform ||
+                                                            '',
+                                                          15
+                                                        )}${
+                                                          idx !== arr.length - 1
+                                                            ? `,\n`
+                                                            : ''
+                                                        }`;
+                                                      }
                                                     )}
                                                   </EuiText>
                                                 </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -25,7 +25,6 @@ import {
   QUERY_PRESETS,
   QueryPreset,
   RequestFormValues,
-  RequestSchema,
   WorkflowFormValues,
 } from '../../../../../common';
 import { getFieldSchema, getInitialValue } from '../../../../utils';
@@ -48,7 +47,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
     request: getFieldSchema({
       type: 'json',
     } as IConfigField),
-  }) as RequestSchema;
+  }) as yup.Schema;
 
   // persist standalone values. update / initialize when it is first opened
   const [tempRequest, setTempRequest] = useState<string>('{}');

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -21,15 +21,16 @@ import {
 } from '@elastic/eui';
 import {
   EMPTY_INPUT_MAP_ENTRY,
+  EMPTY_OUTPUT_MAP_ENTRY,
   IMAGE_FIELD_PATTERN,
   IndexMappings,
   InputMapArrayFormValue,
   InputMapFormValue,
   LABEL_FIELD_PATTERN,
   MODEL_ID_PATTERN,
-  MapArrayFormValue,
-  MapFormValue,
   ModelInterface,
+  OutputMapArrayFormValue,
+  OutputMapFormValue,
   PROCESSOR_TYPE,
   QuickConfigureFields,
   TEXT_FIELD_PATTERN,
@@ -301,7 +302,7 @@ function updateIngestProcessors(
           field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
-          const outputMap = generateMapFromModelOutputs(modelInterface);
+          const outputMap = generateOutputMapFromModelOutputs(modelInterface);
           const defaultField = isVectorSearchUseCase
             ? fields.vectorField
             : fields.labelField;
@@ -309,13 +310,22 @@ function updateIngestProcessors(
             if (outputMap.length > 0) {
               outputMap[0] = {
                 ...outputMap[0],
-                value: defaultField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: defaultField,
+                },
               };
             } else {
-              outputMap.push({ key: '', value: defaultField });
+              outputMap.push({
+                key: '',
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: defaultField,
+                },
+              });
             }
           }
-          field.value = [outputMap] as MapArrayFormValue;
+          field.value = [outputMap] as OutputMapArrayFormValue;
         }
       });
     }
@@ -365,22 +375,28 @@ function updateSearchRequestProcessors(
           field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
-          const outputMap = generateMapFromModelOutputs(modelInterface);
+          const outputMap = generateOutputMapFromModelOutputs(modelInterface);
           const defaultValue = isVectorSearchUseCase
             ? VECTOR
             : defaultQueryValue;
           if (outputMap.length > 0) {
             outputMap[0] = {
               ...outputMap[0],
-              value: defaultValue,
+              value: {
+                transformType: TRANSFORM_TYPE.FIELD,
+                value: defaultValue,
+              },
             };
           } else {
             outputMap.push({
               key: '',
-              value: defaultValue,
+              value: {
+                transformType: TRANSFORM_TYPE.FIELD,
+                value: defaultValue,
+              },
             });
           }
-          field.value = [outputMap] as MapArrayFormValue;
+          field.value = [outputMap] as OutputMapArrayFormValue;
         }
       });
       config.search.enrichRequest.processors[0].optionalFields = config.search.enrichRequest.processors[0].optionalFields?.map(
@@ -437,18 +453,27 @@ function updateSearchResponseProcessors(
           field.value = [inputMap] as InputMapArrayFormValue;
         }
         if (field.id === 'output_map') {
-          const outputMap = generateMapFromModelOutputs(modelInterface);
+          const outputMap = generateOutputMapFromModelOutputs(modelInterface);
           if (fields.llmResponseField) {
             if (outputMap.length > 0) {
               outputMap[0] = {
                 ...outputMap[0],
-                value: fields.llmResponseField,
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.llmResponseField,
+                },
               };
             } else {
-              outputMap.push({ key: '', value: fields.llmResponseField });
+              outputMap.push({
+                key: '',
+                value: {
+                  transformType: TRANSFORM_TYPE.FIELD,
+                  value: fields.llmResponseField,
+                },
+              });
             }
           }
-          field.value = [outputMap] as MapArrayFormValue;
+          field.value = [outputMap] as OutputMapArrayFormValue;
         }
       });
     }
@@ -571,17 +596,17 @@ function generateInputMapFromModelInputs(
 }
 
 // generate a set of mappings s.t. each key is
-// a unique model output
-function generateMapFromModelOutputs(
+// a unique model output.
+function generateOutputMapFromModelOutputs(
   modelInterface?: ModelInterface
-): MapFormValue {
-  const outputMap = [] as MapFormValue;
+): OutputMapFormValue {
+  const outputMap = [] as OutputMapFormValue;
   if (modelInterface) {
     const modelOutputs = parseModelOutputs(modelInterface);
     modelOutputs.forEach((modelOutput) => {
       outputMap.push({
+        ...EMPTY_OUTPUT_MAP_ENTRY,
         key: modelOutput.label,
-        value: '',
       });
     });
   }

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -147,7 +147,8 @@ export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
       return '[]';
     }
     case 'mapArray':
-    case 'inputMapArray': {
+    case 'inputMapArray':
+    case 'outputMapArray': {
       return [];
     }
     case 'boolean': {

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -205,8 +205,23 @@ export function getFieldSchema(
               transformType: defaultStringSchema.required(),
               value: yup
                 .string()
-                .min(1, 'Too short')
-                .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long'),
+                .when('transformType', (transformType, schema) => {
+                  const finalType = getIn(
+                    transformType,
+                    '0',
+                    TRANSFORM_TYPE.FIELD
+                  ) as TRANSFORM_TYPE;
+                  // accept longer string lengths if the input is a template
+                  if (finalType === TRANSFORM_TYPE.TEMPLATE) {
+                    return yup
+                      .string()
+                      .min(1, 'Too short')
+                      .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long')
+                      .required();
+                  } else {
+                    return defaultStringSchema.required();
+                  }
+                }),
               nestedVars: yup.array().of(
                 yup.object().shape({
                   name: defaultStringSchema.required(),

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -194,7 +194,8 @@ export function getFieldSchema(
     }
     // an array of an array of transforms.
     // this format comes from the ML inference processor input map.
-    case 'inputMapArray': {
+    case 'inputMapArray':
+    case 'outputMapArray': {
       baseSchema = yup.array().of(
         yup.array().of(
           yup.object().shape({

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -36,6 +36,7 @@ import {
   MapFormValue,
   TRANSFORM_TYPE,
   OutputMapFormValue,
+  NO_TRANSFORMATION,
 } from '../../common';
 import { processorConfigToFormik } from './config_to_form_utils';
 import { sanitizeJSONPath } from './utils';
@@ -553,6 +554,14 @@ function processModelOutputs(mapFormValue: OutputMapFormValue): {} {
           ),
         };
       });
+      // If there is no transformation selected, just map the same output
+      // field name to the new field name
+      // @ts-ignore
+    } else if (mapEntry.value.transformType === NO_TRANSFORMATION) {
+      outputMap = {
+        ...outputMap,
+        [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(mapEntry.key),
+      };
       // Placeholder logic for future transform types
     } else {
     }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -10,7 +10,6 @@ import {
   JSONPATH_ROOT_SELECTOR,
   MODEL_OUTPUT_SCHEMA_FULL_PATH,
   MODEL_OUTPUT_SCHEMA_NESTED_PATH,
-  MapFormValue,
   ModelInputFormField,
   ModelInterface,
   ModelOutput,
@@ -29,11 +28,10 @@ import {
 import { getCore, getDataSourceEnabled } from '../services';
 import {
   InputMapEntry,
-  InputMapFormValue,
   MDSQueryParams,
-  MapEntry,
   ModelInputMap,
   ModelOutputMap,
+  OutputMapEntry,
 } from '../../common/interfaces';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
@@ -190,7 +188,7 @@ export function unwrapTransformedDocs(
 // We follow the same logic here to generate consistent results.
 export function generateTransform(
   input: {} | [],
-  map: InputMapEntry[],
+  map: (InputMapEntry | OutputMapEntry)[],
   context: PROCESSOR_CONTEXT,
   transformContext: TRANSFORM_CONTEXT,
   queryContext?: {}
@@ -200,7 +198,7 @@ export function generateTransform(
     try {
       const transformedResult = getTransformedResult(
         input,
-        mapEntry.value.value,
+        mapEntry.value.value || '',
         context,
         transformContext,
         queryContext
@@ -220,7 +218,7 @@ export function generateTransform(
 // and the input is an array.
 export function generateArrayTransform(
   input: [],
-  map: InputMapEntry[],
+  map: (InputMapEntry | OutputMapEntry)[],
   context: PROCESSOR_CONTEXT,
   transformContext: TRANSFORM_CONTEXT,
   queryContext?: {}
@@ -232,8 +230,8 @@ export function generateArrayTransform(
       // prefix, parse the query context, instead of the other input.
       let transformedResult;
       if (
-        (mapEntry.value.value.startsWith(REQUEST_PREFIX) ||
-          mapEntry.value.value.startsWith(
+        (mapEntry.value.value?.startsWith(REQUEST_PREFIX) ||
+          mapEntry.value.value?.startsWith(
             REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR
           )) &&
         queryContext !== undefined &&
@@ -250,7 +248,7 @@ export function generateArrayTransform(
         transformedResult = input.map((inputEntry) =>
           getTransformedResult(
             inputEntry,
-            mapEntry.value.value,
+            mapEntry.value.value || '',
             context,
             transformContext,
             queryContext


### PR DESCRIPTION
### Description

Continuation of #495. This PR adds configurable transforms based on transform type. Similar to input transforms, there is a set of available transform types that can be configured in the form. They dynamically render different inputs based on the type selected:
1. `Field`: a field rename to a new document field. Displays freeform text input. Will add a single entry in `output_map` processor config.
2. `Expression`: define a set of transforms to new document fields. Displays a button to configure in a new modal. Since the model output can be complex & nested, this lets users flexibly pull out multiple values from a single model output field. Will add at least one single entry in `output_map` processor config.
3. `No transformation`: keep the field as-is and persist as a new document field. Displays nothing. Will add a single entry in `output_map` processor config with the identical field name. We show this for visibility into the model outputs and how the data will be persisted, even though there is no real transformation happening.

Implementation details:
- adds new `outputMapArray` config field type, which for now, is identical to the `inputMapArray` type under the hood. Adds corresponding changes in the conversion util fns to account for the schema change, the same as what was done for the input schema changes in #495.
- adds new types/interfaces for output, the same as what was done for input in #495 
- adds new `ConfigureMultiExpressionModal` for creating a list of transforms given a single model output. Borrows logic from `ConfigureExpressionModal` and `ConfigureOutputTransformModal` to fetch the model output dynamically, and perform the transformation(s).
- updates most of `ModelOutputs` to be consistent with `ModelInputs` and integrate with the new modal.
- enhancements and bug fixes from previous changes, including 1/ adding guardrails to only execute data fetching in the modals when possible via `isDataFetchingAvailable` prop params, 2/ simplifying the schema for all of the modals that persist form, 3/ fixes schema validation for the input map, which did not have `required()`. Also dynamically sets the string length based on the transform type (template types have longer limits), 4/ renames `TemplateVar` to generic `ExpressionVar`

Demo video, using the preset semantic search use case. Tests out the 3 different types, and highlights how the underlying processor config changes with each type:

[screen-capture (9).webm](https://github.com/user-attachments/assets/625f0d4a-9ffe-4352-a97d-60151978ea64)


Next steps:
- remove legacy modals (configure prompt, configure input transform, configure output transform), and legacy form components. (MapArray)
- add validation logic per-field (and maybe per input/output as a whole?)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
