### PR TITLE
Fix bug of unsaved `full_response_path` not updating when fetching output preview data

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -125,7 +125,6 @@ export function ConfigureMultiExpressionModal(
   const [tempErrors, setTempErrors] = useState<boolean>(false);
 
   // get some current form values
-  const fullResponsePathPath = `${props.baseConfigPath}.${props.config.id}.full_response_path`;
   const docs = getIn(values, 'ingest.docs');
   let docObjs = [] as {}[] | undefined;
   try {
@@ -445,14 +444,6 @@ export function ConfigureMultiExpressionModal(
                                     props.outputMapFieldPath,
                                     []
                                   );
-                                  set(
-                                    valuesWithoutOutputMapConfig,
-                                    fullResponsePathPath,
-                                    getIn(
-                                      formikProps.values,
-                                      'full_response_path'
-                                    )
-                                  );
                                   const curIngestPipeline = formikToPartialPipeline(
                                     valuesWithoutOutputMapConfig,
                                     props.uiConfig,
@@ -514,14 +505,6 @@ export function ConfigureMultiExpressionModal(
                                     valuesWithoutOutputMapConfig,
                                     props.outputMapFieldPath,
                                     []
-                                  );
-                                  set(
-                                    valuesWithoutOutputMapConfig,
-                                    fullResponsePathPath,
-                                    getIn(
-                                      formikProps.values,
-                                      'full_response_path'
-                                    )
                                   );
                                   const curSearchPipeline = formikToPartialPipeline(
                                     valuesWithoutOutputMapConfig,


### PR DESCRIPTION
### Description

There was some leftover code overriding the `full_response_path` to the full_response_path as persisted in the modal-level form, which has been removed. This removes that override to use the current Formik `values` value of `full_response_path`.

Tested by fetching preview with full_response_path set to false -> true -> back to false and re-running preview, works as expected.

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
