### PR TITLE
Add query param list in advanced transform modals

### DIFF
--- a/public/general_components/processors_title.tsx
+++ b/public/general_components/processors_title.tsx
@@ -9,6 +9,7 @@ import { EuiFlexItem, EuiText } from '@elastic/eui';
 interface ProcessorsTitleProps {
   title: string;
   processorCount: number;
+  optional: boolean;
 }
 
 /**
@@ -24,11 +25,13 @@ export function ProcessorsTitle(props: ProcessorsTitleProps) {
         <>
           <h3
             style={{ display: 'inline-block' }}
-          >{`${props.title} (${props.processorCount}) -`}</h3>
+          >{`${props.title} (${props.processorCount})`}</h3>
           &nbsp;
-          <h3 style={{ display: 'inline-block', fontStyle: 'italic' }}>
-            optional
-          </h3>
+          {props.optional && (
+            <h3 style={{ display: 'inline-block', fontStyle: 'italic' }}>
+              - optional
+            </h3>
+          )}
         </>
       </EuiText>
     </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/enrich_data.tsx
@@ -23,6 +23,7 @@ export function EnrichData(props: EnrichDataProps) {
       <ProcessorsTitle
         title="Enrich data"
         processorCount={props.uiConfig.ingest.enrich.processors?.length || 0}
+        optional={true}
       />
       <EuiFlexItem>
         <ProcessorsList

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -39,13 +39,18 @@ import {
   WorkflowFormValues,
   REQUEST_PREFIX,
   REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
+  QueryParam,
 } from '../../../../../../../common';
 import {
+  containsEmptyValues,
+  containsSameValues,
   formikToPartialPipeline,
   generateArrayTransform,
   generateTransform,
   getDataSourceId,
   getInitialValue,
+  getPlaceholdersFromQuery,
+  injectParameters,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
 } from '../../../../../../utils';
@@ -56,6 +61,7 @@ import {
   useAppDispatch,
 } from '../../../../../../store';
 import { getCore } from '../../../../../../services';
+import { QueryParamsList } from '../../../../../../general_components';
 
 interface ConfigureExpressionModalProps {
   uiConfig: WorkflowConfig;
@@ -139,6 +145,29 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
 
   // fetching input data state
   const [isFetching, setIsFetching] = useState<boolean>(false);
+
+  // query params state, if applicable. Users cannot run preview if there are query parameters
+  // and the user is configuring something in a search context (search request/response)
+  const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
+  useEffect(() => {
+    if (props.context !== PROCESSOR_CONTEXT.INGEST && query !== undefined) {
+      const placeholders = getPlaceholdersFromQuery(query);
+      if (
+        !containsSameValues(
+          placeholders,
+          queryParams.map((queryParam) => queryParam.name)
+        )
+      ) {
+        setQueryParams(
+          placeholders.map((placeholder) => ({
+            name: placeholder,
+            type: 'Text',
+            value: '',
+          }))
+        );
+      }
+    }
+  }, [query]);
 
   // hook to re-generate the transform when any inputs to the transform are updated
   useEffect(() => {
@@ -330,19 +359,21 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                     <EuiFlexItem grow={false}>
                       <EuiFlexGroup
                         direction="row"
-                        justifyContent="spaceAround"
+                        justifyContent="spaceBetween"
                       >
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiText size="m">Preview</EuiText>
                         </EuiFlexItem>
-                        <EuiFlexItem>
+                        <EuiFlexItem grow={false}>
                           <EuiSmallButton
                             style={{ width: '100px' }}
                             isLoading={isFetching}
                             disabled={
                               onIngestAndNoDocs ||
                               onSearchAndNoQuery ||
-                              !props.isDataFetchingAvailable
+                              !props.isDataFetchingAvailable ||
+                              (props.context !== PROCESSOR_CONTEXT.INGEST &&
+                                containsEmptyValues(queryParams))
                             }
                             onClick={async () => {
                               setIsFetching(true);
@@ -426,7 +457,9 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                                   // this if check as an extra layer of checking, and if mechanism for gating
                                   // this is changed in the future.
                                   if (curSearchPipeline === undefined) {
-                                    setSourceInput(values.search.request);
+                                    setSourceInput(
+                                      injectParameters(queryParams, query)
+                                    );
                                   }
                                   setIsFetching(false);
                                   break;
@@ -448,7 +481,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                                         index: values.search.index.name,
                                         body: JSON.stringify({
                                           ...JSON.parse(
-                                            values.search.request as string
+                                            injectParameters(queryParams, query)
                                           ),
                                           search_pipeline:
                                             curSearchPipeline || {},
@@ -490,6 +523,15 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
+                    {props.context !== PROCESSOR_CONTEXT.INGEST &&
+                      !isEmpty(queryParams) && (
+                        <EuiFlexItem grow={false}>
+                          <QueryParamsList
+                            queryParams={queryParams}
+                            setQueryParams={setQueryParams}
+                          />
+                        </EuiFlexItem>
+                      )}
                     <EuiFlexItem grow={false}>
                       <EuiText size="s">Source data</EuiText>
                     </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -25,6 +25,7 @@ export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
         processorCount={
           props.uiConfig.search.enrichRequest.processors?.length || 0
         }
+        optional={false}
       />
       <EuiFlexItem>
         <ProcessorsList

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_response.tsx
@@ -25,6 +25,7 @@ export function EnrichSearchResponse(props: EnrichSearchResponseProps) {
         processorCount={
           props.uiConfig.search.enrichResponse.processors?.length || 0
         }
+        optional={false}
       />
       <EuiFlexItem>
         <ProcessorsList


### PR DESCRIPTION
### Description

This PR implements Option 1 stated in the issue #528. All advanced transform modals now show the query param list (if applicable) under search-related contexts, such that the query, or the response from the query, can be fully populated with a valid query before executing and fetching the preview source data.

Other minor improvements:
- prevent duplicate keys when configuring inputs/outputs of ML processors. Technically can be done, but likely not user-intended. Users can still add any mappings they like, but it will be freeform text if there is no remaining preset options based on the model interface.
- spacing issues on a few of the modals
- removed optional flag for search processors. misleading in the case of users creating a search pipeline, and then trying to revert, as fine-grained deprovisioning is not supported with Flow Framework plugin.

Demo video, showing the params appearing in the 3 different advanced transform modals, and how the options for inputs/outputs dynamically change, based on what is already configured:

[screen-capture (6).webm](https://github.com/user-attachments/assets/99d95384-6b7d-45e6-b8ed-6558d55cadd7)

### Issues Resolved

Closes #528 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
