### PR TITLE
Misc improvements

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -546,6 +546,7 @@ export const MAX_DOCS = 1000;
 export const MAX_STRING_LENGTH = 100;
 export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_TEMPLATE_STRING_LENGTH = 10000;
+export const MAX_BYTES = 1048576; // OSD REST request payload size limit
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;

--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -7,5 +7,6 @@ export { MultiSelectFilter } from './multi_select_filter';
 export { ProcessorsTitle } from './processors_title';
 export { ExperimentalBadge } from './experimental_badge';
 export { QueryParamsList } from './query_params_list';
+export { JsonPathExamplesTable } from './jsonpath_examples_table';
 export * from './results';
 export * from './service_card';

--- a/public/general_components/jsonpath_examples_table.tsx
+++ b/public/general_components/jsonpath_examples_table.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiInMemoryTable, EuiCode, EuiText } from '@elastic/eui';
+
+interface JsonPathExamplesTableProps {}
+
+type JSONPathExample = {
+  expression: string;
+  meaning: string;
+  example: string;
+};
+
+const examples = [
+  {
+    expression: '$.data',
+    meaning: 'The entire input',
+    example: '$.data',
+  },
+] as JSONPathExample[];
+
+const columns = [
+  {
+    field: 'expression',
+    name: 'Expression',
+    width: '25%',
+    sortable: false,
+    render: (expression: string) => <EuiCode>{expression}</EuiCode>,
+  },
+  {
+    field: 'meaning',
+    name: 'Meaning',
+    width: '50%',
+    sortable: false,
+    render: (meaning: string) => <EuiText size="s">{meaning}</EuiText>,
+  },
+  {
+    field: 'example',
+    name: 'Example',
+    width: '25%',
+    sortable: false,
+    render: (example: string) => <EuiCode>{example}</EuiCode>,
+  },
+];
+
+/**
+ * A stateless component containing JSONPath examples in a table.
+ */
+export function JsonPathExamplesTable(props: JsonPathExamplesTableProps) {
+  return (
+    <EuiInMemoryTable<JSONPathExample>
+      items={examples}
+      columns={columns}
+      pagination={false}
+      sorting={false}
+      hasActions={false}
+    />
+  );
+}

--- a/public/general_components/jsonpath_examples_table.tsx
+++ b/public/general_components/jsonpath_examples_table.tsx
@@ -4,9 +4,18 @@
  */
 
 import React from 'react';
