### PR TITLE
Improve prompt presets and prompt var generation

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -431,43 +431,85 @@ export const QUERY_PRESETS = [
  */
 export const DEFAULT_PROMPT_RESULTS_FIELD = 'results';
 export const DEFAULT_PROMPT_QUESTION_FIELD = 'question';
+export const DEFAULT_PROMPT_TEXT_CATEGORY_FIELD = 'textCategory';
+export const DEFAULT_PROMPT_ROLE_FIELD = 'role';
 
 /**
- * PROMPT PRESETS
+ * PROMPT PRESETS. Based off of https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-templates-and-examples.html
  */
-export const SUMMARIZE_DOCS_PROMPT =
-  "Human: You are a professional data analyst. \
-You are given a list of document results. You will \
-analyze the data and generate a human-readable summary of the results. If you don't \
-know the answer, just say I don't know.\
-\n\n Results: ${parameters." +
+export const GENERAL_SUMMARIZE_PROMPT =
+  'Read the following text: \
+\n\n${parameters.' +
   DEFAULT_PROMPT_RESULTS_FIELD +
   '.toString()} \
-\n\n Human: Please summarize the results.\
-\n\n Assistant:';
+\n\nSummarize the text in one sentence.';
 
-export const QA_WITH_DOCUMENTS_PROMPT =
-  "Human: You are a professional data analyst. \
-You are given a list of document results, along with a question. You will \
-analyze the results and generate a human-readable response to the question, \
-based on the results. If you don't know the answer, just say I don't know.\
-\n\n Results: ${parameters." +
+export const GENERAL_QA_WITH_CONTEXT_PROMPT =
+  'Read the following text, and answer the question at the end: \
+\n\n${parameters.' +
   DEFAULT_PROMPT_RESULTS_FIELD +
   '.toString()} \
-\n\n Question: ${parameters.' +
+\n\n${parameters.' +
   DEFAULT_PROMPT_QUESTION_FIELD +
-  '.toString()} \
-\n\n Human: Please answer the question using the provided results.\
-\n\n Assistant:';
+  '.toString()}';
+
+export const GENERAL_QA_NO_CONTEXT_PROMPT =
+  'Answer the following question: \
+${parameters.' +
+  DEFAULT_PROMPT_QUESTION_FIELD +
+  '.toString()}';
+
+export const GENERAL_TEXT_GENERATION_PROMPT =
+  'Please write a ${parameters.' +
+  DEFAULT_PROMPT_TEXT_CATEGORY_FIELD +
+  '.toString()} in the voice of ${parameters.' +
+  DEFAULT_PROMPT_ROLE_FIELD +
+  '.toString()}';
+
+export const CLAUDE_SUMMARIZE_PROMPT =
+  'Human: read the following results inside the <text></text> XML tags:\n\n<text>\n\
+${parameters.' +
+  DEFAULT_PROMPT_RESULTS_FIELD +
+  ".toString()}\n</text>\n\n\
+Summarize the above results in one sentence. If you don't know the answer, just \
+say I don't know.\
+\n\nAssistant:";
+
+export const CLAUDE_QA_WITH_CONTEXT_PROMPT =
+  'Human: read the following results inside the <text></text> XML tags, and then answer the question:\
+\n\n<text>\n\
+${parameters.' +
+  DEFAULT_PROMPT_RESULTS_FIELD +
+  '.toString()}\n\
+</text>\n\n' +
+  '${parameters.' +
+  DEFAULT_PROMPT_QUESTION_FIELD +
+  '.toString()}\n\nAssistant:';
 
 export const PROMPT_PRESETS = [
   {
-    name: 'Summarize documents',
-    prompt: SUMMARIZE_DOCS_PROMPT,
+    name: 'Summarize text',
+    prompt: GENERAL_SUMMARIZE_PROMPT,
   },
   {
-    name: 'QA with documents',
-    prompt: QA_WITH_DOCUMENTS_PROMPT,
+    name: 'Question-answer, with context',
+    prompt: GENERAL_QA_WITH_CONTEXT_PROMPT,
+  },
+  {
+    name: 'Question-answer, without context',
+    prompt: GENERAL_QA_NO_CONTEXT_PROMPT,
+  },
+  {
+    name: 'Text generation',
+    prompt: GENERAL_TEXT_GENERATION_PROMPT,
+  },
+  {
+    name: 'Summarize text (Claude)',
+    prompt: CLAUDE_SUMMARIZE_PROMPT,
+  },
+  {
+    name: 'Question-answer, with context (Claude)',
+    prompt: CLAUDE_QA_WITH_CONTEXT_PROMPT,
   },
 ] as PromptPreset[];
 

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -169,8 +169,8 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     }
   }, [uiConfig]);
 
