### PR TITLE
Adding feature flag to OpenSearch Flow

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -5,18 +5,13 @@
   "server": true,
   "ui": true,
   "requiredBundles": [],
-  "requiredPlugins": [
-    "navigation",
-    "opensearchDashboardsUtils"
-  ],
+  "requiredPlugins": ["navigation", "opensearchDashboardsUtils"],
   "optionalPlugins": [
     "dataSource",
     "dataSourceManagement",
     "contentManagement"
   ],
   "supportedOSDataSourceVersions": ">=2.18.0 <4.0.0",
-  "requiredOSDataSourcePlugins": [
-    "opensearch-ml",
-    "opensearch-flow-framework"
-  ]
+  "requiredOSDataSourcePlugins": ["opensearch-ml", "opensearch-flow-framework"],
+  "configPath": ["flowFrameworkDashboards"]
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../src/core/server';
+import {
+  PluginConfigDescriptor,
+  PluginInitializerContext,
+} from '../../../src/core/server';
 import { FlowFrameworkDashboardsPlugin } from './plugin';
+import { configSchema, ConfigSchema } from '../server/types';
+
+export const config: PluginConfigDescriptor<ConfigSchema> = {
+  schema: configSchema,
+};
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,5 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.maybe(schema.boolean()),
+});
+
+export type ConfigSchema = TypeOf<typeof configSchema>;
+
 export interface FlowFrameworkDashboardsPluginSetup {}
 export interface FlowFrameworkDashboardsPluginStart {}


### PR DESCRIPTION
### Description

- This PR is related to adding feature flag for Flow framework Dashboards.
- This gives ability to enable or disable OpenSearch flow plugin in Dashboards.


[screen-capture (30).webm](https://github.com/user-attachments/assets/22ecaf8e-0ee3-455a-ac4e-5ff5a217b678)



Tested:
- Verified by Enabling, disabling feature flag in config/opensearch_dashboards.yml .
- When flowFrameworkDashboards.enabled:false, OpenSearch Flow Will not be visible.
- By default it is true.

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