-import { EuiInMemoryTable, EuiCode, EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import {
+  EuiInMemoryTable,
+  EuiCode,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
 
-interface JsonPathExamplesTableProps {}
+interface JsonPathExamplesTableProps {
+  headerText?: string;
+}
 
 type JSONPathExample = {
   expression: string;
@@ -47,16 +56,28 @@ const columns = [
 ];
 
 /**
- * A stateless component containing JSONPath examples in a table.
+ * A stateless component containing JSONPath examples in a table. Optionally takes in
+ * a header text for some more contextual information.
  */
 export function JsonPathExamplesTable(props: JsonPathExamplesTableProps) {
   return (
-    <EuiInMemoryTable<JSONPathExample>
-      items={examples}
-      columns={columns}
-      pagination={false}
-      sorting={false}
-      hasActions={false}
-    />
+    <EuiFlexItem style={{ width: '20vw' }}>
+      <EuiFlexGroup direction="column" gutterSize="xs">
+        {!isEmpty(props.headerText) && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">{props.headerText}</EuiText>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem>
+          <EuiInMemoryTable<JSONPathExample>
+            items={examples}
+            columns={columns}
+            pagination={false}
+            sorting={false}
+            hasActions={false}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -190,16 +190,7 @@ export function ModelInputs(props: ModelInputsProps) {
 
   // Adding a map entry to the end of the existing arr
   function addMapEntry(curEntries: InputMapFormValue): void {
-    const updatedEntries = [
-      ...curEntries,
-      {
-        key: '',
-        value: {
-          transformType: '' as TRANSFORM_TYPE,
-          value: '',
-        },
-      } as InputMapEntry,
-    ];
+    const updatedEntries = [...curEntries, EMPTY_INPUT_MAP_ENTRY];
     setFieldValue(inputMapFieldPath, updatedEntries);
     setFieldTouched(inputMapFieldPath, true);
   }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -112,16 +112,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
 
   // Adding a map entry to the end of the existing arr
   function addMapEntry(curEntries: OutputMapFormValue): void {
-    const updatedEntries = [
-      ...curEntries,
-      {
-        key: '',
-        value: {
-          transformType: '' as TRANSFORM_TYPE,
-          value: '',
-        },
-      } as OutputMapEntry,
-    ];
+    const updatedEntries = [...curEntries, EMPTY_OUTPUT_MAP_ENTRY];
     setFieldValue(outputMapFieldPath, updatedEntries);
     setFieldTouched(outputMapFieldPath, true);
   }
@@ -427,6 +418,9 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                             }
                                             showError={false}
                                           />
+                                        ) : transformType ===
+                                          NO_TRANSFORMATION ? (
+                                          <EuiText>-</EuiText>
                                         ) : undefined}
                                       </>
                                     </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Formik, getIn, useFormikContext } from 'formik';
 import * as yup from 'yup';
 import { isEmpty } from 'lodash';
@@ -42,7 +43,7 @@ import {
   getPlaceholdersFromQuery,
   injectParameters,
 } from '../../../../utils';
-import { searchIndex, useAppDispatch } from '../../../../store';
+import { AppState, searchIndex, useAppDispatch } from '../../../../store';
 import { QueryParamsList, Results } from '../../../../general_components';
 
 interface EditQueryModalProps {
@@ -57,6 +58,7 @@ interface EditQueryModalProps {
 export function EditQueryModal(props: EditQueryModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const { loading } = useSelector((state: AppState) => state.opensearch);
 
   // sub-form values/schema
   const requestFormValues = {
@@ -257,6 +259,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                           <EuiFlexItem grow={false}>
                             <EuiSmallButton
                               fill={false}
+                              isLoading={loading}
                               disabled={containsEmptyValues(queryParams)}
                               onClick={() => {
                                 dispatch(

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -175,14 +175,18 @@ export function getFieldSchema(
             }
           }
         )
-        .test('jsonArray', `Too large`, (value) => {
-          try {
-            // @ts-ignore
-            return new TextEncoder().encode(value)?.length < MAX_BYTES;
-          } catch (error) {
-            return false;
+        .test(
+          'jsonArray',
+          `Too large. Exceeds OpenSearch Dashboards limit of ${MAX_BYTES} bytes.`,
+          (value) => {
+            try {
+              // @ts-ignore
+              return new TextEncoder().encode(value)?.length < MAX_BYTES;
+            } catch (error) {
+              return false;
+            }
           }
-        });
+        );
       break;
     }
     case 'jsonString': {

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -21,6 +21,7 @@ import {
   MAX_JSON_STRING_LENGTH,
   MAX_TEMPLATE_STRING_LENGTH,
   TRANSFORM_TYPE,
+  MAX_BYTES,
 } from '../../common';
 
 /*
@@ -173,7 +174,15 @@ export function getFieldSchema(
               return false;
             }
           }
-        );
+        )
+        .test('jsonArray', `Too large`, (value) => {
+          try {
+            // @ts-ignore
+            return new TextEncoder().encode(value)?.length < MAX_BYTES;
+          } catch (error) {
+            return false;
+          }
+        });
       break;
     }
     case 'jsonString': {


### PR DESCRIPTION
### Description

Small PR with few improvements:
- always show the query in the search tab. if updated from the default configured query (if in search context), show a button to revert back
- add loading state to the search button to prevent overloading, and for visibility if searches take a long time (e.g., RAG flows)
- makes 'OverrideQueryModal' consistent with other modals by persisting temporary form s.t. query is only updated if users explicitly save
- adds check for `JSONArray` form types to validate on byte size; this prevents hitting OSD REST request limits when executing APIs, such as ingest. For example, adding byte64 encodings in ingest may not exceed the already-defined doc count of 1000, but may exceed the byte count, and thus fail at runtime. This prevents even setting the docs field to something that would later fail, and provides detailed information in the error message.
- tunes placeholder value for output map transforms where "No transformation" is selected
- makes default input/output entries consistent when adding new, by setting default transform types to "Field" and "No transformation", respectively
- add a JSONPath examples table component. Not used yet, as UX is still being finalized for this part. Will be accessible in some tooltips / extra information somewhere.

Demo video showing search changes:

[screen-capture (12).webm](https://github.com/user-attachments/assets/2af3f65c-4f4b-4281-b782-d87bf63f5cba)

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
