### PR TITLE
Improve search response rendering; other minor fixes

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -596,6 +596,27 @@ export type SimulateIngestPipelineResponse = {
 
 export type SearchHit = SimulateIngestPipelineDoc;
 
+export type SearchResponse = {
+  took: number;
+  timed_out: boolean;
+  _shards: {
+    total: number;
+    successful: number;
+    skipped: number;
+    failed: number;
+  };
+  hits?: {
+    total: {
+      value: number;
+      relation: string;
+    };
+    max_score: number;
+    hits: SearchHit[];
+  };
+  aggregations?: {};
+  ext: {};
+};
+
 export type IndexResponse = {
   indexName: string;
   indexDetails: IndexConfiguration;

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -605,7 +605,7 @@ export type SearchResponse = {
     skipped: number;
     failed: number;
   };
-  hits?: {
+  hits: {
     total: {
       value: number;
       relation: string;
@@ -614,7 +614,7 @@ export type SearchResponse = {
     hits: SearchHit[];
   };
   aggregations?: {};
-  ext: {};
+  ext?: {};
 };
 
 export type IndexResponse = {

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -7,4 +7,5 @@ export { MultiSelectFilter } from './multi_select_filter';
 export { ProcessorsTitle } from './processors_title';
 export { ExperimentalBadge } from './experimental_badge';
 export { QueryParamsList } from './query_params_list';
+export * from './results';
 export * from './service_card';

--- a/public/general_components/results/index.ts
+++ b/public/general_components/results/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { Results } from './results';

--- a/public/general_components/results/results.tsx
+++ b/public/general_components/results/results.tsx
@@ -36,7 +36,7 @@ export function Results(props: ResultsProps) {
       hasBorder={false}
       hasShadow={false}
       paddingSize="none"
-      style={{ height: '10vh', overflowY: 'scroll' }}
+      style={{ height: '10vh', overflowY: 'scroll', overflowX: 'hidden' }}
     >
       <EuiFlexGroup
         direction="column"

--- a/public/general_components/results/results.tsx
+++ b/public/general_components/results/results.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSmallButtonGroup,
+} from '@elastic/eui';
+import { SearchResponse } from '../../../common';
+import { ResultsTable } from './results_table';
+import { ResultsJSON } from './results_json';
+
+interface ResultsProps {
+  response: SearchResponse;
+}
+
+enum VIEW {
+  HITS_TABLE = 'hits_table',
+  RAW_JSON = 'raw_json',
+}
+
+/**
+ * Basic component to view OpenSearch response results. Can view hits in a tabular format,
+ * or the raw JSON response.
+ */
+export function Results(props: ResultsProps) {
+  // selected view state
+  const [selectedView, setSelectedView] = useState<VIEW>(VIEW.HITS_TABLE);
+
+  return (
+    <EuiPanel
+      hasBorder={false}
+      hasShadow={false}
+      paddingSize="none"
+      style={{ height: '10vh', overflowY: 'scroll' }}
+    >
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="xs"
+        style={{ height: '100%' }}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiSmallButtonGroup
+            legend="Choose how to view your data"
+            options={[
+              {
+                id: VIEW.HITS_TABLE,
+                label: 'Hits',
+              },
+              {
+                id: VIEW.RAW_JSON,
+                label: 'Raw JSON',
+              },
+            ]}
+            idSelected={selectedView}
+            onChange={(id) => setSelectedView(id as VIEW)}
+            data-testid="resultsToggleButtonGroup"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <>
+            {selectedView === VIEW.HITS_TABLE && (
+              <ResultsTable hits={props.response?.hits?.hits || []} />
+            )}
+            {selectedView === VIEW.RAW_JSON && (
+              <ResultsJSON response={props.response} />
+            )}
+          </>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/public/general_components/results/results_json.tsx
+++ b/public/general_components/results/results_json.tsx
@@ -12,8 +12,7 @@ interface ResultsJSONProps {
 }
 
 /**
- * Small component to render the raw search response. Grows to fill
- * the parent container by setting 100% width/height.
+ * Small component to render the raw search response.
  */
 export function ResultsJSON(props: ResultsJSONProps) {
   return (

--- a/public/general_components/results/results_json.tsx
+++ b/public/general_components/results/results_json.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCodeEditor } from '@elastic/eui';
+import { customStringify, SearchResponse } from '../../../common';
+
+interface ResultsJSONProps {
+  response: SearchResponse;
+}
+
+/**
+ * Small component to render the raw search response. Grows to fill
+ * the parent container by setting 100% width/height.
+ */
+export function ResultsJSON(props: ResultsJSONProps) {
+  return (
+    <EuiCodeEditor
+      mode="json"
+      theme="textmate"
+      width="100%"
+      height="100%"
+      value={customStringify(props.response)}
+      readOnly={true}
+      setOptions={{
+        fontSize: '12px',
+        autoScrollEditorIntoView: true,
+        wrap: true,
+      }}
+      tabSize={2}
+    />
+  );
+}

--- a/public/general_components/results/results_table.tsx
+++ b/public/general_components/results/results_table.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiText,
+  EuiButtonIcon,
+  RIGHT_ALIGNMENT,
+  EuiInMemoryTable,
+  EuiPanel,
+} from '@elastic/eui';
+import { customStringify, SearchHit } from '../../../common';
+
+interface ResultsTableProps {
+  hits: SearchHit[];
+}
+
+/**
+ * Small component to display a list of search results with pagination.
+ * Wrapped in a flexible panel with overflow handling.
+ */
+export function ResultsTable(props: ResultsTableProps) {
+  const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<{
+    [itemId: string]: any;
+  }>({});
+
+  const toggleDetails = (hit: SearchHit) => {
+    const itemIdToExpandedRowMapValues = { ...itemIdToExpandedRowMap };
+    if (itemIdToExpandedRowMapValues[hit._id]) {
+      delete itemIdToExpandedRowMapValues[hit._id];
+    } else {
+      itemIdToExpandedRowMapValues[hit._id] = (
+        <EuiText>{customStringify(hit._source)}</EuiText>
+      );
+    }
+    setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);
+  };
+
+  return (
+    <EuiPanel
+      hasBorder={false}
+      hasShadow={false}
+      paddingSize="none"
+      style={{ height: '10vh', overflowY: 'scroll' }}
+    >
+      <EuiInMemoryTable
+        itemId="_id"
+        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+        items={props.hits}
+        isExpandable={true}
+        compressed={true}
+        pagination={true}
+        tableLayout="auto"
+        columns={[
+          {
+            field: '_id',
+            name: '',
+            sortable: false,
+            render: (_, item: SearchHit) => {
+              return (
+                <EuiText size="s">{customStringify(item._source)}</EuiText>
+              );
+            },
+          },
+          {
+            align: RIGHT_ALIGNMENT,
+            width: '40px',
+            isExpander: true,
+            render: (item: SearchHit) => (
+              <EuiButtonIcon
+                onClick={() => toggleDetails(item)}
+                aria-label={
+                  itemIdToExpandedRowMap[item._id] ? 'Collapse' : 'Expand'
+                }
+                iconType={
+                  itemIdToExpandedRowMap[item._id] ? 'arrowUp' : 'arrowDown'
+                }
+              />
+            ),
+          },
+        ]}
+      />
+    </EuiPanel>
+  );
+}

--- a/public/general_components/results/results_table.tsx
+++ b/public/general_components/results/results_table.tsx
@@ -9,6 +9,7 @@ import {
   EuiButtonIcon,
   RIGHT_ALIGNMENT,
   EuiInMemoryTable,
+  EuiCodeEditor,
   EuiPanel,
 } from '@elastic/eui';
 import { customStringify, SearchHit } from '../../../common';
@@ -32,56 +33,79 @@ export function ResultsTable(props: ResultsTableProps) {
       delete itemIdToExpandedRowMapValues[hit._id];
     } else {
       itemIdToExpandedRowMapValues[hit._id] = (
-        <EuiText>{customStringify(hit._source)}</EuiText>
+        <EuiPanel
+          style={{ height: '20vh' }}
+          hasShadow={false}
+          hasBorder={false}
+          paddingSize="none"
+        >
+          <EuiCodeEditor
+            mode="json"
+            theme="textmate"
+            width="100%"
+            height="100%"
+            value={customStringify(hit._source)}
+            readOnly={true}
+            setOptions={{
+              fontSize: '12px',
+              autoScrollEditorIntoView: true,
+              wrap: true,
+            }}
+            tabSize={2}
+          />
+        </EuiPanel>
       );
     }
     setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);
   };
 
   return (
-    <EuiPanel
-      hasBorder={false}
-      hasShadow={false}
-      paddingSize="none"
-      style={{ height: '10vh', overflowY: 'scroll' }}
-    >
-      <EuiInMemoryTable
-        itemId="_id"
-        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-        items={props.hits}
-        isExpandable={true}
-        compressed={true}
-        pagination={true}
-        tableLayout="auto"
-        columns={[
-          {
-            field: '_id',
-            name: '',
-            sortable: false,
-            render: (_, item: SearchHit) => {
-              return (
-                <EuiText size="s">{customStringify(item._source)}</EuiText>
-              );
-            },
+    <EuiInMemoryTable
+      itemId="_id"
+      itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+      items={props.hits}
+      isExpandable={true}
+      compressed={true}
+      pagination={true}
+      tableLayout="auto"
+      columns={[
+        {
+          field: '_id',
+          name: '',
+          sortable: false,
+          render: (_, item: SearchHit) => {
+            return (
+              <EuiText
+                size="s"
+                color="subdued"
+                style={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  width: '20vw',
+                }}
+              >
+                {customStringify(item._source)}
+              </EuiText>
+            );
           },
-          {
-            align: RIGHT_ALIGNMENT,
-            width: '40px',
-            isExpander: true,
-            render: (item: SearchHit) => (
-              <EuiButtonIcon
-                onClick={() => toggleDetails(item)}
-                aria-label={
-                  itemIdToExpandedRowMap[item._id] ? 'Collapse' : 'Expand'
-                }
-                iconType={
-                  itemIdToExpandedRowMap[item._id] ? 'arrowUp' : 'arrowDown'
-                }
-              />
-            ),
-          },
-        ]}
-      />
-    </EuiPanel>
+        },
+        {
+          align: RIGHT_ALIGNMENT,
+          width: '40px',
+          isExpander: true,
+          render: (item: SearchHit) => (
+            <EuiButtonIcon
+              onClick={() => toggleDetails(item)}
+              aria-label={
+                itemIdToExpandedRowMap[item._id] ? 'Collapse' : 'Expand'
+              }
+              iconType={
+                itemIdToExpandedRowMap[item._id] ? 'arrowUp' : 'arrowDown'
+              }
+            />
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/public/general_components/results/results_table.tsx
+++ b/public/general_components/results/results_table.tsx
@@ -20,7 +20,7 @@ interface ResultsTableProps {
 
 /**
  * Small component to display a list of search results with pagination.
- * Wrapped in a flexible panel with overflow handling.
+ * Can expand each entry to view the full _source response
  */
 export function ResultsTable(props: ResultsTableProps) {
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<{

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -82,7 +82,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Inspector panel state vars. Actions taken in the form can update the Inspector panel,
   // hence we keep top-level vars here to pass to both form and inspector components.
   const [ingestResponse, setIngestResponse] = useState<string>('');
-  const [queryResponse, setQueryResponse] = useState<string>('');
   const [selectedInspectorTabId, setSelectedInspectorTabId] = useState<
     INSPECTOR_TAB_ID
   >(INSPECTOR_TAB_ID.INGEST);
@@ -207,8 +206,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                         <Tools
                           workflow={props.workflow}
                           ingestResponse={ingestResponse}
-                          queryResponse={queryResponse}
-                          setQueryResponse={setQueryResponse}
                           selectedTabId={selectedInspectorTabId}
                           setSelectedTabId={setSelectedInspectorTabId}
                           selectedStep={props.selectedStep}

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -21,7 +21,6 @@ import {
   customStringify,
   FETCH_ALL_QUERY,
   QueryParam,
-  SearchHit,
   SearchResponse,
   WorkflowFormValues,
 } from '../../../../../common';
@@ -36,8 +35,6 @@ import {
 import { QueryParamsList, Results } from '../../../../general_components';
 
 interface QueryProps {
-  queryResponse: string;
-  setQueryResponse: (queryResponse: string) => void;
   hasSearchPipeline: boolean;
   hasIngestResources: boolean;
   selectedStep: CONFIG_STEP;
@@ -68,9 +65,9 @@ export function Query(props: QueryProps) {
 
   // query response state
   // TODO: clean up how/what responses we are persisting and where.
-  const [tempResponse, setTempResponse] = useState<SearchResponse | undefined>(
-    undefined
-  );
+  const [queryResponse, setQueryResponse] = useState<
+    SearchResponse | undefined
+  >(undefined);
 
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value. We default to different values
@@ -123,7 +120,7 @@ export function Query(props: QueryProps) {
         }))
       );
     }
-    props.setQueryResponse('');
+    setQueryResponse(undefined);
   }, [tempRequest]);
 
   // empty states
@@ -190,17 +187,10 @@ export function Query(props: QueryProps) {
                         )
                           .unwrap()
                           .then(async (resp: SearchResponse) => {
-                            setTempResponse(resp);
-                            props.setQueryResponse(
-                              customStringify(
-                                resp?.hits?.hits?.map(
-                                  (hit: SearchHit) => hit._source
-                                ) || []
-                              )
-                            );
+                            setQueryResponse(resp);
                           })
                           .catch((error: any) => {
-                            props.setQueryResponse('');
+                            setQueryResponse(undefined);
                             console.error('Error running query: ', error);
                           });
                       }}
@@ -294,7 +284,7 @@ export function Query(props: QueryProps) {
                 {/**
                  * TODO: clean up how/what responses we are persisting
                  */}
-                {isEmpty(tempResponse) ? (
+                {queryResponse === undefined || isEmpty(queryResponse) ? (
                   <EuiEmptyPrompt
                     title={<h2>No results</h2>}
                     titleSize="s"
@@ -305,7 +295,7 @@ export function Query(props: QueryProps) {
                     }
                   />
                 ) : (
-                  <Results response={tempResponse as SearchResponse} />
+                  <Results response={queryResponse} />
                 )}
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -64,7 +64,6 @@ export function Query(props: QueryProps) {
   const [useCustomQuery, setUseCustomQuery] = useState<boolean>(false);
 
   // query response state
-  // TODO: clean up how/what responses we are persisting and where.
   const [queryResponse, setQueryResponse] = useState<
     SearchResponse | undefined
   >(undefined);
@@ -281,9 +280,6 @@ export function Query(props: QueryProps) {
                 <EuiText size="m">Results</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
-                {/**
-                 * TODO: clean up how/what responses we are persisting
-                 */}
                 {queryResponse === undefined || isEmpty(queryResponse) ? (
                   <EuiEmptyPrompt
                     title={<h2>No results</h2>}

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -33,8 +33,6 @@ import {
 interface ToolsProps {
   workflow?: Workflow;
   ingestResponse: string;
-  queryResponse: string;
-  setQueryResponse: (queryResponse: string) => void;
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
   selectedStep: CONFIG_STEP;
@@ -83,13 +81,6 @@ export function Tools(props: ToolsProps) {
     }
   }, [props.ingestResponse]);
 
-  // auto-navigate to query tab if a populated value has been set, indicating search has been ran
-  useEffect(() => {
-    if (!isEmpty(props.queryResponse)) {
-      props.setSelectedTabId(INSPECTOR_TAB_ID.QUERY);
-    }
-  }, [props.queryResponse]);
-
   return (
     <EuiPanel
       paddingSize="m"
@@ -135,8 +126,6 @@ export function Tools(props: ToolsProps) {
                 )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.QUERY && (
                   <Query
-                    queryResponse={props.queryResponse}
-                    setQueryResponse={props.setQueryResponse}
                     hasSearchPipeline={hasProvisionedSearchResources(
                       props.workflow
                     )}

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -20,19 +20,16 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
-  EuiCodeEditor,
   EuiEmptyPrompt,
   EuiCallOut,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
-  customStringify,
   IConfigField,
   QUERY_PRESETS,
   QueryParam,
   QueryPreset,
   RequestFormValues,
-  SearchHit,
   SearchResponse,
   WorkflowFormValues,
 } from '../../../../../common';

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -82,6 +82,9 @@ export function EditQueryModal(props: EditQueryModalProps) {
   // popover state
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false);
 
+  // optional search panel state. allows searching within the modal
+  const [searchPanelOpen, setSearchPanelOpen] = useState<boolean>(false);
+
   // results state
   const [tempResults, setTempResults] = useState<string>('');
   const [tempResultsError, setTempResultsError] = useState<string>('');
@@ -171,43 +174,62 @@ export function EditQueryModal(props: EditQueryModalProps) {
                           <EuiText size="m">Query definition</EuiText>
                         </EuiFlexItem>
                         <EuiFlexItem grow={false}>
-                          <EuiPopover
-                            button={
-                              <EuiSmallButton
-                                onClick={() => setPopoverOpen(!popoverOpen)}
-                                data-testid="searchQueryPresetButton"
-                                iconSide="right"
-                                iconType="arrowDown"
+                          <EuiFlexGroup direction="row" gutterSize="s">
+                            <EuiFlexItem grow={false}>
+                              <EuiPopover
+                                button={
+                                  <EuiSmallButton
+                                    onClick={() => setPopoverOpen(!popoverOpen)}
+                                    data-testid="searchQueryPresetButton"
+                                    iconSide="right"
+                                    iconType="arrowDown"
+                                  >
+                                    Query samples
+                                  </EuiSmallButton>
+                                }
+                                isOpen={popoverOpen}
+                                closePopover={() => setPopoverOpen(false)}
+                                anchorPosition="downLeft"
                               >
-                                Query samples
+                                <EuiContextMenu
+                                  size="s"
+                                  initialPanelId={0}
+                                  panels={[
+                                    {
+                                      id: 0,
+                                      items: QUERY_PRESETS.map(
+                                        (preset: QueryPreset) => ({
+                                          name: preset.name,
+                                          onClick: () => {
+                                            formikProps.setFieldValue(
+                                              'request',
+                                              preset.query
+                                            );
+                                            setPopoverOpen(false);
+                                          },
+                                        })
+                                      ),
+                                    },
+                                  ]}
+                                />
+                              </EuiPopover>
+                            </EuiFlexItem>
+                            <EuiFlexItem grow={false}>
+                              <EuiSmallButton
+                                data-testid="showOrHideSearchPanelButton"
+                                fill={false}
+                                iconType={
+                                  searchPanelOpen ? 'menuLeft' : 'menuRight'
+                                }
+                                iconSide="right"
+                                onClick={() => {
+                                  setSearchPanelOpen(!searchPanelOpen);
+                                }}
+                              >
+                                Test query
                               </EuiSmallButton>
-                            }
-                            isOpen={popoverOpen}
-                            closePopover={() => setPopoverOpen(false)}
-                            anchorPosition="downLeft"
-                          >
-                            <EuiContextMenu
-                              size="s"
-                              initialPanelId={0}
-                              panels={[
-                                {
-                                  id: 0,
-                                  items: QUERY_PRESETS.map(
-                                    (preset: QueryPreset) => ({
-                                      name: preset.name,
-                                      onClick: () => {
-                                        formikProps.setFieldValue(
-                                          'request',
-                                          preset.query
-                                        );
-                                        setPopoverOpen(false);
-                                      },
-                                    })
-                                  ),
-                                },
-                              ]}
-                            />
-                          </EuiPopover>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -221,103 +243,108 @@ export function EditQueryModal(props: EditQueryModalProps) {
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiFlexGroup direction="column">
-                    <EuiFlexItem grow={false}>
-                      <EuiFlexGroup
-                        direction="row"
-                        justifyContent="spaceBetween"
-                      >
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="m">Test query</EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiSmallButton
-                            fill={false}
-                            disabled={containsEmptyValues(queryParams)}
-                            onClick={() => {
-                              dispatch(
-                                searchIndex({
-                                  apiBody: {
-                                    index: values?.search?.index?.name,
-                                    body: injectParameters(
-                                      queryParams,
-                                      tempRequest
-                                    ),
-                                    // Run the query independent of the pipeline inside this modal
-                                    searchPipeline: '_none',
-                                  },
-                                  dataSourceId,
-                                })
-                              )
-                                .unwrap()
-                                .then(async (resp) => {
-                                  setTempResults(
-                                    customStringify(
-                                      resp?.hits?.hits?.map(
-                                        (hit: SearchHit) => hit._source
+                {searchPanelOpen && (
+                  <EuiFlexItem>
+                    <EuiFlexGroup direction="column">
+                      <EuiFlexItem grow={false}>
+                        <EuiFlexGroup
+                          direction="row"
+                          justifyContent="spaceBetween"
+                        >
+                          <EuiFlexItem grow={false}>
+                            <EuiText size="m">Test query</EuiText>
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiSmallButton
+                              fill={false}
+                              disabled={containsEmptyValues(queryParams)}
+                              onClick={() => {
+                                dispatch(
+                                  searchIndex({
+                                    apiBody: {
+                                      index: values?.search?.index?.name,
+                                      body: injectParameters(
+                                        queryParams,
+                                        tempRequest
+                                      ),
+                                      // Run the query independent of the pipeline inside this modal
+                                      searchPipeline: '_none',
+                                    },
+                                    dataSourceId,
+                                  })
+                                )
+                                  .unwrap()
+                                  .then(async (resp) => {
+                                    setTempResults(
+                                      customStringify(
+                                        resp?.hits?.hits?.map(
+                                          (hit: SearchHit) => hit._source
+                                        )
                                       )
-                                    )
-                                  );
-                                  setTempResultsError('');
-                                })
-                                .catch((error: any) => {
-                                  setTempResults('');
-                                  const errorMsg = `Error running query: ${error}`;
-                                  setTempResultsError(errorMsg);
-                                  console.error(errorMsg);
-                                });
-                            }}
-                          >
-                            Search
-                          </EuiSmallButton>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                    {/**
-                     * This may return nothing if the list of params are empty
-                     */}
-                    <QueryParamsList
-                      queryParams={queryParams}
-                      setQueryParams={setQueryParams}
-                    />
-                    <EuiFlexItem>
-                      <>
-                        <EuiText size="s">Results</EuiText>
-                        {isEmpty(tempResults) && isEmpty(tempResultsError) ? (
-                          <EuiEmptyPrompt
-                            title={<h2>No results</h2>}
-                            titleSize="s"
-                            body={
-                              <>
-                                <EuiText size="s">
-                                  Run search to view results.
-                                </EuiText>
-                              </>
-                            }
-                          />
-                        ) : !isEmpty(tempResultsError) ? (
-                          <EuiCallOut color="danger" title={tempResultsError} />
-                        ) : (
-                          <EuiCodeEditor
-                            mode="json"
-                            theme="textmate"
-                            width="100%"
-                            height="100%"
-                            value={tempResults}
-                            readOnly={true}
-                            setOptions={{
-                              fontSize: '12px',
-                              autoScrollEditorIntoView: true,
-                              wrap: true,
-                            }}
-                            tabSize={2}
-                          />
-                        )}
-                      </>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
+                                    );
+                                    setTempResultsError('');
+                                  })
+                                  .catch((error: any) => {
+                                    setTempResults('');
+                                    const errorMsg = `Error running query: ${error}`;
+                                    setTempResultsError(errorMsg);
+                                    console.error(errorMsg);
+                                  });
+                              }}
+                            >
+                              Search
+                            </EuiSmallButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiFlexItem>
+                      {/**
+                       * This may return nothing if the list of params are empty
+                       */}
+                      <QueryParamsList
+                        queryParams={queryParams}
+                        setQueryParams={setQueryParams}
+                      />
+                      <EuiFlexItem>
+                        <>
+                          <EuiText size="s">Results</EuiText>
+                          {isEmpty(tempResults) && isEmpty(tempResultsError) ? (
+                            <EuiEmptyPrompt
+                              title={<h2>No results</h2>}
+                              titleSize="s"
+                              body={
+                                <>
+                                  <EuiText size="s">
+                                    Run search to view results.
+                                  </EuiText>
+                                </>
+                              }
+                            />
+                          ) : !isEmpty(tempResultsError) ? (
+                            <EuiCallOut
+                              color="danger"
+                              title={tempResultsError}
+                            />
+                          ) : (
+                            <EuiCodeEditor
+                              mode="json"
+                              theme="textmate"
+                              width="100%"
+                              height="100%"
+                              value={tempResults}
+                              readOnly={true}
+                              setOptions={{
+                                fontSize: '12px',
+                                autoScrollEditorIntoView: true,
+                                wrap: true,
+                              }}
+                              tabSize={2}
+                            />
+                          )}
+                        </>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
             </EuiModalBody>
             <EuiModalFooter>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -502,6 +502,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             .unwrap()
             .then(async (resp) => {
               props.setIngestResponse(customStringify(resp));
+              props.setIsRunningIngest(false);
               setLastIngested(Date.now());
             })
             .catch((error: any) => {
@@ -792,6 +793,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                             'Search pipeline updated'
                           );
                           props.displaySearchPanel();
+                          setSearchProvisioned(true);
                         }
                       }}
                     >

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -171,10 +171,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           formikToUiConfig(values, props.uiConfig as WorkflowConfig),
           true,
           includeSearchDuringProvision
-        ).provision.nodes) ||
+        )?.provision?.nodes) ||
         []
     );
-  }, [values, props.uiConfig, props.workflow]);
+  }, [values, props.uiConfig, props.workflow, includeSearchDuringProvision]);
 
   // fetch the persisted template nodes for ingest & search
   useEffect(() => {

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -66,11 +66,11 @@ export function Workspace(props: WorkspaceProps) {
   >(TOGGLE_BUTTON_ID.VISUAL);
   const toggleButtons = [
     {
-      id: `workspaceVisualButton`,
+      id: TOGGLE_BUTTON_ID.VISUAL,
       label: 'Visual',
     },
     {
-      id: `workspaceJSONButton`,
+      id: TOGGLE_BUTTON_ID.JSON,
       label: 'JSON',
     },
   ];


### PR DESCRIPTION
### Description

This PR primarily improves the search response rendering. Instead of a single JSON editor view showing the list of _sources from the response, now offer 2 modes: 1/ a more structured view of the sources in a tabular format with pagination to look through the data, or 2/ a raw JSON view which shows the full response. This ensures that any data users are interested outside of the _source hits (e.g., aggregations, ext field values, etc.) is still accessible.

Implementation details:
- adds new `Results` component and sub-components containing the new rendering options
- makes new `Results` component accessible in the edit query modal and the query tab of the Inspector, which is the 2 places search is supported
- adds new "Search" button to open/close the search-related components in the edit query modal. Defaults to closed
- other: bug fix: handles edge case of search-related template node diffs not being detected when no search resources exist
- other: enhancement: small state updates when creating ingest/search resources for the first time
- other: cleanup of unused props

Demo video, showing the updates to the edit query modal and the query panel in Inspector:

[screen-capture (1).webm](https://github.com/user-attachments/assets/7281bb08-7acd-4e78-ad63-c02ab6d78a73)

### Issues Resolved
--

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