-  return errorMessage.includes(ERROR_GETTING_WORKFLOW_MSG) ||
-    errorMessage.includes(NO_TEMPLATES_FOUND_MSG) ? (
+  return errorMessage?.includes(ERROR_GETTING_WORKFLOW_MSG) ||
+    errorMessage?.includes(NO_TEMPLATES_FOUND_MSG) ? (
     <EuiFlexGroup direction="column" alignItems="center">
       <EuiFlexItem grow={3}>
         <EuiEmptyPrompt

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -332,11 +332,23 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                   items: PROMPT_PRESETS.map(
                                     (preset: PromptPreset) => ({
                                       name: preset.name,
+                                      // If a new prompt is selected, update the prompt,
+                                      // and reset any nested vars.
                                       onClick: () => {
                                         try {
                                           formikProps.setFieldValue(
                                             'value',
                                             preset.prompt
+                                          );
+                                          formikProps.setFieldValue(
+                                            'nestedVars',
+                                            extractParametersFromTemplate(
+                                              preset.prompt
+                                            )
+                                          );
+                                          formikProps.setFieldTouched(
+                                            'nestedVars',
+                                            false
                                           );
                                         } catch {}
                                         formikProps.setFieldTouched(
@@ -807,4 +819,22 @@ function injectValuesIntoTemplate(
   });
 
   return finalTemplate;
+}
+
+function extractParametersFromTemplate(template: string): ExpressionVar[] {
+  const expressionVars = [] as ExpressionVar[];
+  const paramsFound = template.match(/\${([^}]+)}/g);
+  paramsFound?.forEach((param) => {
+    const curExpressionNames = expressionVars.map(
+      (expressionVar) => expressionVar.name
+    );
+    const curExpressionName = param.slice(2, -1).split('.')[1];
+    if (!curExpressionNames.includes(curExpressionName)) {
+      expressionVars.push({
+        name: curExpressionName,
+        transform: '',
+      });
+    }
+  });
+  return expressionVars;
 }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -34,7 +34,7 @@ import {
   OutputMapFormValue,
   PROCESSOR_TYPE,
   QuickConfigureFields,
-  SUMMARIZE_DOCS_PROMPT,
+  CLAUDE_SUMMARIZE_PROMPT,
   TEXT_FIELD_PATTERN,
   TRANSFORM_TYPE,
   VECTOR,
@@ -439,7 +439,7 @@ function updateRAGSearchResponseProcessors(
                 ...inputMap[0],
                 value: {
                   transformType: TRANSFORM_TYPE.TEMPLATE,
-                  value: SUMMARIZE_DOCS_PROMPT,
+                  value: CLAUDE_SUMMARIZE_PROMPT,
                   nestedVars: [
                     {
                       name: DEFAULT_PROMPT_RESULTS_FIELD,


### PR DESCRIPTION
### Description

This PR improves the prompt building experience by:
1. Improving the presets. Added several based on some suggested ones here: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-templates-and-examples.html
2. Automatically generating the unique list of nested vars based on the prompt presets, if any placeholders are found. This helps the mental model and association of how the parameters/placeholders in the prompts are tied to the form entries.

Demo video, showing the updated RAG preset, and then going through the added presets and associated generated nested parameter vars.

[screen-capture (8).webm](https://github.com/user-attachments/assets/5dcf6dbc-6e01-4222-84bf-68a0bff3fd99)

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
