### PR TITLE
filter preset and enrich data section processors based on version 

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -131,6 +131,8 @@ export enum PROCESSOR_TYPE {
   NORMALIZATION = 'normalization-processor',
   COLLAPSE = 'collapse',
   RERANK = 'rerank',
+  TEXT_EMBEDDING = 'text_embedding-processor',
+  TEXT_IMAGE_EMBEDDING = 'text_image_embedding-processor',
 }
 
 export enum MODEL_TYPE {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -126,7 +126,9 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   }, [USE_NEW_HOME_PAGE, dataSourceEnabled, dataSourceId, workflowName]);
 
   // form state
-  const [formValues, setFormValues] = useState<WorkflowFormValues>({});
+  const [formValues, setFormValues] = useState<WorkflowFormValues>(
+    {} as WorkflowFormValues
+  );
   const [formSchema, setFormSchema] = useState<WorkflowSchema>(yup.object({}));
 
   // ingest docs state. we need to persist here to update the form values.

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -3,32 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsList } from '../processors_list';
 import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
 import { ProcessorsTitle } from '../../../../general_components';
+import { SavedObject } from '../../../../../../../src/core/public';
+import { DataSourceAttributes } from '../../../../../../../src/plugins/data_source/common/data_sources';
 
 interface EnrichDataProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
+  dataSource?: SavedObject<DataSourceAttributes>;
 }
 
 /**
  * Base component for configuring any data enrichment
  */
 export function EnrichData(props: EnrichDataProps) {
+  const [filteredCount, setFilteredCount] = useState(0);
+
   return (
     <EuiFlexGroup direction="column">
-      <ProcessorsTitle
-        title="Enrich data"
-        processorCount={props.uiConfig.ingest.enrich.processors?.length || 0}
-      />
+      <ProcessorsTitle title="Enrich data" processorCount={filteredCount} />
       <EuiFlexItem>
         <ProcessorsList
           uiConfig={props.uiConfig}
           setUiConfig={props.setUiConfig}
           context={PROCESSOR_CONTEXT.INGEST}
+          dataSource={props.dataSource}
+          onProcessorsChange={setFilteredCount}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -3,34 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsTitle } from '../../../../general_components';
 import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
 import { ProcessorsList } from '../processors_list';
+import { SavedObject } from '../../../../../../../src/core/public';
+import { DataSourceAttributes } from '../../../../../../../src/plugins/data_source/common/data_sources';
 
 interface EnrichSearchRequestProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
+  dataSource?: SavedObject<DataSourceAttributes>;
 }
 
 /**
  * Input component for enriching a search request (configuring search request processors, etc.)
  */
 export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
+  const [filteredCount, setFilteredCount] = useState(0);
+
   return (
     <EuiFlexGroup direction="column">
       <ProcessorsTitle
         title="Enhance query request"
-        processorCount={
-          props.uiConfig.search.enrichRequest.processors?.length || 0
-        }
+        processorCount={filteredCount}
       />
       <EuiFlexItem>
         <ProcessorsList
           uiConfig={props.uiConfig}
           setUiConfig={props.setUiConfig}
           context={PROCESSOR_CONTEXT.SEARCH_REQUEST}
+          dataSource={props.dataSource}
+          onProcessorsChange={setFilteredCount}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -3,34 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ProcessorsTitle } from '../../../../general_components';
 import { PROCESSOR_CONTEXT, WorkflowConfig } from '../../../../../common';
 import { ProcessorsList } from '../processors_list';
+import { SavedObject } from '../../../../../../../src/core/public';
+import { DataSourceAttributes } from '../../../../../../../src/plugins/data_source/common/data_sources';
 
 interface EnrichSearchResponseProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
+  dataSource?: SavedObject<DataSourceAttributes>;
 }
 
 /**
  * Input component for enriching a search response (configuring search response processors, etc.)
  */
 export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
