### PR TITLE
Add `ui_metadata` versioning; other small fixes

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -108,6 +108,8 @@ export const BEDROCK_DIMENSIONS = {
  * Various constants pertaining to Workflow configs
  */
 
+export const UI_METADATA_SCHEMA_VERSION = 1;
+
 // frontend-specific workflow types, derived from the available preset templates
 export enum WORKFLOW_TYPE {
   SEMANTIC_SEARCH = 'Semantic search',

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -428,7 +428,7 @@ export const QUERY_PRESETS = [
  * PROMPT PRESETS
  */
 export const SUMMARIZE_DOCS_PROMPT =
-  "Human: You are a professional data analyist. \
+  "Human: You are a professional data analyst. \
 You are given a list of document results. You will \
 analyze the data and generate a human-readable summary of the results. If you don't \
 know the answer, just say I don't know.\
@@ -437,7 +437,7 @@ know the answer, just say I don't know.\
 \n\n Assistant:";
 
 export const QA_WITH_DOCUMENTS_PROMPT =
-  "Human: You are a professional data analyist. \
+  "Human: You are a professional data analyst. \
 You are given a list of document results, along with a question. You will \
 analyze the results and generate a human-readable response to the question, \
 based on the results. If you don't know the answer, just say I don't know.\

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -242,7 +242,7 @@ type ReactFlowViewport = {
 };
 
 export type UIState = {
-  schema_version: 1;
+  schema_version: number;
   config: WorkflowConfig;
   type: WORKFLOW_TYPE;
   // Will be used in future when changing from form-based to flow-based configs via drag-and-drop

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -242,7 +242,7 @@ type ReactFlowViewport = {
 };
 
 export type UIState = {
-  version: string;
+  schema_version: 1;
   config: WorkflowConfig;
   type: WORKFLOW_TYPE;
   // Will be used in future when changing from form-based to flow-based configs via drag-and-drop

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -242,6 +242,7 @@ type ReactFlowViewport = {
 };
 
 export type UIState = {
+  version: string;
   config: WorkflowConfig;
   type: WORKFLOW_TYPE;
   // Will be used in future when changing from form-based to flow-based configs via drag-and-drop

--- a/documentation/tutorial.md
+++ b/documentation/tutorial.md
@@ -486,7 +486,7 @@ NOTE: the below connector blueprint & model interface may change over time. The 
 
 ```
 {
-  "prompt": "Human: You are a professional data analyist. You are given a list of document results. You will analyze the data and generate a human-readable summary of the results. If you don't know the answer, just say I don't know.\n\n Results: ${parameters.results.toString()}\n\n Human: Please summarize the results.\n\n Assistant:"
+  "prompt": "Human: You are a professional data analyst. You are given a list of document results. You will analyze the data and generate a human-readable summary of the results. If you don't know the answer, just say I don't know.\n\n Results: ${parameters.results.toString()}\n\n Human: Please summarize the results.\n\n Assistant:"
 }
 ```
 

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -68,11 +68,14 @@ export function Query(props: QueryProps) {
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value. We default to different values
   // based on the context (ingest or search).
-  const [tempRequest, setTempRequest] = useState<string>(
-    props.selectedStep === CONFIG_STEP.INGEST
-      ? customStringify(FETCH_ALL_QUERY)
-      : values?.search?.request || '{}'
-  );
+  const [tempRequest, setTempRequest] = useState<string>('');
+  useEffect(() => {
+    setTempRequest(
+      props.selectedStep === CONFIG_STEP.INGEST
+        ? customStringify(FETCH_ALL_QUERY)
+        : values?.search?.request || '{}'
+    );
+  }, [props.selectedStep]);
 
   // state for if to execute search w/ or w/o any configured search pipeline.
   // default based on if there is an available search pipeline or not.

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -102,7 +102,7 @@ export function Tools(props: ToolsProps) {
         gutterSize="s"
         style={{
           height: '100%',
-          overflow: 'scroll',
+          overflow: 'hidden',
         }}
       >
         <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -28,9 +28,9 @@ import {
   KNN_QUERY,
   HYBRID_SEARCH_QUERY_MATCH_KNN,
   WorkflowConfig,
+  UI_METADATA_SCHEMA_VERSION,
 } from '../../../../common';
 import { generateId } from '../../../utils';
-import * as pluginManifest from '../../../../opensearch_dashboards.json';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
 export function enrichPresetWorkflowWithUiMetadata(
@@ -75,7 +75,7 @@ export function enrichPresetWorkflowWithUiMetadata(
 
 export function fetchEmptyMetadata(): UIState {
   return {
-    version: pluginManifest.version,
+    schema_version: UI_METADATA_SCHEMA_VERSION,
     type: WORKFLOW_TYPE.CUSTOM,
     config: fetchEmptyUIConfig(),
   };

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -30,6 +30,7 @@ import {
   WorkflowConfig,
 } from '../../../../common';
 import { generateId } from '../../../utils';
+import * as pluginManifest from '../../../../opensearch_dashboards.json';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
 export function enrichPresetWorkflowWithUiMetadata(
@@ -74,6 +75,7 @@ export function enrichPresetWorkflowWithUiMetadata(
 
 export function fetchEmptyMetadata(): UIState {
   return {
+    version: pluginManifest.version,
     type: WORKFLOW_TYPE.CUSTOM,
     config: fetchEmptyUIConfig(),
   };

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -47,7 +47,6 @@ import { sanitizeJSONPath } from './utils';
 
 export function configToTemplateFlows(config: WorkflowConfig): TemplateFlows {
   const provisionFlow = configToProvisionTemplateFlow(config);
-
   return {
     provision: provisionFlow,
   };
@@ -486,13 +485,14 @@ function processModelInputs(
   mapFormValue.forEach((mapEntry) => {
     // dynamic data
     if (
-      mapEntry.value.transformType === TRANSFORM_TYPE.FIELD ||
-      mapEntry.value.transformType === TRANSFORM_TYPE.EXPRESSION
+      (mapEntry.value.transformType === TRANSFORM_TYPE.FIELD ||
+        mapEntry.value.transformType === TRANSFORM_TYPE.EXPRESSION) &&
+      !isEmpty(mapEntry.value.value)
     ) {
       inputMap = {
         ...inputMap,
         [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(
-          mapEntry.value.value
+          mapEntry.value.value as string
         ),
       };
       // template with dynamic nested vars. Add the nested vars as input map entries,
@@ -532,10 +532,13 @@ function processModelOutputs(mapFormValue: OutputMapFormValue): {} {
   let outputMap = {};
   mapFormValue.forEach((mapEntry) => {
     // field transform: just a rename
-    if (mapEntry.value.transformType === TRANSFORM_TYPE.FIELD) {
+    if (
+      mapEntry.value.transformType === TRANSFORM_TYPE.FIELD &&
+      !isEmpty(mapEntry.value.value)
+    ) {
       outputMap = {
         ...outputMap,
-        [sanitizeJSONPath(mapEntry.value.value)]: sanitizeJSONPath(
+        [sanitizeJSONPath(mapEntry.value.value as string)]: sanitizeJSONPath(
           mapEntry.key
         ),
       };

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -6,6 +6,9 @@
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
 import { escape, get, isEmpty } from 'lodash';
+import semver from 'semver';
+import queryString from 'query-string';
+import { useLocation } from 'react-router-dom';
 import {
   JSONPATH_ROOT_SELECTOR,
   MODEL_OUTPUT_SCHEMA_FULL_PATH,
@@ -34,12 +37,9 @@ import {
   OutputMapEntry,
   QueryParam,
 } from '../../common/interfaces';
-import queryString from 'query-string';
-import { useLocation } from 'react-router-dom';
 import * as pluginManifest from '../../opensearch_dashboards.json';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 import { SavedObject } from '../../../../src/core/public';
-import semver from 'semver';
 
 // Generate a random ID. Optionally add a prefix. Optionally
 // override the default # characters to generate.
@@ -533,7 +533,7 @@ export const getErrorMessageForStepType = (
 // scenarios will succeed on the frontend and fail on the backend,
 // or vice versa.
 export function sanitizeJSONPath(path: string): string {
-  return path.split('.').reduce((prevValue, curValue, idx) => {
+  return path?.split('.').reduce((prevValue, curValue, idx) => {
     // Case 1: accessing array via dot notation. Fails on the backend.
     if (!isNaN(parseInt(curValue))) {
       return prevValue + `[${curValue}]`;


### PR DESCRIPTION
### Description

PR to update variety of things:
1. Adds a `schema_version` within the `ui_metadata` field to track schema changes over time. This follows the pattern used in [AD](https://github.com/opensearch-project/anomaly-detection/blob/main/src/main/resources/mappings/config.json#L3C4-L5C7) for maintaining schema versions of the detector JSON object mappings within the system indices. Over time, if there are substantial UI changes requiring new logic to parse to/from the `ui_metadata` schema (e.g., some new UI-only construct/idea), we can add such logic, bump the schema version, and add branching logic to parse the legacy schema to the new schema. Future work can be done to optimize/minimize the amount of data and help de-risk BWC concerns and the chances of requiring schema version bumps. For more details on that, see #511 .
2. Resets default queries in the Inspector search panel when switching contexts (ingest v. search)
3. Fixes typo in preset prompt templates
4. Fixes overflow in Inspector panel
5. Misc NPE checks

Testing:
- confirmed the default `schema_version: 1` entry is added to the UI metadata when inspecting the template JSON after creating workflows made after this change
- confirmed default queries are reset when switching between ingest & search

### Issues Resolved

Closes #386 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
