### PR TITLE
Support inserting template vars at cursor position; improve RAG preset

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -427,6 +427,12 @@ export const QUERY_PRESETS = [
 ] as QueryPreset[];
 
 /**
+ * DEFAULT TEMPLATE VAR NAMES
+ */
+export const DEFAULT_PROMPT_RESULTS_FIELD = 'results';
+export const DEFAULT_PROMPT_QUESTION_FIELD = 'question';
+
+/**
  * PROMPT PRESETS
  */
 export const SUMMARIZE_DOCS_PROMPT =
@@ -434,19 +440,25 @@ export const SUMMARIZE_DOCS_PROMPT =
 You are given a list of document results. You will \
 analyze the data and generate a human-readable summary of the results. If you don't \
 know the answer, just say I don't know.\
-\n\n Results: <provide some results> \
+\n\n Results: ${parameters." +
+  DEFAULT_PROMPT_RESULTS_FIELD +
+  '.toString()} \
 \n\n Human: Please summarize the results.\
-\n\n Assistant:";
+\n\n Assistant:';
 
 export const QA_WITH_DOCUMENTS_PROMPT =
   "Human: You are a professional data analyst. \
 You are given a list of document results, along with a question. You will \
 analyze the results and generate a human-readable response to the question, \
 based on the results. If you don't know the answer, just say I don't know.\
-\n\n Results: <provide some results> \
-\n\n Question: <provide some question> \
+\n\n Results: ${parameters." +
+  DEFAULT_PROMPT_RESULTS_FIELD +
+  '.toString()} \
+\n\n Question: ${parameters.' +
+  DEFAULT_PROMPT_QUESTION_FIELD +
+  '.toString()} \
 \n\n Human: Please answer the question using the provided results.\
-\n\n Assistant:";
+\n\n Assistant:';
 
 export const PROMPT_PRESETS = [
   {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -519,11 +519,18 @@ export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
 export const EMPTY_INPUT_MAP_ENTRY = {
   key: '',
   value: {
-    transformType: '' as TRANSFORM_TYPE,
+    transformType: TRANSFORM_TYPE.FIELD,
     value: '',
   },
 } as InputMapEntry;
-export const EMPTY_OUTPUT_MAP_ENTRY = EMPTY_INPUT_MAP_ENTRY;
+
+export const EMPTY_OUTPUT_MAP_ENTRY = {
+  ...EMPTY_INPUT_MAP_ENTRY,
+  value: {
+    ...EMPTY_INPUT_MAP_ENTRY.value,
+    transformType: NO_TRANSFORMATION as TRANSFORM_TYPE,
+  },
+};
 export const MODEL_OUTPUT_SCHEMA_NESTED_PATH =
   'output.properties.inference_results.items.properties.output.items.properties.dataAsMap.properties';
 export const MODEL_OUTPUT_SCHEMA_FULL_PATH = 'output.properties';

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -554,6 +554,7 @@ export type QuickConfigureFields = {
   textField?: string;
   imageField?: string;
   labelField?: string;
+  promptField?: string;
   embeddingLength?: number;
   llmResponseField?: string;
 };

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -365,7 +365,7 @@ export type WorkflowTemplate = {
   // https://github.com/opensearch-project/flow-framework/issues/526
   version?: any;
   workflows?: TemplateFlows;
-  use_case?: USE_CASE;
+  use_case?: string;
   // UI state and any ReactFlow state may not exist if a workflow is created via API/backend-only.
   ui_metadata?: UIState;
 };
@@ -385,12 +385,6 @@ export type Workflow = WorkflowTemplate & {
   // won't exist until launched/provisioned in backend
   resourcesCreated?: WorkflowResource[];
 };
-
-export enum USE_CASE {
-  SEMANTIC_SEARCH = 'SEMANTIC_SEARCH',
-  NEURAL_SPARSE_SEARCH = 'NEURAL_SPARSE_SEARCH',
-  HYBRID_SEARCH = 'HYBRID_SEARCH',
-}
 
 /**
  ********** ML PLUGIN TYPES/INTERFACES **********

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useFormikContext, getIn, Formik } from 'formik';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import * as yup from 'yup';
 import {
   EuiCodeEditor,
@@ -23,7 +23,6 @@ import {
   EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
   EuiSpacer,
-  EuiCopy,
   EuiIconTip,
 } from '@elastic/eui';
 import {
@@ -79,6 +78,10 @@ const VALUE_FLEX_RATIO = 6;
 
 // the max number of input docs we use to display & test transforms with (search response hits)
 const MAX_INPUT_DOCS = 10;
+
+// the prompt editor element ID. Used when fetching the element to perform functions on the
+// underlying ace editor (inserting template variables at the cursor position)
+const PROMPT_EDITOR_ID = 'promptEditor';
 
 /**
  * A modal to configure a prompt template. Can manually configure, include placeholder values
@@ -352,7 +355,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                       </EuiFlexGroup>
                     </EuiFlexItem>
                     <EuiSpacer size="s" />
-                    <EuiFlexItem grow={false}>
+                    <EuiFlexItem grow={false} id={PROMPT_EDITOR_ID}>
                       <EuiCodeEditor
                         mode="json"
                         theme="textmate"
@@ -386,7 +389,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         <EuiFlexItem grow={false}>
                           <EuiIconTip
                             content={`Define input variables with JSONPath to extract out source data. 
-                              Inject into the prompt by clicking the "Copy" button and pasting into the prompt.`}
+                              Insert into the prompt by clicking the "Insert" button.`}
                             position="right"
                           />
                         </EuiFlexItem>
@@ -443,38 +446,51 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                       />
                                     </EuiFlexItem>
                                     <EuiFlexItem grow={false}>
-                                      <EuiCopy
-                                        textToCopy={getPlaceholderString(
+                                      <EuiSmallButtonEmpty
+                                        disabled={isEmpty(
                                           getIn(
                                             formikProps.values,
-                                            `nestedVars.${idx}.name`
+                                            `nestedVars.${idx}.transform`
                                           )
                                         )}
+                                        onClick={() => {
+                                          const promptEditorParentElement = document
+                                            .getElementById(PROMPT_EDITOR_ID)
+                                            ?.getElementsByClassName(
+                                              'ace_editor'
+                                            );
+                                          const promptEditor = get(
+                                            promptEditorParentElement,
+                                            '0.env.editor'
+                                          );
+                                          const promptEditorSession =
+                                            promptEditor?.session;
+                                          const cursorPosition = promptEditor?.getCursorPosition();
+                                          const valueToInsert = getPlaceholderString(
+                                            getIn(
+                                              formikProps.values,
+                                              `nestedVars.${idx}.name`
+                                            )
+                                          );
+                                          if (
+                                            promptEditorSession !== undefined &&
+                                            cursorPosition !== undefined &&
+                                            valueToInsert !== undefined &&
+                                            !isEmpty(valueToInsert)
+                                          ) {
+                                            promptEditorSession.insert(
+                                              cursorPosition,
+                                              valueToInsert
+                                            );
+                                          } else {
+                                            console.error(
+                                              'Value could not be inserted'
+                                            );
+                                          }
+                                        }}
                                       >
-                                        {(copy) => (
-                                          <EuiSmallButtonIcon
-                                            aria-label="Copy"
-                                            iconType="copy"
-                                            disabled={isEmpty(
-                                              getIn(
-                                                formikProps.values,
-                                                `nestedVars.${idx}.transform`
-                                              )
-                                            )}
-                                            color={
-                                              isEmpty(
-                                                getIn(
-                                                  formikProps.values,
-                                                  `nestedVars.${idx}.transform`
-                                                )
-                                              )
-                                                ? 'subdued'
-                                                : 'primary'
-                                            }
-                                            onClick={copy}
-                                          />
-                                        )}
-                                      </EuiCopy>
+                                        Insert
+                                      </EuiSmallButtonEmpty>
                                     </EuiFlexItem>
                                     <EuiFlexItem grow={false}>
                                       <EuiSmallButtonIcon

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -301,12 +301,12 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
-                        justifyContent="spaceAround"
+                        justifyContent="spaceBetween"
                       >
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiText size="m">Prompt</EuiText>
                         </EuiFlexItem>
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiPopover
                             button={
                               <EuiSmallButton
@@ -534,12 +534,12 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
-                        justifyContent="spaceAround"
+                        justifyContent="spaceBetween"
                       >
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiText size="m">Prompt preview</EuiText>
                         </EuiFlexItem>
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiSmallButton
                             style={{ width: '100px' }}
                             isLoading={isFetching}

--- a/public/pages/workflows/workflow_list/workflow_list.test.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.test.tsx
@@ -162,7 +162,7 @@ describe('WorkflowList', () => {
     const viewResourcesButtons = getAllByLabelText('View resources');
     userEvent.click(viewResourcesButtons[0]);
     await waitFor(() => {
-      expect(getByText('No existing resources found')).toBeInTheDocument();
+      expect(getByText(/Active resources/)).toBeInTheDocument();
     });
   });
 

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { debounce } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import {
   EuiInMemoryTable,
   Direction,
@@ -148,7 +148,9 @@ export function WorkflowList(props: WorkflowListProps) {
             </EuiText>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
-            {selectedWorkflow?.ui_metadata?.type === WORKFLOW_TYPE.CUSTOM ? (
+            {selectedWorkflow?.ui_metadata === undefined ||
+            isEmpty(selectedWorkflow?.ui_metadata) ||
+            selectedWorkflow?.ui_metadata?.type === WORKFLOW_TYPE.CUSTOM ? (
               <EuiEmptyPrompt
                 title={<h2>Invalid workflow type</h2>}
                 titleSize="s"


### PR DESCRIPTION
### Description

Mixed-bag PR, includes the following:
- changes the variable insertion in the template from a copy/paste flow, to a single "insert" flow. Cursor position is persisted in the prompt code editor, and when users click "insert" on a particular template var, the formatted var is injected at such position. Further improvements to help automate these things, as well as better & more prompt templates, will come in the future when those flows are finalized and UX feedback is gathered.
- improves the RAG quick-configure presets to follow the new pattern of a model expecting a single 'prompt' field. This is defined in quick create, and used alongside any contextual field (so far, the "text field") and automatically attach as a template variable.'
- improves default transform types for the input / output transforms, and doesn't leave them as empty like before
- minor spacing improvements in the Configure Prompt modal
- NPE check which can be triggered if server-side returns 500s on Workflow List page
- filters out register-agent-related workflows on the Workflow List page
- provides better messaging if resource fetching for a particular workflow (e.g., custom, no ui_metadata found, etc.) when opening the flyout on the Workflow List page

Demo video covering most of the changes listed above:

[screen-capture (4).webm](https://github.com/user-attachments/assets/cafab795-1d92-43a2-8d6f-0c85beb4bf94)

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
