### PR TITLE
Add parameterized search

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -522,3 +522,32 @@ export enum SOURCE_OPTIONS {
   UPLOAD = 'upload',
   EXISTING_INDEX = 'existing_index',
 }
+export enum INSPECTOR_TAB_ID {
+  INGEST = 'ingest',
+  QUERY = 'query',
+  ERRORS = 'errors',
+  RESOURCES = 'resources',
+}
+
+export const INSPECTOR_TABS = [
+  {
+    id: INSPECTOR_TAB_ID.INGEST,
+    name: 'Ingest response',
+    disabled: false,
+  },
+  {
+    id: INSPECTOR_TAB_ID.QUERY,
+    name: 'Search response',
+    disabled: false,
+  },
+  {
+    id: INSPECTOR_TAB_ID.ERRORS,
+    name: 'Errors',
+    disabled: false,
+  },
+  {
+    id: INSPECTOR_TAB_ID.RESOURCES,
+    name: 'Resources',
+    disabled: false,
+  },
+];

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -557,8 +557,11 @@ export type QuickConfigureFields = {
   llmResponseField?: string;
 };
 
+export type QueryParamType = 'Text' | 'Binary';
+
 export type QueryParam = {
   name: string;
+  type: QueryParamType;
   value: string;
 };
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -557,6 +557,11 @@ export type QuickConfigureFields = {
   llmResponseField?: string;
 };
 
+export type QueryParam = {
+  name: string;
+  value: string;
+};
+
 /**
  ********** OPENSEARCH TYPES/INTERFACES ************
  */

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -6,4 +6,5 @@
 export { MultiSelectFilter } from './multi_select_filter';
 export { ProcessorsTitle } from './processors_title';
 export { ExperimentalBadge } from './experimental_badge';
+export { QueryParamsList } from './query_params_list';
 export * from './service_card';

