### PR TITLE
UX fit-n-finish updates I

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -108,10 +108,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     };
   }, [setHeaderVariant, USE_NEW_HOME_PAGE]);
 
-  const onExportButtonClick = () => {
-    setIsExportModalOpen(true);
-  };
-
   const onExitButtonClick = () => {
     history.replace(
       constructUrlWithParams(APP_PATH.WORKFLOWS, undefined, dataSourceId)
@@ -303,13 +299,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 disabled: saveDisabled,
               } as TopNavMenuIconData,
               {
-                iconType: 'exportAction',
-                tooltip: 'Export',
-                ariaLabel: 'Export',
-                run: onExportButtonClick,
-                controlType: 'icon',
-              } as TopNavMenuIconData,
-              {
                 iconType: 'exit',
                 tooltip: 'Return to projects',
                 ariaLabel: 'Exit',
@@ -353,10 +342,23 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 ),
               },
               {
-                text: `Last updated: ${workflowLastUpdated}`,
+                text: `Last saved: ${workflowLastUpdated}`,
                 color: 'subdued',
                 className: 'workflow-detail-last-updated',
               } as TopNavControlData,
+              {
+                renderComponent: (
+                  <EuiSmallButton
+                    fill={true}
+                    onClick={() => {
+                      setIsExportModalOpen(true);
+                    }}
+                    data-testid="exportButton"
+                  >
+                    Export
+                  </EuiSmallButton>
+                ),
+              },
             ]}
           />
         </>
@@ -411,7 +413,7 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 }}
               />,
               <EuiText color="subdued" size="s">
-                {`Last updated: ${workflowLastUpdated}`}
+                {`Last saved: ${workflowLastUpdated}`}
               </EuiText>,
               <ExperimentalBadge
                 popoverEnabled={true}

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -38,7 +38,7 @@ interface ToolsProps {
   selectedStep: CONFIG_STEP;
 }
 
-const PANEL_TITLE = 'Inspector';
+const PANEL_TITLE = 'Inspect pipeline';
 
 /**
  * The base Tools component for performing ingest and search, viewing resources, and debugging.
@@ -98,7 +98,7 @@ export function Tools(props: ToolsProps) {
       >
         <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>
           <EuiText size="s">
-            <h2>{PANEL_TITLE}</h2>
+            <h3>{PANEL_TITLE}</h3>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -78,10 +78,10 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       } = renderWithRouter(workflowId, workflowName, type);
 
       expect(getAllByText(workflowName).length).toBeGreaterThan(0);
-      expect(getAllByText('Inspector').length).toBeGreaterThan(0);
-      expect(getAllByText('Preview').length).toBeGreaterThan(0);
+      expect(getAllByText('Inspect pipeline').length).toBeGreaterThan(0);
+      expect(getAllByText('Preview pipeline').length).toBeGreaterThan(0);
       expect(
-        getAllByText((content) => content.startsWith('Last updated:')).length
+        getAllByText((content) => content.startsWith('Last saved:')).length
       ).toBeGreaterThan(0);
       expect(getByText('Close')).toBeInTheDocument();
       expect(getByText('Export')).toBeInTheDocument();

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -23,6 +23,7 @@ import {
   EuiSpacer,
   EuiIconTip,
   EuiPopover,
+  EuiBadge,
 } from '@elastic/eui';
 import {
   customStringify,
@@ -562,7 +563,20 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                         </EuiFlexItem>
                       )}
                     <EuiFlexItem grow={false}>
-                      <EuiText size="s">Source data</EuiText>
+                      <EuiFlexGroup
+                        direction="row"
+                        gutterSize="s"
+                        justifyContent="flexStart"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s">Sample of source data</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiBadge>{`${
+                            oneToOne ? 'One' : 'Many'
+                          } to one processing`}</EuiBadge>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiCodeEditor

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -573,7 +573,7 @@ export function ConfigureMultiExpressionModal(
                         </EuiFlexItem>
                       )}
                     <EuiFlexItem grow={false}>
-                      <EuiText size="s">Source data</EuiText>
+                      <EuiText size="s">Sample of model output</EuiText>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiCodeEditor

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -24,6 +24,7 @@ import {
   EuiSmallButtonIcon,
   EuiSpacer,
   EuiIconTip,
+  EuiBadge,
 } from '@elastic/eui';
 import {
   customStringify,
@@ -622,7 +623,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         justifyContent="spaceBetween"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiText size="m">Prompt preview</EuiText>
+                          <EuiText size="m">Preview</EuiText>
                         </EuiFlexItem>
                         <EuiFlexItem grow={false}>
                           <EuiSmallButton
@@ -793,7 +794,20 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         </EuiFlexItem>
                       )}
                     <EuiFlexItem grow={false}>
-                      <EuiText size="s">Source data</EuiText>
+                      <EuiFlexGroup
+                        direction="row"
+                        gutterSize="s"
+                        justifyContent="flexStart"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s">Sample of source data</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiBadge>{`${
+                            oneToOne ? 'One' : 'Many'
+                          } to one processing`}</EuiBadge>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiCodeEditor

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -47,6 +47,8 @@ interface WorkspaceProps {
   uiConfig?: WorkflowConfig;
 }
 
+const PANEL_TITLE = 'Preview pipeline';
+
 const nodeTypes = {
   custom: WorkspaceComponent,
   ingestGroup: IngestGroupComponent,
@@ -140,7 +142,7 @@ export function Workspace(props: WorkspaceProps) {
           <EuiFlexGroup direction="row" style={{ padding: '12px' }}>
             <EuiFlexItem grow={false}>
               <EuiText size="s">
-                <h2>Preview</h2>
+                <h3>{PANEL_TITLE}</h3>
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>


### PR DESCRIPTION
### Description

Small PR with some minor UX fit-n-finish updates:
1. Move 'Export' to a primary button on upper-right-hand side in the new look and feel env.
2. Tune `Last updated` -> `Last saved`
3. Tune Preview and Inspector panel titles and sizing
4. Add a badge in the advanced transform modals indicating many-to-one/one-to-one for visibility
5. Tune wording of the sample data fetched in the advanced transform modals

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
