### PR TITLE
Simplify form navigation

### DIFF
--- a/public/pages/workflow_detail/components/export_modal.tsx
+++ b/public/pages/workflow_detail/components/export_modal.tsx
@@ -18,6 +18,8 @@ import {
   EuiModalBody,
   EuiModalFooter,
   EuiSmallButtonEmpty,
+  EuiCallOut,
+  EuiSpacer,
 } from '@elastic/eui';
 import {
   CREATE_WORKFLOW_LINK,
@@ -29,6 +31,8 @@ import { reduceToTemplate } from '../../../utils';
 
 interface ExportModalProps {
   workflow?: Workflow;
+  unsavedIngestProcessors: boolean;
+  unsavedSearchProcessors: boolean;
   setIsExportModalOpen(isOpen: boolean): void;
 }
 
@@ -78,14 +82,25 @@ export function ExportModal(props: ExportModalProps) {
     >
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Export ${getCharacterLimitedString(
+          <p>{`Export '${getCharacterLimitedString(
             props.workflow?.name || '',
             25
-          )}`}</p>
+          )}'`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
         <EuiFlexGroup direction="column">
+          {(props.unsavedIngestProcessors || props.unsavedSearchProcessors) && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiCallOut
+                size="s"
+                title="Unsaved configurations detected. Ensure to save and update all resources before exporting."
+                iconType={'warn'}
+                color="warning"
+              />
+            </>
+          )}
           <EuiFlexItem grow={false}>
             <EuiText size="s">
               {`To build out identical resources in other environments, create and provision a workflow using the below template.`}{' '}

--- a/public/pages/workflow_detail/components/export_modal.tsx
+++ b/public/pages/workflow_detail/components/export_modal.tsx
@@ -96,7 +96,7 @@ export function ExportModal(props: ExportModalProps) {
               <EuiCallOut
                 size="s"
                 title="Unsaved configurations detected. Ensure to save and update all resources before exporting."
-                iconType={'warn'}
+                iconType={'alert'}
                 color="warning"
               />
             </>

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -276,6 +276,8 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
       {isExportModalOpen && (
         <ExportModal
           workflow={props.workflow}
+          unsavedIngestProcessors={props.unsavedIngestProcessors}
+          unsavedSearchProcessors={props.unsavedSearchProcessors}
           setIsExportModalOpen={setIsExportModalOpen}
         />
       )}

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -126,7 +126,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                 uiConfig={props.uiConfig}
                 setUiConfig={props.setUiConfig}
                 setIngestResponse={setIngestResponse}
-                setQueryResponse={setQueryResponse}
                 ingestDocs={props.ingestDocs}
                 setIngestDocs={props.setIngestDocs}
                 isRunningIngest={props.isRunningIngest}

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -67,7 +67,8 @@ export function Query(props: QueryProps) {
 
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value. We default to different values
-  // based on the context (ingest or search).
+  // based on the context (ingest or search), and update based on changes to the context
+  // (ingest v. search), or if the parent form values are changed.
   const [tempRequest, setTempRequest] = useState<string>('');
   useEffect(() => {
     setTempRequest(
@@ -76,6 +77,14 @@ export function Query(props: QueryProps) {
         : values?.search?.request || '{}'
     );
   }, [props.selectedStep]);
+  useEffect(() => {
+    if (
+      !isEmpty(values?.search?.request) &&
+      props.selectedStep === CONFIG_STEP.SEARCH
+    ) {
+      setTempRequest(values?.search?.request);
+    }
+  }, [values?.search?.request]);
 
   // state for if to execute search w/ or w/o any configured search pipeline.
   // default based on if there is an available search pipeline or not.
@@ -86,13 +95,6 @@ export function Query(props: QueryProps) {
 
   // query params state
   const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
-
-  // listen for changes to the upstream / form query, and reset the default
-  useEffect(() => {
-    if (!isEmpty(values?.search?.request)) {
-      setTempRequest(values?.search?.request);
-    }
-  }, [values?.search?.request]);
 
   // Do a few things when the request is changed:
   // 1. Check if there is a new set of query parameters, and if so,

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -83,7 +83,6 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(
         getAllByText((content) => content.startsWith('Last updated:')).length
       ).toBeGreaterThan(0);
-      expect(getAllByText('Search pipeline').length).toBeGreaterThan(0);
       expect(getByText('Close')).toBeInTheDocument();
       expect(getByText('Export')).toBeInTheDocument();
       expect(getByText('Visual')).toBeInTheDocument();
@@ -92,10 +91,6 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(getByRole('tab', { name: 'Search response' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
-
-      // "Run ingestion" button exists
-      const runIngestionButton = getByTestId('runIngestionButton');
-      expect(runIngestionButton).toBeInTheDocument();
 
       // "Search pipeline" button should be disabled by default
       const searchPipelineButton = getByTestId('searchPipelineButton');
@@ -119,7 +114,7 @@ describe('WorkflowDetail Page Functionality (Custom Workflow)', () => {
     // Export button opens the export component
     userEvent.click(getByTestId('exportButton'));
     await waitFor(() => {
-      expect(getByText(`Export ${workflowName}`)).toBeInTheDocument();
+      expect(getByText(`Export '${workflowName}'`)).toBeInTheDocument();
     });
 
     // Close the export component
@@ -179,8 +174,7 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
     );
 
     // Defining a new ingest pipeline & index is enabled by default
-    const enabledCheckbox = getByTestId('checkbox-ingest.enabled');
-    expect(enabledCheckbox).toBeChecked();
+    const enabledCheckbox = getByTestId('switch-ingest.enabled');
 
     // Skipping ingest pipeline and navigating to search
     userEvent.click(enabledCheckbox);
@@ -190,7 +184,7 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
 
     // Search pipeline
     await waitFor(() => {
-      expect(getAllByText('Define search pipeline').length).toBeGreaterThan(0);
+      expect(getAllByText('Define search flow').length).toBeGreaterThan(0);
     });
     expect(getAllByText('Configure query').length).toBeGreaterThan(0);
 
@@ -224,7 +218,6 @@ describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow
     });
 
     // Build and Run query, Back buttons are present
-    expect(getByTestId('runQueryButton')).toBeInTheDocument();
     const searchPipelineBackButton = getByTestId('searchPipelineBackButton');
     userEvent.click(searchPipelineBackButton);
 

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -63,6 +63,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                 <BooleanField
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={fieldPath}
+                  type="Checkbox"
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -10,14 +10,18 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIconTip,
+  EuiSwitch,
   EuiText,
 } from '@elastic/eui';
 
 interface BooleanFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   label: string;
+  type: ComponentType;
   helpText?: string;
 }
+
+type ComponentType = 'Checkbox' | 'Switch';
 
 /**
  * An input field for a boolean value. Implemented as an EuiCompressedRadioGroup with 2 mutually exclusive options.
@@ -26,10 +30,37 @@ export function BooleanField(props: BooleanFieldProps) {
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
-        return (
+        return props.type === 'Checkbox' ? (
           <EuiCompressedCheckbox
             data-testid={`checkbox-${field.name}`}
             id={`checkbox-${field.name}`}
+            label={
+              <>
+                <EuiFlexGroup direction="row">
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s">{props.label}</EuiText>
+                  </EuiFlexItem>
+                  {props.helpText && (
+                    <EuiFlexItem
+                      grow={false}
+                      style={{ marginLeft: '-8px', marginTop: '10px' }}
+                    >
+                      <EuiIconTip content={props.helpText} position="right" />
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
+              </>
+            }
+            checked={field.value === undefined || field.value === true}
+            onChange={() => {
+              form.setFieldValue(field.name, !field.value);
+              form.setFieldTouched(field.name, true);
+            }}
+          />
+        ) : (
+          <EuiSwitch
+            data-testid={`switch-${field.name}`}
+            id={`switch-${field.name}`}
             label={
               <>
                 <EuiFlexGroup direction="row">

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -21,10 +21,7 @@ import { WorkflowFormValues } from '../../../../../common';
 import { AppState } from '../../../../store';
 import { EditQueryModal } from './edit_query_modal';
 
-interface ConfigureSearchRequestProps {
-  setQuery: (query: string) => void;
-  setQueryResponse: (queryResponse: string) => void;
-}
+interface ConfigureSearchRequestProps {}
 
 /**
  * Input component for configuring a search request
@@ -54,14 +51,6 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
 
   // Edit modal state
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
-
-  // Hook to listen when the query form value changes.
-  // Try to set the query request if possible
-  useEffect(() => {
-    if (values?.search?.request) {
-      props.setQuery(values.search.request);
-    }
-  }, [values?.search?.request]);
 
   return (
     <>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -18,8 +18,6 @@ import { getDataSourceId } from '../../../../utils';
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
-  setQuery: (query: string) => void;
-  setQueryResponse: (queryResponse: string) => void;
 }
 
 /**
@@ -38,10 +36,7 @@ export function SearchInputs(props: SearchInputsProps) {
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
-        <ConfigureSearchRequest
-          setQuery={props.setQuery}
-          setQueryResponse={props.setQueryResponse}
-        />
+        <ConfigureSearchRequest />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -674,7 +674,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                           <EuiFlexItem grow={false}>
                             <EuiSmallButtonIcon
                               style={{ marginTop: '-4px' }}
-                              aria-label={'ingestBackButton'}
+                              aria-label="searchPipelineBackButton"
+                              data-testid="searchPipelineBackButton"
                               iconType={'arrowLeft'}
                               onClick={() =>
                                 props.setSelectedStep(CONFIG_STEP.INGEST)

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -110,7 +110,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const onIngest = props.selectedStep === CONFIG_STEP.INGEST;
   const onSearch = props.selectedStep === CONFIG_STEP.SEARCH;
   const ingestEnabled = values?.ingest?.enabled || false;
-  const onSearchAndProvisioned = onSearch && searchProvisioned;
   const onIngestAndUnprovisioned = onIngest && !ingestProvisioned;
   const onIngestAndDisabled = onIngest && !ingestEnabled;
   const isProposingNoSearchResources =
@@ -565,18 +564,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     type="Switch"
                     helpText="Create a new ingest pipeline and index"
                   />
-                </EuiFlexItem>
-              )}
-              {onSearchAndProvisioned && (
-                <EuiFlexItem grow={false}>
-                  <EuiSmallButton
-                    fill={false}
-                    onClick={() => {
-                      props.displaySearchPanel();
-                    }}
-                  >
-                    Test pipeline
-                  </EuiSmallButton>
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -484,7 +484,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   // to clean up any created resources and not have leftover / stale data in some index.
   // This is propagated by passing `reprovision=false` to validateAndUpdateWorkflow()
   async function validateAndRunIngestion(): Promise<boolean> {
-    console.log('running ingestion only');
     props.setIsRunningIngest(true);
     let success = false;
     try {

--- a/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
+++ b/public/pages/workflows/workflow_list/delete_workflow_modal.tsx
@@ -74,10 +74,10 @@ export function DeleteWorkflowModal(props: DeleteWorkflowModalProps) {
     <EuiModal onClose={() => props.clearDeleteState()}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <p>{`Delete ${getCharacterLimitedString(
+          <p>{`Delete '${getCharacterLimitedString(
             props.workflow.name,
             MAX_WORKFLOW_NAME_TO_DISPLAY
-          )}?`}</p>
+          )}'?`}</p>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -140,10 +140,10 @@ export function WorkflowList(props: WorkflowListProps) {
         >
           <EuiFlyoutHeader hasBorder={true}>
             <EuiText size="m">
-              <h2>{`Active resources with ${getCharacterLimitedString(
+              <h2>{`Active resources with '${getCharacterLimitedString(
                 selectedWorkflow.name,
                 MAX_WORKFLOW_NAME_TO_DISPLAY
-              )}`}</h2>
+              )}'`}</h2>
             </EuiText>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -45,21 +45,35 @@ import { sanitizeJSONPath } from './utils';
  **************** Config -> template utils **********************
  */
 
-export function configToTemplateFlows(config: WorkflowConfig): TemplateFlows {
-  const provisionFlow = configToProvisionTemplateFlow(config);
+export function configToTemplateFlows(
+  config: WorkflowConfig,
+  includeIngest: boolean = true,
+  includeSearch: boolean = true
+): TemplateFlows {
+  const provisionFlow = configToProvisionTemplateFlow(
+    config,
+    includeIngest,
+    includeSearch
+  );
   return {
     provision: provisionFlow,
   };
 }
 
-function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
+function configToProvisionTemplateFlow(
+  config: WorkflowConfig,
+  includeIngest: boolean = true,
+  includeSearch: boolean = true
+): TemplateFlow {
   const nodes = [] as TemplateNode[];
   const edges = [] as TemplateEdge[];
 
-  nodes.push(
-    ...ingestConfigToTemplateNodes(config.ingest),
-    ...searchConfigToTemplateNodes(config.search)
-  );
+  if (includeIngest) {
+    nodes.push(...ingestConfigToTemplateNodes(config.ingest));
+  }
+  if (includeSearch) {
+    nodes.push(...searchConfigToTemplateNodes(config.search));
+  }
 
   const createIngestPipelineNode = nodes.find(
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE
@@ -68,7 +82,7 @@ function configToProvisionTemplateFlow(config: WorkflowConfig): TemplateFlow {
     (node) => node.type === WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
   ) as CreateSearchPipelineNode;
 
-  if (config.ingest.enabled.value) {
+  if (config?.ingest?.enabled?.value && includeIngest) {
     nodes.push(
       indexConfigToTemplateNode(
         config.ingest.index,


### PR DESCRIPTION
### Description

This PR updates the navigation across ingest and search. The main changes include:
- automatic bottom bars that pop up if there are changes detected that will impact the resources created (or if creating for the first time). Within them, can either update the resources, or undo changes and revert to the last saved state. These also work to block the complexity around buttons being enabled/disabled which the users don't need to care about, as navigation is disabled by default while the bottom bar is present and changes need to be updated or reverted first.
- state updates of the resources indicating if they are provisioned or not. Shows ingest state on ingest flow, and ingest/search states on search flow for easier visibility
- simplifies search flow: rather than handling search within the update, it is now decoupled from the "Update" button. Instead, once successfully updated, we show a toast indicating as such, and automatically navigate to the "search" tab in the Inspector.
- general simplification of the form - removing the `EuiStepsHorizontal` at the top, moving the enable/disable ingestion at the top, and minor rewordings
- other: some prop reduction in some related components
- other: adds callout in export modal if unsaved resources detected
- other: adds quotes around workflow names in modals
- other: fixes bug of search resources being created during provisioning on ingest if preset search form values configured (for the preset workflow usecases)

Testing:
- custom/empty workflows work as expected
- preset workflows with presets in ingest & search work as expected
- skipping ingest works as expected
- creation and update for ingest and search work as expected
- update search -> test flow works as expected
- lightweight guardrail testing / bug bashing. more to come later.

Next steps:
- finalize if enable/disable can happen at other phases
- finalize if deletion is supported on ingest at all (constraints on search pipelines entirely)

Demo video, overview & different states:

[screen-capture (16).webm](https://github.com/user-attachments/assets/47f9cdce-06eb-4d71-ac56-0319d4a6d467)

Demo video 2, with a preset usecase & comparing to custom:

[screen-capture (17).webm](https://github.com/user-attachments/assets/58b7fd46-8d12-486f-be55-5b6cd5893ab9)


### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