--- a/public/general_components/query_params_list.tsx
+++ b/public/general_components/query_params_list.tsx
@@ -43,7 +43,7 @@ export function QueryParamsList(props: QueryParamsListProps) {
   return (
     <>
       {props.queryParams?.length > 0 && (
-        <EuiFlexItem>
+        <EuiFlexItem grow={false}>
           <EuiFlexGroup direction="column" gutterSize="xs">
             <EuiFlexItem grow={false}>
               <EuiFlexGroup direction="row" gutterSize="s">

--- a/public/general_components/query_params_list.tsx
+++ b/public/general_components/query_params_list.tsx
@@ -4,13 +4,35 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiFieldText } from '@elastic/eui';
-import { QueryParam } from '../../common';
+import { get } from 'lodash';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiFieldText,
+  EuiComboBox,
+} from '@elastic/eui';
+import { QueryParam, QueryParamType } from '../../common';
 
 interface QueryParamsListProps {
   queryParams: QueryParam[];
   setQueryParams: (params: QueryParam[]) => void;
 }
+
+// The keys will be more static in general. Give more space for values where users
+// will typically be writing out more complex transforms/configuration (in the case of ML inference processors).
+const KEY_FLEX_RATIO = 3;
+const TYPE_FLEX_RATIO = 2;
+const VALUE_FLEX_RATIO = 5;
+
+const OPTIONS = [
+  {
+    label: 'Text' as QueryParamType,
+  },
+  {
+    label: 'Binary' as QueryParamType,
+  },
+];
 
 /**
  * Basic, reusable component for displaying a list of query parameters, and allowing
@@ -24,12 +46,17 @@ export function QueryParamsList(props: QueryParamsListProps) {
           <EuiFlexGroup direction="column" gutterSize="xs">
             <EuiFlexItem grow={false}>
               <EuiFlexGroup direction="row" gutterSize="s">
-                <EuiFlexItem grow={3}>
+                <EuiFlexItem grow={KEY_FLEX_RATIO}>
                   <EuiText size="s" color="subdued">
                     Parameter
                   </EuiText>
                 </EuiFlexItem>
-                <EuiFlexItem grow={7}>
+                <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                  <EuiText size="s" color="subdued">
+                    Type
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                   <EuiText size="s" color="subdued">
                     Value
                   </EuiText>
@@ -40,12 +67,32 @@ export function QueryParamsList(props: QueryParamsListProps) {
               return (
                 <EuiFlexItem grow={false} key={idx}>
                   <EuiFlexGroup direction="row" gutterSize="s">
-                    <EuiFlexItem grow={3}>
+                    <EuiFlexItem grow={KEY_FLEX_RATIO}>
                       <EuiText size="s" style={{ paddingTop: '4px' }}>
                         {queryParam.name}
                       </EuiText>
                     </EuiFlexItem>
-                    <EuiFlexItem grow={7}>
+                    <EuiFlexItem grow={TYPE_FLEX_RATIO}>
+                      <EuiComboBox
+                        fullWidth={true}
+                        compressed={true}
+                        placeholder={`Type`}
+                        singleSelection={{ asPlainText: true }}
+                        isClearable={false}
+                        options={OPTIONS}
+                        selectedOptions={[{ label: queryParam.type || 'Text' }]}
+                        onChange={(options) => {
+                          props.setQueryParams(
+                            props.queryParams.map((qp, i) =>
+                              i === idx
+                                ? { ...qp, type: get(options, '0.label') }
+                                : qp
+                            )
+                          );
+                        }}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                       <EuiFieldText
                         compressed={true}
                         fullWidth={true}

--- a/public/general_components/query_params_list.tsx
+++ b/public/general_components/query_params_list.tsx
@@ -11,6 +11,7 @@ import {
   EuiText,
   EuiFieldText,
   EuiComboBox,
+  EuiCompressedFilePicker,
 } from '@elastic/eui';
 import { QueryParam, QueryParamType } from '../../common';
 
@@ -93,19 +94,51 @@ export function QueryParamsList(props: QueryParamsListProps) {
                       />
                     </EuiFlexItem>
                     <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                      <EuiFieldText
-                        compressed={true}
-                        fullWidth={true}
-                        placeholder={`Value`}
-                        value={queryParam.value}
-                        onChange={(e) => {
-                          props.setQueryParams(
-                            props.queryParams.map((qp, i) =>
-                              i === idx ? { ...qp, value: e.target.value } : qp
-                            )
-                          );
-                        }}
-                      />
+                      {queryParam.type === 'Binary' ? (
+                        // For binary filetypes, accept images
+                        <EuiCompressedFilePicker
+                          accept="image/*"
+                          multiple={false}
+                          initialPromptText="Select or drag and drop an image"
+                          onChange={(files) => {
+                            if (files && files.length > 0) {
+                              const fileReader = new FileReader();
+                              fileReader.onload = (e) => {
+                                try {
+                                  const binaryData = e.target?.result as string;
+                                  const base64Str = binaryData.split(',')[1];
+                                  props.setQueryParams(
+                                    props.queryParams.map((qp, i) =>
+                                      i === idx
+                                        ? { ...qp, value: base64Str }
+                                        : qp
+                                    )
+                                  );
+                                } catch {}
+                              };
+                              fileReader.readAsDataURL(files[0]);
+                            }
+                          }}
+                          display="default"
+                        />
+                      ) : (
+                        // Default to freeform text input
+                        <EuiFieldText
+                          compressed={true}
+                          fullWidth={true}
+                          placeholder={`Value`}
+                          value={queryParam.value}
+                          onChange={(e) => {
+                            props.setQueryParams(
+                              props.queryParams.map((qp, i) =>
+                                i === idx
+                                  ? { ...qp, value: e?.target?.value }
+                                  : qp
+                              )
+                            );
+                          }}
+                        />
+                      )}
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>

--- a/public/general_components/query_params_list.tsx
+++ b/public/general_components/query_params_list.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiFieldText } from '@elastic/eui';
+import { QueryParam } from '../../common';
+
+interface QueryParamsListProps {
+  queryParams: QueryParam[];
+  setQueryParams: (params: QueryParam[]) => void;
+}
+
+/**
+ * Basic, reusable component for displaying a list of query parameters, and allowing
+ * users to freely enter values for each.
+ */
+export function QueryParamsList(props: QueryParamsListProps) {
+  return (
+    <>
+      {props.queryParams?.length > 0 && (
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup direction="row" gutterSize="s">
+                <EuiFlexItem grow={3}>
+                  <EuiText size="s" color="subdued">
+                    Parameter
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={7}>
+                  <EuiText size="s" color="subdued">
+                    Value
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            {props.queryParams.map((queryParam, idx) => {
+              return (
+                <EuiFlexItem grow={false} key={idx}>
+                  <EuiFlexGroup direction="row" gutterSize="s">
+                    <EuiFlexItem grow={3}>
+                      <EuiText size="s" style={{ paddingTop: '4px' }}>
+                        {queryParam.name}
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={7}>
+                      <EuiFieldText
+                        compressed={true}
+                        fullWidth={true}
+                        placeholder={`Value`}
+                        value={queryParam.value}
+                        onChange={(e) => {
+                          props.setQueryParams(
+                            props.queryParams.map((qp, i) =>
+                              i === idx ? { ...qp, value: e.target.value } : qp
+                            )
+                          );
+                        }}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              );
+            })}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      )}
+    </>
+  );
+}

--- a/public/pages/workflow_detail/components/export_modal.tsx
+++ b/public/pages/workflow_detail/components/export_modal.tsx
@@ -71,7 +71,11 @@ export function ExportModal(props: ExportModalProps) {
   }, [props.workflow, selectedOption]);
 
   return (
-    <EuiModal onClose={() => props.setIsExportModalOpen(false)}>
+    <EuiModal
+      maxWidth={false}
+      style={{ width: '70vw' }}
+      onClose={() => props.setIsExportModalOpen(false)}
+    >
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <p>{`Export ${getCharacterLimitedString(

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -209,6 +209,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                           workflow={props.workflow}
                           ingestResponse={ingestResponse}
                           queryResponse={queryResponse}
+                          setQueryResponse={setQueryResponse}
                           selectedTabId={selectedInspectorTabId}
                           setSelectedTabId={setSelectedInspectorTabId}
                         />

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -14,6 +14,7 @@ import {
 } from '@elastic/eui';
 import {
   CONFIG_STEP,
+  INSPECTOR_TAB_ID,
   Workflow,
   WorkflowConfig,
   customStringify,
@@ -78,9 +79,13 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
     setIsToolsPanelOpen(!isToolsPanelOpen);
   };
 
-  // ingest / search response states to be populated in the Tools panel
+  // Inspector panel state vars. Actions taken in the form can update the Inspector panel,
+  // hence we keep top-level vars here to pass to both form and inspector components.
   const [ingestResponse, setIngestResponse] = useState<string>('');
   const [queryResponse, setQueryResponse] = useState<string>('');
+  const [selectedInspectorTabId, setSelectedInspectorTabId] = useState<
+    INSPECTOR_TAB_ID
+  >(INSPECTOR_TAB_ID.INGEST);
 
   // is valid workflow state, + associated hook to set it as such
   const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
@@ -132,6 +137,12 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                 setSelectedStep={props.setSelectedStep}
                 setUnsavedIngestProcessors={props.setUnsavedIngestProcessors}
                 setUnsavedSearchProcessors={props.setUnsavedSearchProcessors}
+                displaySearchPanel={() => {
+                  if (!isToolsPanelOpen) {
+                    onToggleToolsChange();
+                  }
+                  setSelectedInspectorTabId(INSPECTOR_TAB_ID.QUERY);
+                }}
               />
             </EuiResizablePanel>
             <EuiResizableButton />
@@ -198,6 +209,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                           workflow={props.workflow}
                           ingestResponse={ingestResponse}
                           queryResponse={queryResponse}
+                          selectedTabId={selectedInspectorTabId}
+                          setSelectedTabId={setSelectedInspectorTabId}
                         />
                       </EuiResizablePanel>
                     </>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -212,6 +212,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                           setQueryResponse={setQueryResponse}
                           selectedTabId={selectedInspectorTabId}
                           setSelectedTabId={setSelectedInspectorTabId}
+                          selectedStep={props.selectedStep}
                         />
                       </EuiResizablePanel>
                     </>

--- a/public/pages/workflow_detail/tools/ingest/ingest.tsx
+++ b/public/pages/workflow_detail/tools/ingest/ingest.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { EuiCodeEditor } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import { EuiCodeEditor, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 
 interface IngestProps {
   ingestResponse: string;
@@ -19,19 +20,33 @@ export function Ingest(props: IngestProps) {
     // TODO: known issue with the editor where resizing the resizablecontainer does not
     // trigger vertical scroll updates. Updating the window, or reloading the component
     // by switching tabs etc. will refresh it correctly
-    <EuiCodeEditor
-      mode="json"
-      theme="textmate"
-      width="100%"
-      height="100%"
-      value={props.ingestResponse}
-      readOnly={true}
-      setOptions={{
-        fontSize: '12px',
-        autoScrollEditorIntoView: true,
-        wrap: true,
-      }}
-      tabSize={2}
-    />
+    <>
+      {isEmpty(props.ingestResponse) ? (
+        <EuiEmptyPrompt
+          title={<h2>No data</h2>}
+          titleSize="s"
+          body={
+            <>
+              <EuiText size="s">Run ingest and view the response here.</EuiText>
+            </>
+          }
+        />
+      ) : (
+        <EuiCodeEditor
+          mode="json"
+          theme="textmate"
+          width="100%"
+          height="100%"
+          value={props.ingestResponse}
+          readOnly={true}
+          setOptions={{
+            fontSize: '12px',
+            autoScrollEditorIntoView: true,
+            wrap: true,
+          }}
+          tabSize={2}
+        />
+      )}
+    </>
   );
 }

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -137,7 +137,7 @@ export function Query(props: QueryProps) {
             <>
               <EuiText size="s">
                 {onIngestAndInvalid
-                  ? `Configure an index and ingest data first.`
+                  ? `Create an index and ingest data first.`
                   : `Configure a search request and an index to search against first.`}
               </EuiText>
             </>
@@ -230,12 +230,12 @@ export function Query(props: QueryProps) {
                 />
               </EuiFlexItem>
               {useCustomQuery && (
-                <EuiFlexItem grow={false}>
+                <EuiFlexItem grow={true}>
                   <EuiCodeEditor
                     mode="json"
                     theme="textmate"
                     width="100%"
-                    height={'15vh'}
+                    height={'100%'}
                     value={tempRequest}
                     onChange={(input) => {
                       setTempRequest(input);

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { isEmpty } from 'lodash';
 import { useFormikContext } from 'formik';
 import {
@@ -26,6 +26,7 @@ import { getDataSourceId } from '../../../../utils';
 interface QueryProps {
   queryResponse: string;
   setQueryResponse: (queryResponse: string) => void;
+  hasSearchPipeline: boolean;
 }
 
 const SEARCH_OPTIONS = [
@@ -48,118 +49,143 @@ export function Query(props: QueryProps) {
   // Form state
   const { values } = useFormikContext<WorkflowFormValues>();
 
-  // state for if to execute search w/ or w/o any configured search pipeline
-  const [includePipeline, setIncludePipeline] = useState<boolean>(true);
+  // state for if to execute search w/ or w/o any configured search pipeline.
+  // default based on if there is an available search pipeline or not.
+  const [includePipeline, setIncludePipeline] = useState<boolean>(false);
+  useEffect(() => {
+    setIncludePipeline(props.hasSearchPipeline);
+  }, [props.hasSearchPipeline]);
+
+  // empty states
+  const noSearchIndex = isEmpty(values?.search?.index?.name);
+  const noSearchRequest = isEmpty(values?.search?.request);
 
   return (
-    <EuiFlexGroup direction="row">
-      <EuiFlexItem>
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+    <>
+      {noSearchIndex || noSearchRequest ? (
+        <EuiEmptyPrompt
+          title={<h2>Missing search configurations</h2>}
+          titleSize="s"
+          body={
+            <>
+              <EuiText size="s">
+                Configure a search request and an index to search against first.
+              </EuiText>
+            </>
+          }
+        />
+      ) : (
+        <EuiFlexGroup direction="row">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiText size="m">Search</EuiText>
+                <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="m">Search</EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiSmallButton
+                      fill={true}
+                      onClick={() => {
+                        dispatch(
+                          searchIndex({
+                            apiBody: {
+                              index: values?.search?.index?.name,
+                              body: values?.search?.request,
+                              searchPipeline:
+                                props.hasSearchPipeline &&
+                                includePipeline &&
+                                !isEmpty(values?.search?.pipelineName)
+                                  ? values?.search?.pipelineName
+                                  : '_none',
+                            },
+                            dataSourceId,
+                          })
+                        )
+                          .unwrap()
+                          .then(async (resp) => {
+                            props.setQueryResponse(
+                              customStringify(
+                                resp?.hits?.hits?.map(
+                                  (hit: SearchHit) => hit._source
+                                )
+                              )
+                            );
+                          })
+                          .catch((error: any) => {
+                            props.setQueryResponse('');
+                            console.error('Error running query: ', error);
+                          });
+                      }}
+                    >
+                      Search
+                    </EuiSmallButton>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiSmallButton
-                  fill={true}
-                  onClick={() => {
-                    let searchApiBody = {
-                      index: values?.search?.index?.name,
-                      body: values?.search?.request,
-                    } as {
-                      index: string;
-                      body: string;
-                      searchPipeline: string | undefined;
-                    };
-                    if (!includePipeline) {
-                      searchApiBody = {
-                        ...searchApiBody,
-                        searchPipeline: '_none',
-                      };
-                    }
-                    dispatch(
-                      searchIndex({
-                        apiBody: searchApiBody,
-                        dataSourceId,
-                      })
-                    )
-                      .unwrap()
-                      .then(async (resp) => {
-                        props.setQueryResponse(
-                          customStringify(
-                            resp?.hits?.hits?.map(
-                              (hit: SearchHit) => hit._source
-                            )
-                          )
-                        );
-                      })
-                      .catch((error: any) => {
-                        props.setQueryResponse('');
-                        console.error('Error running query: ', error);
-                      });
+                <EuiComboBox
+                  fullWidth={false}
+                  compressed={true}
+                  singleSelection={{ asPlainText: true }}
+                  isClearable={false}
+                  options={
+                    props.hasSearchPipeline
+                      ? SEARCH_OPTIONS
+                      : [SEARCH_OPTIONS[1]]
+                  }
+                  selectedOptions={
+                    props.hasSearchPipeline && includePipeline
+                      ? [SEARCH_OPTIONS[0]]
+                      : [SEARCH_OPTIONS[1]]
+                  }
+                  onChange={(options) => {
+                    setIncludePipeline(!includePipeline);
                   }}
-                >
-                  Search
-                </EuiSmallButton>
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiComboBox
-              fullWidth={false}
-              compressed={true}
-              singleSelection={{ asPlainText: true }}
-              isClearable={false}
-              options={SEARCH_OPTIONS}
-              selectedOptions={
-                includePipeline ? [SEARCH_OPTIONS[0]] : [SEARCH_OPTIONS[1]]
-              }
-              onChange={(options) => {
-                setIncludePipeline(!includePipeline);
-              }}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiText size="m">Results</EuiText>
-          </EuiFlexItem>
           <EuiFlexItem>
-            {isEmpty(props.queryResponse) ? (
-              <EuiEmptyPrompt
-                title={<h2>No results</h2>}
-                titleSize="s"
-                body={
-                  <>
-                    <EuiText size="s">Run search to view results.</EuiText>
-                  </>
-                }
-              />
-            ) : (
-              // Known issue with the editor where resizing the resizablecontainer does not
-              // trigger vertical scroll updates. Updating the window, or reloading the component
-              // by switching tabs etc. will refresh it correctly
-              <EuiCodeEditor
-                mode="json"
-                theme="textmate"
-                width="100%"
-                height="100%"
-                value={props.queryResponse}
-                readOnly={true}
-                setOptions={{
-                  fontSize: '12px',
-                  autoScrollEditorIntoView: true,
-                  wrap: true,
-                }}
-                tabSize={2}
-              />
-            )}
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiText size="m">Results</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                {isEmpty(props.queryResponse) ? (
+                  <EuiEmptyPrompt
+                    title={<h2>No results</h2>}
+                    titleSize="s"
+                    body={
+                      <>
+                        <EuiText size="s">Run search to view results.</EuiText>
+                      </>
+                    }
+                  />
+                ) : (
+                  // Known issue with the editor where resizing the resizablecontainer does not
+                  // trigger vertical scroll updates. Updating the window, or reloading the component
+                  // by switching tabs etc. will refresh it correctly
+                  <EuiCodeEditor
+                    mode="json"
+                    theme="textmate"
+                    width="100%"
+                    height="100%"
+                    value={props.queryResponse}
+                    readOnly={true}
+                    setOptions={{
+                      fontSize: '12px',
+                      autoScrollEditorIntoView: true,
+                      wrap: true,
+                    }}
+                    tabSize={2}
+                  />
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      )}
+    </>
   );
 }

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -3,35 +3,163 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiCodeEditor } from '@elastic/eui';
+import React, { useState } from 'react';
+import { isEmpty } from 'lodash';
+import { useFormikContext } from 'formik';
+import {
+  EuiCodeEditor,
+  EuiComboBox,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSmallButton,
+  EuiText,
+} from '@elastic/eui';
+import {
+  customStringify,
+  SearchHit,
+  WorkflowFormValues,
+} from '../../../../../common';
+import { searchIndex, useAppDispatch } from '../../../../store';
+import { getDataSourceId } from '../../../../utils';
 
 interface QueryProps {
   queryResponse: string;
+  setQueryResponse: (queryResponse: string) => void;
 }
 
+const SEARCH_OPTIONS = [
+  {
+    label: 'FULL search pipeline',
+  },
+  {
+    label: 'No search pipeline',
+  },
+];
+
 /**
- * The basic query component for the Tools panel.
- * Displays a read-only view of the query response after users perform search.
+ * The search component for the Tools panel.
+ * Lets users configure query parameters, execute search, and view responses.
  */
 export function Query(props: QueryProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+
+  // Form state
+  const { values } = useFormikContext<WorkflowFormValues>();
+
+  // state for if to execute search w/ or w/o any configured search pipeline
+  const [includePipeline, setIncludePipeline] = useState<boolean>(true);
+
   return (
-    // TODO: known issue with the editor where resizing the resizablecontainer does not
-    // trigger vertical scroll updates. Updating the window, or reloading the component
-    // by switching tabs etc. will refresh it correctly
-    <EuiCodeEditor
-      mode="json"
-      theme="textmate"
-      width="100%"
-      height="100%"
-      value={props.queryResponse}
-      readOnly={true}
-      setOptions={{
-        fontSize: '12px',
-        autoScrollEditorIntoView: true,
-        wrap: true,
-      }}
-      tabSize={2}
-    />
+    <EuiFlexGroup direction="row">
+      <EuiFlexItem>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+              <EuiFlexItem grow={false}>
+                <EuiText size="m">Search</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiSmallButton
+                  fill={true}
+                  onClick={() => {
+                    let searchApiBody = {
+                      index: values?.search?.index?.name,
+                      body: values?.search?.request,
+                    } as {
+                      index: string;
+                      body: string;
+                      searchPipeline: string | undefined;
+                    };
+                    if (!includePipeline) {
+                      searchApiBody = {
+                        ...searchApiBody,
+                        searchPipeline: '_none',
+                      };
+                    }
+                    dispatch(
+                      searchIndex({
+                        apiBody: searchApiBody,
+                        dataSourceId,
+                      })
+                    )
+                      .unwrap()
+                      .then(async (resp) => {
+                        props.setQueryResponse(
+                          customStringify(
+                            resp?.hits?.hits?.map(
+                              (hit: SearchHit) => hit._source
+                            )
+                          )
+                        );
+                      })
+                      .catch((error: any) => {
+                        props.setQueryResponse('');
+                        console.error('Error running query: ', error);
+                      });
+                  }}
+                >
+                  Search
+                </EuiSmallButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiComboBox
+              fullWidth={false}
+              compressed={true}
+              singleSelection={{ asPlainText: true }}
+              isClearable={false}
+              options={SEARCH_OPTIONS}
+              selectedOptions={
+                includePipeline ? [SEARCH_OPTIONS[0]] : [SEARCH_OPTIONS[1]]
+              }
+              onChange={(options) => {
+                setIncludePipeline(!includePipeline);
+              }}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiText size="m">Results</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {isEmpty(props.queryResponse) ? (
+              <EuiEmptyPrompt
+                title={<h2>No results</h2>}
+                titleSize="s"
+                body={
+                  <>
+                    <EuiText size="s">Run search to view results.</EuiText>
+                  </>
+                }
+              />
+            ) : (
+              // Known issue with the editor where resizing the resizablecontainer does not
+              // trigger vertical scroll updates. Updating the window, or reloading the component
+              // by switching tabs etc. will refresh it correctly
+              <EuiCodeEditor
+                mode="json"
+                theme="textmate"
+                width="100%"
+                height="100%"
+                value={props.queryResponse}
+                readOnly={true}
+                setOptions={{
+                  fontSize: '12px',
+                  autoScrollEditorIntoView: true,
+                  wrap: true,
+                }}
+                tabSize={2}
+              />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../../../common';
 import { searchIndex, useAppDispatch } from '../../../../store';
 import {
+  containsEmptyValues,
   containsSameValues,
   getDataSourceId,
   getPlaceholdersFromQuery,
@@ -90,7 +91,11 @@ export function Query(props: QueryProps) {
       )
     ) {
       setQueryParams(
-        placeholders.map((placeholder) => ({ name: placeholder, value: '' }))
+        placeholders.map((placeholder) => ({
+          name: placeholder,
+          type: 'Text',
+          value: '',
+        }))
       );
     }
   }, [tempRequest]);
@@ -125,6 +130,7 @@ export function Query(props: QueryProps) {
                   <EuiFlexItem grow={false}>
                     <EuiSmallButton
                       fill={true}
+                      disabled={containsEmptyValues(queryParams)}
                       onClick={() => {
                         dispatch(
                           searchIndex({
@@ -166,6 +172,7 @@ export function Query(props: QueryProps) {
               <EuiFlexItem grow={false}>
                 <EuiComboBox
                   fullWidth={false}
+                  style={{ width: '250px' }}
                   compressed={true}
                   singleSelection={{ asPlainText: true }}
                   isClearable={false}

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -80,8 +80,20 @@ export function Query(props: QueryProps) {
     setIncludePipeline(props.hasSearchPipeline);
   }, [props.hasSearchPipeline]);
 
-  // query/request params state, update when the request is changed/updated
+  // query params state
   const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
+
+  // listen for changes to the upstream / form query, and reset the default
+  useEffect(() => {
+    if (!isEmpty(values?.search?.request)) {
+      setTempRequest(values?.search?.request);
+    }
+  }, [values?.search?.request]);
+
+  // Do a few things when the request is changed:
+  // 1. Check if there is a new set of query parameters, and if so,
+  //    reset the form.
+  // 2. Clear any stale results
   useEffect(() => {
     const placeholders = getPlaceholdersFromQuery(tempRequest);
     if (
@@ -98,6 +110,7 @@ export function Query(props: QueryProps) {
         }))
       );
     }
+    props.setQueryResponse('');
   }, [tempRequest]);
 
   // empty states

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -95,12 +95,14 @@ export function Tools(props: ToolsProps) {
       paddingSize="m"
       borderRadius="l"
       grow={true}
-      style={{ minHeight: '100%' }}
+      style={{ height: '100%' }}
     >
       <EuiFlexGroup
         direction="column"
+        gutterSize="s"
         style={{
           height: '100%',
+          overflow: 'scroll',
         }}
       >
         <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -92,7 +92,7 @@ export function Tools(props: ToolsProps) {
       paddingSize="m"
       borderRadius="l"
       grow={true}
-      style={{ height: '100%' }}
+      style={{ minHeight: '100%' }}
     >
       <EuiFlexGroup
         direction="column"

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -20,6 +20,7 @@ import { Resources } from './resources';
 import { Query } from './query';
 import { Ingest } from './ingest';
 import { Errors } from './errors';
+import { hasProvisionedSearchResources } from '../../../utils';
 
 interface ToolsProps {
   workflow?: Workflow;
@@ -125,6 +126,9 @@ export function Tools(props: ToolsProps) {
                   <Query
                     queryResponse={props.queryResponse}
                     setQueryResponse={props.setQueryResponse}
+                    hasSearchPipeline={hasProvisionedSearchResources(
+                      props.workflow
+                    )}
                   />
                 )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.ERRORS && (

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -25,7 +25,10 @@ import { Resources } from './resources';
 import { Query } from './query';
 import { Ingest } from './ingest';
 import { Errors } from './errors';
-import { hasProvisionedSearchResources } from '../../../utils';
+import {
+  hasProvisionedIngestResources,
+  hasProvisionedSearchResources,
+} from '../../../utils';
 
 interface ToolsProps {
   workflow?: Workflow;
@@ -133,6 +136,9 @@ export function Tools(props: ToolsProps) {
                     queryResponse={props.queryResponse}
                     setQueryResponse={props.setQueryResponse}
                     hasSearchPipeline={hasProvisionedSearchResources(
+                      props.workflow
+                    )}
+                    hasIngestResources={hasProvisionedIngestResources(
                       props.workflow
                     )}
                     selectedStep={props.selectedStep}

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -15,7 +15,12 @@ import {
   EuiTabs,
   EuiText,
 } from '@elastic/eui';
-import { INSPECTOR_TAB_ID, INSPECTOR_TABS, Workflow } from '../../../../common';
+import {
+  CONFIG_STEP,
+  INSPECTOR_TAB_ID,
+  INSPECTOR_TABS,
+  Workflow,
+} from '../../../../common';
 import { Resources } from './resources';
 import { Query } from './query';
 import { Ingest } from './ingest';
@@ -29,6 +34,7 @@ interface ToolsProps {
   setQueryResponse: (queryResponse: string) => void;
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
+  selectedStep: CONFIG_STEP;
 }
 
 const PANEL_TITLE = 'Inspector';
@@ -129,6 +135,7 @@ export function Tools(props: ToolsProps) {
                     hasSearchPipeline={hasProvisionedSearchResources(
                       props.workflow
                     )}
+                    selectedStep={props.selectedStep}
                   />
                 )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.ERRORS && (

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -15,7 +15,7 @@ import {
   EuiTabs,
   EuiText,
 } from '@elastic/eui';
-import { Workflow } from '../../../../common';
+import { INSPECTOR_TAB_ID, INSPECTOR_TABS, Workflow } from '../../../../common';
 import { Resources } from './resources';
 import { Query } from './query';
 import { Ingest } from './ingest';
@@ -25,39 +25,10 @@ interface ToolsProps {
   workflow?: Workflow;
   ingestResponse: string;
   queryResponse: string;
+  selectedTabId: INSPECTOR_TAB_ID;
+  setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
 }
 
-enum TAB_ID {
-  INGEST = 'ingest',
-  QUERY = 'query',
-  ERRORS = 'errors',
-  RESOURCES = 'resources',
-}
-
-const inputTabs = [
-  {
-    id: TAB_ID.INGEST,
-    name: 'Ingest response',
-    disabled: false,
-  },
-  {
-    id: TAB_ID.QUERY,
-    name: 'Search response',
-    disabled: false,
-  },
-  {
-    id: TAB_ID.ERRORS,
-    name: 'Errors',
-    disabled: false,
-  },
-  {
-    id: TAB_ID.RESOURCES,
-    name: 'Resources',
-    disabled: false,
-  },
-];
-
-// TODO: this may change in the future
 const PANEL_TITLE = 'Inspector';
 
 /**
@@ -70,9 +41,6 @@ export function Tools(props: ToolsProps) {
   const workflowsError = workflows.errorMessage;
   const [curErrorMessage, setCurErrorMessage] = useState<string>('');
 
-  // selected tab state
-  const [selectedTabId, setSelectedTabId] = useState<string>(TAB_ID.INGEST);
-
   // auto-navigate to errors tab if a new error has been set as a result of
   // executing OpenSearch or Flow Framework workflow APIs, or from the workflow state
   // (note that if provision/deprovision fails, there is no concrete exception returned at the API level -
@@ -80,34 +48,34 @@ export function Tools(props: ToolsProps) {
   useEffect(() => {
     setCurErrorMessage(opensearchError);
     if (!isEmpty(opensearchError)) {
-      setSelectedTabId(TAB_ID.ERRORS);
+      props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [opensearchError]);
 
   useEffect(() => {
     setCurErrorMessage(workflowsError);
     if (!isEmpty(workflowsError)) {
-      setSelectedTabId(TAB_ID.ERRORS);
+      props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [workflowsError]);
   useEffect(() => {
     setCurErrorMessage(props.workflow?.error || '');
     if (!isEmpty(props.workflow?.error)) {
-      setSelectedTabId(TAB_ID.ERRORS);
+      props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [props.workflow?.error]);
 
   // auto-navigate to ingest tab if a populated value has been set, indicating ingest has been ran
   useEffect(() => {
     if (!isEmpty(props.ingestResponse)) {
-      setSelectedTabId(TAB_ID.INGEST);
+      props.setSelectedTabId(INSPECTOR_TAB_ID.INGEST);
     }
   }, [props.ingestResponse]);
 
   // auto-navigate to query tab if a populated value has been set, indicating search has been ran
   useEffect(() => {
     if (!isEmpty(props.queryResponse)) {
-      setSelectedTabId(TAB_ID.QUERY);
+      props.setSelectedTabId(INSPECTOR_TAB_ID.QUERY);
     }
   }, [props.queryResponse]);
 
@@ -131,11 +99,11 @@ export function Tools(props: ToolsProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiTabs size="s" expand={false}>
-            {inputTabs.map((tab, idx) => {
+            {INSPECTOR_TABS.map((tab, idx) => {
               return (
                 <EuiTab
-                  onClick={() => setSelectedTabId(tab.id)}
-                  isSelected={tab.id === selectedTabId}
+                  onClick={() => props.setSelectedTabId(tab.id)}
+                  isSelected={tab.id === props.selectedTabId}
                   disabled={tab.disabled}
                   key={idx}
                 >
@@ -149,16 +117,16 @@ export function Tools(props: ToolsProps) {
           <EuiFlexGroup direction="column">
             <EuiFlexItem grow={true}>
               <>
-                {selectedTabId === TAB_ID.INGEST && (
+                {props.selectedTabId === INSPECTOR_TAB_ID.INGEST && (
                   <Ingest ingestResponse={props.ingestResponse} />
                 )}
-                {selectedTabId === TAB_ID.QUERY && (
+                {props.selectedTabId === INSPECTOR_TAB_ID.QUERY && (
                   <Query queryResponse={props.queryResponse} />
                 )}
-                {selectedTabId === TAB_ID.ERRORS && (
+                {props.selectedTabId === INSPECTOR_TAB_ID.ERRORS && (
                   <Errors errorMessage={curErrorMessage} />
                 )}
-                {selectedTabId === TAB_ID.RESOURCES && (
+                {props.selectedTabId === INSPECTOR_TAB_ID.RESOURCES && (
                   <Resources workflow={props.workflow} />
                 )}
               </>

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -25,6 +25,7 @@ interface ToolsProps {
   workflow?: Workflow;
   ingestResponse: string;
   queryResponse: string;
+  setQueryResponse: (queryResponse: string) => void;
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
 }
@@ -121,7 +122,10 @@ export function Tools(props: ToolsProps) {
                   <Ingest ingestResponse={props.ingestResponse} />
                 )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.QUERY && (
-                  <Query queryResponse={props.queryResponse} />
+                  <Query
+                    queryResponse={props.queryResponse}
+                    setQueryResponse={props.setQueryResponse}
+                  />
                 )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.ERRORS && (
                   <Errors errorMessage={curErrorMessage} />

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -194,8 +194,6 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
       expect(getAllByText('Define search pipeline').length).toBeGreaterThan(0);
     });
     expect(getAllByText('Configure query').length).toBeGreaterThan(0);
-    const searchTestButton = getByTestId('searchTestButton');
-    expect(searchTestButton).toBeInTheDocument();
 
     // Edit Search Query
     const queryEditButton = getByTestId('queryEditButton');

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -202,7 +202,7 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
     expect(queryEditButton).toBeInTheDocument();
     userEvent.click(queryEditButton);
     await waitFor(() => {
-      expect(getAllByText('Edit query').length).toBeGreaterThan(0);
+      expect(getAllByText('Edit query definition').length).toBeGreaterThan(0);
     });
     const searchQueryPresetButton = getByTestId('searchQueryPresetButton');
     expect(searchQueryPresetButton).toBeInTheDocument();

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -93,10 +93,9 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
 
-      // "Run ingestion" button should be enabled by default
+      // "Run ingestion" button exists
       const runIngestionButton = getByTestId('runIngestionButton');
       expect(runIngestionButton).toBeInTheDocument();
-      expect(runIngestionButton).toBeEnabled();
 
       // "Search pipeline" button should be disabled by default
       const searchPipelineButton = getByTestId('searchPipelineButton');

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -188,7 +188,11 @@ export function SourceDataModal(props: SourceDataProps) {
         }, [formikProps.errors]);
 
         return (
-          <EuiModal onClose={() => onClose()} style={{ width: '70vw' }}>
+          <EuiModal
+            maxWidth={false}
+            onClose={() => onClose()}
+            style={{ width: '70vw' }}
+          >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
                 <p>{`Import data`}</p>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -260,6 +260,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
 
         return (
           <EuiModal
+            maxWidth={false}
             onClose={props.onClose}
             style={{ width: '70vw' }}
             id={props.fieldPath}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -232,7 +232,11 @@ export function ConfigureMultiExpressionModal(
         }
 
         return (
-          <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+          <EuiModal
+            maxWidth={false}
+            onClose={props.onClose}
+            style={{ width: '70vw' }}
+          >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
                 <p>{`Extract data with expression`}</p>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -281,7 +281,11 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
         }
 
         return (
-          <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+          <EuiModal
+            maxWidth={false}
+            onClose={props.onClose}
+            style={{ width: '70vw' }}
+          >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
                 <p>{`Configure prompt`}</p>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -82,7 +82,11 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
   const [presetsPopoverOpen, setPresetsPopoverOpen] = useState<boolean>(false);
 
   return (
-    <EuiModal onClose={props.onClose} style={{ width: '70vw' }}>
+    <EuiModal
+      maxWidth={false}
+      onClose={props.onClose}
+      style={{ width: '70vw' }}
+    >
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <p>{`Override query`}</p>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -17,13 +17,8 @@ import {
   EuiCodeBlock,
   EuiSmallButtonEmpty,
 } from '@elastic/eui';
-import {
-  SearchHit,
-  WorkflowFormValues,
-  customStringify,
-} from '../../../../../common';
-import { AppState, searchIndex, useAppDispatch } from '../../../../store';
-import { getDataSourceId } from '../../../../utils/utils';
+import { WorkflowFormValues } from '../../../../../common';
+import { AppState } from '../../../../store';
 import { EditQueryModal } from './edit_query_modal';
 
 interface ConfigureSearchRequestProps {
@@ -35,9 +30,6 @@ interface ConfigureSearchRequestProps {
  * Input component for configuring a search request
  */
 export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
-  const dispatch = useAppDispatch();
-  const dataSourceId = getDataSourceId();
-
   // Form state
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
@@ -131,43 +123,6 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
                     iconSide="left"
                   >
                     Edit
-                  </EuiSmallButtonEmpty>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiSmallButtonEmpty
-                    onClick={() => {
-                      // for this test query, we don't want to involve any configured search pipelines, if any exist
-                      // see https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/#disabling-the-default-pipeline-for-a-request
-                      dispatch(
-                        searchIndex({
-                          apiBody: {
-                            index: values.search.index.name,
-                            body: values.search.request,
-                            searchPipeline: '_none',
-                          },
-                          dataSourceId,
-                        })
-                      )
-                        .unwrap()
-                        .then(async (resp) => {
-                          props.setQueryResponse(
-                            customStringify(
-                              resp?.hits?.hits?.map(
-                                (hit: SearchHit) => hit._source
-                              )
-                            )
-                          );
-                        })
-                        .catch((error: any) => {
-                          props.setQueryResponse('');
-                          console.error('Error running query: ', error);
-                        });
-                    }}
-                    data-testid="searchTestButton"
-                    iconType="play"
-                    iconSide="left"
-                  >
-                    Test query
                   </EuiSmallButtonEmpty>
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -144,6 +144,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
             onClose={() => props.setModalOpen(false)}
             style={{ width: '70vw' }}
             data-testid="editQueryModal"
+            maxWidth={false}
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -93,6 +93,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
   // 1. Check if there is a new set of query parameters, and if so,
   //    reset the form.
   // 2. Clear any persisted error
+  // 3. Clear any stale results
   useEffect(() => {
     const placeholders = getPlaceholdersFromQuery(tempRequest);
     if (
@@ -110,6 +111,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
       );
     }
     setTempResultsError('');
+    setTempResults('');
   }, [tempRequest]);
 
   // Clear any error if the parameters have been updated in any way
@@ -147,7 +149,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
         return (
           <EuiModal
             onClose={() => props.setModalOpen(false)}
-            style={{ width: '70vw' }}
+            style={{ width: '70vw', height: '70vh' }}
             data-testid="editQueryModal"
             maxWidth={false}
           >
@@ -213,6 +215,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                       <JsonField
                         label="Query"
                         fieldPath={'request'}
+                        editorHeight="50vh"
                         readOnly={false}
                       />
                     </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -36,6 +36,7 @@ import {
   WorkflowFormValues,
 } from '../../../../../common';
 import {
+  containsEmptyValues,
   containsSameValues,
   getDataSourceId,
   getFieldSchema,
@@ -101,7 +102,11 @@ export function EditQueryModal(props: EditQueryModalProps) {
       )
     ) {
       setQueryParams(
-        placeholders.map((placeholder) => ({ name: placeholder, value: '' }))
+        placeholders.map((placeholder) => ({
+          name: placeholder,
+          type: 'Text',
+          value: '',
+        }))
       );
     }
     setTempResultsError('');
@@ -226,6 +231,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                         <EuiFlexItem grow={false}>
                           <EuiSmallButton
                             fill={false}
+                            disabled={containsEmptyValues(queryParams)}
                             onClick={() => {
                               dispatch(
                                 searchIndex({

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -85,8 +85,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
   const [tempResults, setTempResults] = useState<string>('');
   const [tempResultsError, setTempResultsError] = useState<string>('');
 
-  // query/request params state. Re-generate when the request has been updated,
-  // and if there are a new set of parameters
+  // query/request params state
   const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
 
   // Do a few things when the request is changed:
@@ -208,7 +207,6 @@ export function EditQueryModal(props: EditQueryModalProps) {
                       <JsonField
                         label="Query"
                         fieldPath={'request'}
-                        editorHeight="25vh"
                         readOnly={false}
                       />
                     </EuiFlexItem>
@@ -267,7 +265,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                       </EuiFlexGroup>
                     </EuiFlexItem>
                     {/**
-                     * Note: this may return nothing if the list of params are empty
+                     * This may return nothing if the list of params are empty
                      */}
                     <QueryParamsList
                       queryParams={queryParams}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -23,7 +23,6 @@ import {
   EuiCodeEditor,
   EuiEmptyPrompt,
   EuiCallOut,
-  EuiFieldText,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -45,6 +44,7 @@ import {
   injectParameters,
 } from '../../../../utils';
 import { searchIndex, useAppDispatch } from '../../../../store';
+import { QueryParamsList } from '../../../../general_components';
 
 interface EditQueryModalProps {
   queryFieldPath: string;
@@ -88,6 +88,11 @@ export function EditQueryModal(props: EditQueryModalProps) {
   // query/request params state. Re-generate when the request has been updated,
   // and if there are a new set of parameters
   const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
+
+  // Do a few things when the request is changed:
+  // 1. Check if there is a new set of query parameters, and if so,
+  //    reset the form.
+  // 2. Clear any persisted error
   useEffect(() => {
     const placeholders = getPlaceholdersFromQuery(tempRequest);
     if (
@@ -100,7 +105,13 @@ export function EditQueryModal(props: EditQueryModalProps) {
         placeholders.map((placeholder) => ({ name: placeholder, value: '' }))
       );
     }
+    setTempResultsError('');
   }, [tempRequest]);
+
+  // Clear any error if the parameters have been updated in any way
+  useEffect(() => {
+    setTempResultsError('');
+  }, [queryParams]);
 
   return (
     <Formik
@@ -255,60 +266,13 @@ export function EditQueryModal(props: EditQueryModalProps) {
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
-                    {queryParams?.length > 0 && (
-                      <EuiFlexItem>
-                        <EuiFlexGroup direction="column" gutterSize="xs">
-                          <EuiFlexItem grow={false}>
-                            <EuiFlexGroup direction="row" gutterSize="s">
-                              <EuiFlexItem grow={3}>
-                                <EuiText size="s" color="subdued">
-                                  Parameter
-                                </EuiText>
-                              </EuiFlexItem>
-                              <EuiFlexItem grow={7}>
-                                <EuiText size="s" color="subdued">
-                                  Value
-                                </EuiText>
-                              </EuiFlexItem>
-                            </EuiFlexGroup>
-                          </EuiFlexItem>
-                          {queryParams.map((queryParam, idx) => {
-                            return (
-                              <EuiFlexItem grow={false} key={idx}>
-                                <EuiFlexGroup direction="row" gutterSize="s">
-                                  <EuiFlexItem grow={3}>
-                                    <EuiText
-                                      size="s"
-                                      style={{ paddingTop: '4px' }}
-                                    >
-                                      {queryParam.name}
-                                    </EuiText>
-                                  </EuiFlexItem>
-                                  <EuiFlexItem grow={7}>
-                                    <EuiFieldText
-                                      compressed={true}
-                                      fullWidth={true}
-                                      placeholder={`Value`}
-                                      value={queryParam.value}
-                                      onChange={(e) => {
-                                        setQueryParams(
-                                          queryParams.map((qp, i) =>
-                                            i === idx
-                                              ? { ...qp, value: e.target.value }
-                                              : qp
-                                          )
-                                        );
-                                      }}
-                                    />
-                                  </EuiFlexItem>
-                                </EuiFlexGroup>
-                              </EuiFlexItem>
-                            );
-                          })}
-                        </EuiFlexGroup>
-                      </EuiFlexItem>
-                    )}
-
+                    {/**
+                     * Note: this may return nothing if the list of params are empty
+                     */}
+                    <QueryParamsList
+                      queryParams={queryParams}
+                      setQueryParams={setQueryParams}
+                    />
                     <EuiFlexItem>
                       <>
                         <EuiText size="s">Results</EuiText>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -16,8 +16,10 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiPopover,
-  EuiSpacer,
   EuiSmallButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -96,49 +98,99 @@ export function EditQueryModal(props: EditQueryModalProps) {
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
-                <p>{`Edit query`}</p>
+                <p>{`Edit query definition`}</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiModalBody data-testid="editQueryModalBody">
-              <EuiPopover
-                button={
-                  <EuiSmallButton
-                    onClick={() => setPopoverOpen(!popoverOpen)}
-                    data-testid="searchQueryPresetButton"
-                    iconSide="right"
-                    iconType="arrowDown"
-                  >
-                    Choose from a preset
-                  </EuiSmallButton>
-                }
-                isOpen={popoverOpen}
-                closePopover={() => setPopoverOpen(false)}
-                anchorPosition="downLeft"
-              >
-                <EuiContextMenu
-                  size="s"
-                  initialPanelId={0}
-                  panels={[
-                    {
-                      id: 0,
-                      items: QUERY_PRESETS.map((preset: QueryPreset) => ({
-                        name: preset.name,
-                        onClick: () => {
-                          formikProps.setFieldValue('request', preset.query);
-                          setPopoverOpen(false);
-                        },
-                      })),
-                    },
-                  ]}
-                />
-              </EuiPopover>
-              <EuiSpacer size="s" />
-              <JsonField
-                label="Query"
-                fieldPath={'request'}
-                editorHeight="25vh"
-                readOnly={false}
-              />
+              <EuiFlexGroup direction="row">
+                <EuiFlexItem>
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceBetween"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="m">Query definition</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiPopover
+                            button={
+                              <EuiSmallButton
+                                onClick={() => setPopoverOpen(!popoverOpen)}
+                                data-testid="searchQueryPresetButton"
+                                iconSide="right"
+                                iconType="arrowDown"
+                              >
+                                Query samples
+                              </EuiSmallButton>
+                            }
+                            isOpen={popoverOpen}
+                            closePopover={() => setPopoverOpen(false)}
+                            anchorPosition="downLeft"
+                          >
+                            <EuiContextMenu
+                              size="s"
+                              initialPanelId={0}
+                              panels={[
+                                {
+                                  id: 0,
+                                  items: QUERY_PRESETS.map(
+                                    (preset: QueryPreset) => ({
+                                      name: preset.name,
+                                      onClick: () => {
+                                        formikProps.setFieldValue(
+                                          'request',
+                                          preset.query
+                                        );
+                                        setPopoverOpen(false);
+                                      },
+                                    })
+                                  ),
+                                },
+                              ]}
+                            />
+                          </EuiPopover>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <JsonField
+                        label="Query"
+                        fieldPath={'request'}
+                        editorHeight="25vh"
+                        readOnly={false}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFlexGroup direction="column">
+                    <EuiFlexItem grow={false}>
+                      <EuiFlexGroup
+                        direction="row"
+                        justifyContent="spaceBetween"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="m">Test query</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiSmallButton
+                            fill={false}
+                            onClick={() => {
+                              console.log('searching...');
+                            }}
+                          >
+                            Search
+                          </EuiSmallButton>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem>TODO add query parameters</EuiFlexItem>
+                    <EuiFlexItem>TODO add search results</EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiModalBody>
             <EuiModalFooter>
               <EuiSmallButtonEmpty

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -241,8 +241,18 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     setSearchProvisioned(hasProvisionedSearchResources(props.workflow));
   }, [props.workflow]);
 
+  // populated ingest docs state
+  const [docsPopulated, setDocsPopulated] = useState<boolean>(false);
+  useEffect(() => {
+    let parsedDocsObjs = [] as {}[];
+    try {
+      parsedDocsObjs = JSON.parse(props.ingestDocs);
+    } catch (e) {}
+    setDocsPopulated(parsedDocsObjs.length > 0 && !isEmpty(parsedDocsObjs[0]));
+  }, [props.ingestDocs]);
+
   // maintain global states (button eligibility)
-  const ingestRunButtonDisabled = !ingestTemplatesDifferent;
+  const ingestRunButtonDisabled = !ingestTemplatesDifferent || !docsPopulated;
   const ingestToSearchButtonDisabled =
     ingestTemplatesDifferent || props.isRunningIngest;
   const searchBackButtonDisabled =

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -591,7 +591,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               ]}
             />
             {isDeleteModalOpen && (
-              <EuiModal onClose={() => setIsDeleteModalOpen(false)}>
+              <EuiModal
+                maxWidth={false}
+                style={{ width: '70vw' }}
+                onClose={() => setIsDeleteModalOpen(false)}
+              >
                 <EuiModalHeader>
                   <EuiModalHeaderTitle>
                     <p>{`Delete resources for workflow ${getCharacterLimitedString(

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -619,6 +619,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     onClick={async () => {
                       setIsRunningDelete(true);
                       await dispatch(
+                        // If in the future we want to start with a fresh/empty state after deleting resources,
+                        // will need to update the workflow with an empty UI config before re-fetching the workflow.
+                        // For now we still persist the config, just clean up / deprovision the resources.
                         deprovisionWorkflow({
                           apiBody: {
                             workflowId: props.workflow?.id as string,

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -12,7 +12,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
-  EuiIcon,
   EuiLoadingSpinner,
   EuiModal,
   EuiModalBody,
@@ -57,9 +56,9 @@ import {
   generateId,
   sleep,
   getResourcesToBeForceDeleted,
+  getDataSourceId,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
-import { getDataSourceId } from '../../../utils/utils';
 
 // styling
 import '../workspace/workspace-styles.scss';
@@ -80,6 +79,7 @@ interface WorkflowInputsProps {
   setSelectedStep: (step: CONFIG_STEP) => void;
   setUnsavedIngestProcessors: (unsavedIngestProcessors: boolean) => void;
   setUnsavedSearchProcessors: (unsavedSearchProcessors: boolean) => void;
+  displaySearchPanel: () => void;
 }
 
 /**
@@ -676,13 +676,30 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           : `Edit search pipeline`}
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiSmallButtonEmpty
-                          color="danger"
-                          onClick={() => setIsDeleteModalOpen(true)}
-                        >
-                          <EuiIcon type="trash" />
-                          {`    `}Delete resources
-                        </EuiSmallButtonEmpty>
+                        <EuiFlexGroup direction="row" gutterSize="s">
+                          <EuiFlexItem grow={false}>
+                            <EuiSmallButtonEmpty
+                              color="danger"
+                              onClick={() => setIsDeleteModalOpen(true)}
+                              iconType="trash"
+                              iconSide="left"
+                            >
+                              Delete resources
+                            </EuiSmallButtonEmpty>
+                          </EuiFlexItem>
+                          {onSearchAndProvisioned && (
+                            <EuiFlexItem grow={false}>
+                              <EuiSmallButton
+                                fill={false}
+                                onClick={() => {
+                                  props.displaySearchPanel();
+                                }}
+                              >
+                                Test pipeline
+                              </EuiSmallButton>
+                            </EuiFlexItem>
+                          )}
+                        </EuiFlexGroup>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   ) : (

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -106,9 +106,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   // provisioned resources states
   const [ingestProvisioned, setIngestProvisioned] = useState<boolean>(false);
+  const [searchProvisioned, setSearchProvisioned] = useState<boolean>(false);
 
   // confirm modal state
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
 
   // last ingested state
   const [lastIngested, setLastIngested] = useState<number | undefined>(
@@ -120,6 +121,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const onSearch = props.selectedStep === CONFIG_STEP.SEARCH;
   const ingestEnabled = values?.ingest?.enabled || false;
   const onIngestAndProvisioned = onIngest && ingestProvisioned;
+  const onSearchAndProvisioned = onSearch && searchProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
   const onIngestAndDisabled = onIngest && !ingestEnabled;
   const isProposingNoSearchResources =
@@ -234,6 +236,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   useEffect(() => {
     setIngestProvisioned(hasProvisionedIngestResources(props.workflow));
+  }, [props.workflow]);
+  useEffect(() => {
+    setSearchProvisioned(hasProvisionedSearchResources(props.workflow));
   }, [props.workflow]);
 
   // maintain global states (button eligibility)
@@ -585,8 +590,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 },
               ]}
             />
-            {isModalOpen && (
-              <EuiModal onClose={() => setIsModalOpen(false)}>
+            {isDeleteModalOpen && (
+              <EuiModal onClose={() => setIsDeleteModalOpen(false)}>
                 <EuiModalHeader>
                   <EuiModalHeaderTitle>
                     <p>{`Delete resources for workflow ${getCharacterLimitedString(
@@ -602,7 +607,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                   </EuiText>
                 </EuiModalBody>
                 <EuiModalFooter>
-                  <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>
+                  <EuiSmallButtonEmpty
+                    onClick={() => setIsDeleteModalOpen(false)}
+                  >
                     {' '}
                     Cancel
                   </EuiSmallButtonEmpty>
@@ -624,6 +631,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       )
                         .unwrap()
                         .then(async (result) => {
+                          props.setSelectedStep(CONFIG_STEP.INGEST);
                           setFieldValue('ingest.enabled', false);
                           // @ts-ignore
                           await dispatch(
@@ -635,7 +643,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                         })
                         .catch((error: any) => {})
                         .finally(() => {
-                          setIsModalOpen(false);
+                          setIsDeleteModalOpen(false);
                           setIsRunningDelete(false);
                         });
                     }}
@@ -660,15 +668,17 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 <h2>
                   {onIngestAndUnprovisioned ? (
                     'Define ingest pipeline'
-                  ) : onIngestAndProvisioned ? (
+                  ) : onIngestAndProvisioned || onSearchAndProvisioned ? (
                     <EuiFlexGroup direction="row" justifyContent="spaceBetween">
                       <EuiFlexItem grow={false}>
-                        Edit ingest pipeline
+                        {onIngestAndProvisioned
+                          ? `Edit ingest pipeline`
+                          : `Edit search pipeline`}
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiSmallButtonEmpty
                           color="danger"
-                          onClick={() => setIsModalOpen(true)}
+                          onClick={() => setIsDeleteModalOpen(true)}
                         >
                           <EuiIcon type="trash" />
                           {`    `}Delete resources

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -592,7 +592,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             />
             {isDeleteModalOpen && (
               <EuiModal
-                maxWidth={false}
                 style={{ width: '70vw' }}
                 onClose={() => setIsDeleteModalOpen(false)}
               >

--- a/public/pages/workflows/new_workflow/index.ts
+++ b/public/pages/workflows/new_workflow/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { NewWorkflow } from './new_workflow';
+export { fetchEmptyMetadata, fetchEmptyUIConfig } from './utils';

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -27,6 +27,7 @@ import {
   VECTOR_PATTERN,
   KNN_QUERY,
   HYBRID_SEARCH_QUERY_MATCH_KNN,
+  WorkflowConfig,
 } from '../../../../common';
 import { generateId } from '../../../utils';
 
@@ -74,63 +75,67 @@ export function enrichPresetWorkflowWithUiMetadata(
 export function fetchEmptyMetadata(): UIState {
   return {
     type: WORKFLOW_TYPE.CUSTOM,
-    config: {
-      ingest: {
-        enabled: {
-          id: 'enabled',
-          type: 'boolean',
-          value: true,
-        },
-        pipelineName: {
-          id: 'pipelineName',
+    config: fetchEmptyUIConfig(),
+  };
+}
+
+export function fetchEmptyUIConfig(): WorkflowConfig {
+  return {
+    ingest: {
+      enabled: {
+        id: 'enabled',
+        type: 'boolean',
+        value: true,
+      },
+      pipelineName: {
+        id: 'pipelineName',
+        type: 'string',
+        value: generateId('ingest_pipeline'),
+      },
+      enrich: {
+        processors: [],
+      },
+      index: {
+        name: {
+          id: 'indexName',
           type: 'string',
-          value: generateId('ingest_pipeline'),
+          value: generateId('my_index', 6),
         },
-        enrich: {
-          processors: [],
+        mappings: {
+          id: 'indexMappings',
+          type: 'json',
+          value: customStringify({
+            properties: {},
+          }),
         },
-        index: {
-          name: {
-            id: 'indexName',
-            type: 'string',
-            value: generateId('my_index', 6),
-          },
-          mappings: {
-            id: 'indexMappings',
-            type: 'json',
-            value: customStringify({
-              properties: {},
-            }),
-          },
-          settings: {
-            id: 'indexSettings',
-            type: 'json',
-          },
+        settings: {
+          id: 'indexSettings',
+          type: 'json',
         },
       },
-      search: {
-        request: {
-          id: 'request',
-          type: 'json',
-          value: customStringify(FETCH_ALL_QUERY),
-        },
-        pipelineName: {
-          id: 'pipelineName',
+    },
+    search: {
+      request: {
+        id: 'request',
+        type: 'json',
+        value: customStringify(FETCH_ALL_QUERY),
+      },
+      pipelineName: {
+        id: 'pipelineName',
+        type: 'string',
+        value: generateId('search_pipeline'),
+      },
+      index: {
+        name: {
+          id: 'indexName',
           type: 'string',
-          value: generateId('search_pipeline'),
         },
-        index: {
-          name: {
-            id: 'indexName',
-            type: 'string',
-          },
-        },
-        enrichRequest: {
-          processors: [],
-        },
-        enrichResponse: {
-          processors: [],
-        },
+      },
+      enrichRequest: {
+        processors: [],
+      },
+      enrichResponse: {
+        processors: [],
       },
     },
   };

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -32,6 +32,7 @@ import {
   ModelInputMap,
   ModelOutputMap,
   OutputMapEntry,
+  QueryParam,
 } from '../../common/interfaces';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
@@ -543,4 +544,45 @@ export function sanitizeJSONPath(path: string): string {
       return prevValue + '.' + curValue;
     }
   });
+}
+
+// given a stringified query, extract out all unique placeholder vars
+// that follow the pattern {{some-placeholder}}
+export function getPlaceholdersFromQuery(queryString: string): string[] {
+  const regex = /\{\{([^}]+)\}\}/g;
+  return [
+    // convert to set to collapse duplicate names
+    ...new Set([...queryString.matchAll(regex)].map((match) => match[1])),
+  ];
+}
+
+// simple fn to check if the values in an arr are the same. used for
+// checking if the same set of placeholders exists when a new query is selected,
+// or an existing query is updated.
+export function containsSameValues(arr1: string[], arr2: string[]) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  arr1.sort();
+  arr2.sort();
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function injectParameters(
+  params: QueryParam[],
+  queryString: string
+): string {
+  let finalQueryString = queryString;
+  params.forEach((param) => {
+    finalQueryString = finalQueryString.replace(
+      new RegExp(`{{${param.name}}}`, 'g'),
+      param.value
+    );
+  });
+  return finalQueryString;
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -573,6 +573,18 @@ export function containsSameValues(arr1: string[], arr2: string[]) {
   return true;
 }
 
+// simple util fn to check for empty/missing query param values
+export function containsEmptyValues(params: QueryParam[]): boolean {
+  let containsEmpty = false;
+  params.forEach((param) => {
+    if (isEmpty(param.value)) {
+      containsEmpty = true;
+    }
+  });
+  return containsEmpty;
+}
+
+// simple util fn to inject parameters in the base query string with its associated value
 export function injectParameters(
   params: QueryParam[],
   queryString: string


### PR DESCRIPTION
### Description

This PR greatly improves the search experience and flexibility in few different ways:
1. Updates the `EditQueryModal` to dynamically display parameters/placeholders in a query that matches the pattern `{{<placeholder>}}`. Users can fill these out (either text or binary - binary accepts an image input and performs the conversion to binary automatically), and execute search directly within the modal, to quickly verify different queries with different parameters, before saving.
2. Updates the `Search` tab in the Inspector to have similar functionality as ^; a default query will be provided, but users can override in this sandboxed env. They can search and view results all within this panel. Additionally, they can search with/without any configured search pipeline (no search pipeline allowed if in the context of ingest for simplicity).
3. Adds a few header buttons on the search form, including 'Delete resources' to delete everything similar to ingest, and a 'Test pipeline' button, which will automatically open up the Inspector's Search tab to let users test.

Implementation details:
- Adds reusable `QueryParamsList` used in both the modal and the Inspector to dynamically render a form list of parameters based on some source query.
- Updates the `EditQueryModal` and `Query` (the search tab in Inspector) to leverage the `QueryParamsList` and maintain standalone request query state
- utils / types / constants added to define and process query parameters
- other: standardizes many of the modal widths to be larger to more easily display details without truncation (advanced transformation configurations, query configurations, etc.)
- other: fixes overflow in the inspector panel for all tabs
- other: removes 'Test query' button in the configure query form panel, since this can now be done via Inspector
- other: adds empty state modal for ingest tab in Inspector
- other: adds a check to block ingest until docs are populated

Demo video, showing the different states of the Search panel in the Inspector, in both the contexts of ingest and search. There is guardrails for running each (e.g., no "with pipeline" option if in the context of ingest, search disabled if empty parameters, etc.). Also shows the updated "Edit query configuration" panel, which has similar functionality as that of the Inspector panel.

[screen-capture (13).webm](https://github.com/user-attachments/assets/001124d2-da6c-4fc3-96cc-ed170c43ff66)

### Issues Resolved

Closes #431 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