+  const [filteredCount, setFilteredCount] = useState(0);
+
   return (
     <EuiFlexGroup direction="column">
       <ProcessorsTitle
         title="Enhance query results"
-        processorCount={
-          props.uiConfig.search.enrichResponse.processors?.length || 0
-        }
+        processorCount={filteredCount}
       />
       <EuiFlexItem>
         <ProcessorsList
           uiConfig={props.uiConfig}
           setUiConfig={props.setUiConfig}
           context={PROCESSOR_CONTEXT.SEARCH_RESPONSE}
+          dataSource={props.dataSource}
+          onProcessorsChange={setFilteredCount}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -53,9 +53,9 @@ import {
   getDataSourceId,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
-
 // styling
 import '../workspace/workspace-styles.scss';
+// import { getDataSourceEnabled } from '../../../services';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;
@@ -443,7 +443,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
         };
         if (Object.keys(relevantValidationResults).length > 0) {
           getCore().notifications.toasts.addDanger('Missing or invalid fields');
-          console.error('Form invalid');
         } else {
           setTouched({});
           const updatedConfig = formikToUiConfig(

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -29,12 +29,15 @@ import {
   HYBRID_SEARCH_QUERY_MATCH_KNN,
   WorkflowConfig,
   UI_METADATA_SCHEMA_VERSION,
+  PROCESSOR_TYPE,
 } from '../../../../common';
 import { generateId } from '../../../utils';
+import semver from 'semver';
 
 // Fn to produce the complete preset template with all necessary UI metadata.
 export function enrichPresetWorkflowWithUiMetadata(
-  presetWorkflow: Partial<WorkflowTemplate>
+  presetWorkflow: Partial<WorkflowTemplate>,
+  version: string
 ): WorkflowTemplate {
   let uiMetadata = {} as UIState;
   switch (presetWorkflow.ui_metadata?.type || WORKFLOW_TYPE.CUSTOM) {
@@ -64,6 +67,38 @@ export function enrichPresetWorkflowWithUiMetadata(
     }
   }
 
+  if (semver.eq(version, '2.17.0')) {
+    uiMetadata.config.ingest.enrich.processors = uiMetadata.config.ingest.enrich.processors.filter(
+      (p) => p.type !== PROCESSOR_TYPE.ML
+    );
+    uiMetadata.config.search.enrichRequest.processors = uiMetadata.config.search.enrichRequest.processors.filter(
+      (p) => p.type !== PROCESSOR_TYPE.ML
+    );
+    uiMetadata.config.search.enrichResponse.processors = uiMetadata.config.search.enrichResponse.processors.filter(
+      (p) => p.type !== PROCESSOR_TYPE.ML
+    );
+  }
+
+  if (semver.eq(version, '2.19.0')) {
+    uiMetadata.config.ingest.enrich.processors = uiMetadata.config.ingest.enrich.processors.filter(
+      (p) =>
+        p.type !== PROCESSOR_TYPE.TEXT_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.TEXT_IMAGE_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.NORMALIZATION
+    );
+    uiMetadata.config.search.enrichRequest.processors = uiMetadata.config.search.enrichRequest.processors.filter(
+      (p) =>
+        p.type !== PROCESSOR_TYPE.TEXT_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.TEXT_IMAGE_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.NORMALIZATION
+    );
+    uiMetadata.config.search.enrichResponse.processors = uiMetadata.config.search.enrichResponse.processors.filter(
+      (p) =>
+        p.type !== PROCESSOR_TYPE.TEXT_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.TEXT_IMAGE_EMBEDDING &&
+        p.type !== PROCESSOR_TYPE.NORMALIZATION
+    );
+  }
   return {
     ...presetWorkflow,
     ui_metadata: {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -31,6 +31,7 @@ import {
   setHeaderActionMenu,
 } from './services';
 import { configureRoutes } from './route_service';
+import { dataSourceFilterFn } from './utils';
 
 export class FlowFrameworkDashboardsPlugin
   implements
@@ -76,6 +77,8 @@ export class FlowFrameworkDashboardsPlugin
     setDataSourceManagementPlugin(plugins.dataSourceManagement);
     const enabled = !!plugins.dataSource;
     setDataSourceEnabled({ enabled });
+    console.log('datasourceManagement', plugins.dataSourceManagement);
+    console.log('data source', plugins.dataSource);
     return {
       dataSourceManagement: plugins.dataSourceManagement,
       dataSource: plugins.dataSource,


### PR DESCRIPTION

Signed-off-by: Kama Huang <kamahuan@amazon.com>

### Description
Use datasource to get backend version.
If open search backend version is 2.17.0:
1. filter the presets using ML processors, and keep only 3 presets
2. in the enrich data section, disable all the ML processors in both ingest and search pipeline

if open search backend version is 2.19.0:
1. filter all the presets using neural processors, in this case, keep all the presets as they are.
2. in the enrich data section, keep all the ML processors and disable the neural processors in both ingest and search pipeline.

Upon checking this PR only handle version before 2.17.0 and 2.19.0. 2.18.0 is not handled.

Add processor list change is out of scope of this CR.

### Issues Resolved

NONE

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
