### PR TITLE
Add auto-generation of index mappings & settings based on processors

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -77,31 +77,81 @@ export const SEARCH_CONNECTORS_NODE_API_PATH = `${BASE_CONNECTOR_NODE_API_PATH}/
  * based on the specified remote model from a remote service, if found
  */
 
+interface RemoteEmbeddingModelConfig {
+  dimension: number;
+  fieldName: string;
+}
+
+// Amazon BedRock
+export const BEDROCK_CONFIGS = {
+  [`amazon.titan-embed-text-v1`]: {
+    dimension: 1536,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
+  [`amazon.titan-embed-text-v2`]: {
+    dimension: 1024,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
+  [`amazon.titan-embed-image-v1`]: {
+    dimension: 1024,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
+  [`cohere.embed-english-v3`]: {
+    dimension: 1024,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`cohere.embed-multilingual-v3`]: {
+    dimension: 1024,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+};
+
 // Cohere
-export const COHERE_DIMENSIONS = {
-  [`embed-english-v3.0`]: 1024,
-  [`embed-english-light-v3.0`]: 384,
-  [`embed-multilingual-v3.0`]: 1024,
-  [`embed-multilingual-light-v3.0`]: 384,
-  [`embed-english-v2.0`]: 4096,
-  [`embed-english-light-v2.0`]: 1024,
-  [`embed-multilingual-v2.0`]: 768,
+export const COHERE_CONFIGS = {
+  [`embed-english-v3.0`]: {
+    dimension: 1024,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-english-light-v3.0`]: {
+    dimension: 384,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-multilingual-v3.0`]: {
+    dimension: 1024,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-multilingual-light-v3.0`]: {
+    dimension: 384,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-english-v2.0`]: {
+    dimension: 4096,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-english-light-v2.0`]: {
+    dimension: 1024,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
+  [`embed-multilingual-v2.0`]: {
+    dimension: 768,
+    fieldName: 'embeddings',
+  } as RemoteEmbeddingModelConfig,
 };
 
 // OpenAI
-export const OPENAI_DIMENSIONS = {
-  [`text-embedding-3-small`]: 1536,
-  [`text-embedding-3-large`]: 3072,
-  [`text-embedding-ada-002`]: 1536,
-};
-
-// Amazon BedRock
-export const BEDROCK_DIMENSIONS = {
-  [`amazon.titan-embed-text-v1`]: 1536,
-  [`amazon.titan-embed-text-v2`]: 1024,
-  [`amazon.titan-embed-image-v1`]: 1024,
-  [`cohere.embed-english-v3`]: 1024, // same as Cohere directly
-  [`cohere.embed-multilingual-v3`]: 1024, // same as Cohere directly
+export const OPENAI_CONFIGS = {
+  [`text-embedding-3-small`]: {
+    dimension: 1536,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
+  [`text-embedding-3-large`]: {
+    dimension: 3072,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
+  [`text-embedding-ada-002`]: {
+    dimension: 1536,
+    fieldName: 'embedding',
+  } as RemoteEmbeddingModelConfig,
 };
 
 /**

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { isEmpty } from 'lodash';
 import {
   EuiAccordion,
   EuiFlexGroup,
@@ -11,6 +13,14 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
+import { getIn, useFormikContext } from 'formik';
+import { WorkflowFormValues } from '../../../../../common';
+import { AppState } from '../../../../store';
+import {
+  getEmbeddingDimensions,
+  getUpdatedIndexSettings,
+  isKnnIndex,
+} from '../../../../utils';
 
 interface AdvancedSettingsProps {}
 
@@ -18,6 +28,50 @@ interface AdvancedSettingsProps {}
  * Input component for configuring ingest-side advanced settings
  */
 export function AdvancedSettings(props: AdvancedSettingsProps) {
+  const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
+  const { models, connectors } = useSelector((state: AppState) => state.ml);
+  const ingestProcessors = Object.values(values?.ingest?.enrich) as [];
+  const ingestProcessorModelIds = ingestProcessors
+    .map((ingestProcessor) => ingestProcessor?.model?.id as string | undefined)
+    .filter((modelId) => !isEmpty(modelId));
+  const indexMappingsPath = 'ingest.index.mappings';
+  const indexSettingsPath = 'ingest.index.settings';
+  const curMappings = getIn(values, indexMappingsPath);
+  const curSettings = getIn(values, indexSettingsPath);
+
+  // listen on when processor with models are added / removed. dynamically update index
+  // mappings and settings, if applicable.
+  useEffect(() => {
+    if (ingestProcessorModelIds.length > 0) {
+      ingestProcessorModelIds.forEach((ingestProcessorModelId) => {
+        const processorModel = Object.values(models).find(
+          (model) => model.id === ingestProcessorModelId
+        );
+        if (processorModel?.connectorId !== undefined) {
+          const processorConnector = connectors[processorModel?.connectorId];
+          const dimension = getEmbeddingDimensions(processorConnector);
+          if (dimension !== undefined) {
+            // TODO: update mappings
+            if (!isKnnIndex(curSettings)) {
+              setFieldValue(
+                indexSettingsPath,
+                getUpdatedIndexSettings(curSettings, true)
+              );
+            }
+          }
+        }
+      });
+    } else {
+      // TODO: update mappings
+      if (isKnnIndex(curSettings)) {
+        setFieldValue(
+          indexSettingsPath,
+          getUpdatedIndexSettings(curSettings, false)
+        );
+      }
+    }
+  }, [ingestProcessorModelIds.length]);
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
@@ -25,16 +79,10 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="column">
             <EuiFlexItem>
-              <JsonField
-                label="Index mappings"
-                fieldPath={'ingest.index.mappings'}
-              />
+              <JsonField label="Index mappings" fieldPath={indexMappingsPath} />
             </EuiFlexItem>
             <EuiFlexItem>
-              <JsonField
-                label="Index settings"
-                fieldPath={'ingest.index.settings'}
-              />
+              <JsonField label="Index settings" fieldPath={indexSettingsPath} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiAccordion>

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -27,7 +27,7 @@ import {
   WORKFLOW_TYPE,
 } from '../../../../common';
 import { AppState } from '../../../store';
-import { getEmbeddingDimensions, parseModelInputs } from '../../../utils';
+import { getEmbeddingModelDimensions, parseModelInputs } from '../../../utils';
 import { get } from 'lodash';
 
 interface QuickConfigureInputsProps {
@@ -120,7 +120,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
       if (connector !== undefined) {
         setFieldValues({
           ...fieldValues,
-          embeddingLength: getEmbeddingDimensions(connector),
+          embeddingLength: getEmbeddingModelDimensions(connector),
         });
       }
     }

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -16,8 +16,6 @@ import {
   EuiCompressedFieldNumber,
 } from '@elastic/eui';
 import {
-  BEDROCK_DIMENSIONS,
-  COHERE_DIMENSIONS,
   DEFAULT_IMAGE_FIELD,
   DEFAULT_LLM_RESPONSE_FIELD,
   DEFAULT_TEXT_FIELD,
@@ -25,12 +23,11 @@ import {
   MODEL_STATE,
   Model,
   ModelInterface,
-  OPENAI_DIMENSIONS,
   QuickConfigureFields,
   WORKFLOW_TYPE,
 } from '../../../../common';
 import { AppState } from '../../../store';
-import { parseModelInputs } from '../../../utils';
+import { getEmbeddingDimensions, parseModelInputs } from '../../../utils';
 import { get } from 'lodash';
 
 interface QuickConfigureInputsProps {
@@ -121,33 +118,10 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
     if (selectedModel?.connectorId !== undefined) {
       const connector = connectors[selectedModel.connectorId];
       if (connector !== undefined) {
-        // some APIs allow specifically setting the dimensions at runtime,
-        // so we check for that first.
-        if (connector.parameters?.dimensions !== undefined) {
-          setFieldValues({
-            ...fieldValues,
-            embeddingLength: connector.parameters?.dimensions,
-          });
-        } else if (connector.parameters?.model !== undefined) {
-          const dimensions =
-            // @ts-ignore
-            COHERE_DIMENSIONS[connector.parameters?.model] ||
-            // @ts-ignore
-            OPENAI_DIMENSIONS[connector.parameters?.model] ||
-            // @ts-ignore
-            BEDROCK_DIMENSIONS[connector.parameters?.model];
-          if (dimensions !== undefined) {
-            setFieldValues({
-              ...fieldValues,
-              embeddingLength: dimensions,
-            });
-          }
-        } else {
-          setFieldValues({
-            ...fieldValues,
-            embeddingLength: undefined,
-          });
-        }
+        setFieldValues({
+          ...fieldValues,
+          embeddingLength: getEmbeddingDimensions(connector),
+        });
       }
     }
   }, [fieldValues.modelId, deployedModels, connectors]);

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -714,17 +714,6 @@ export function getEmbeddingField(
         break;
       }
     }
-    // if (relevantOutputMapEntry?.value?.transformType === NO_TRANSFORMATION) {
-    //   embeddingField = relevantOutputMapEntry?.key;
-    // } else if (
-    //   relevantOutputMapEntry?.value?.transformType === TRANSFORM_TYPE.FIELD
-    // ) {
-    //   embeddingField = relevantOutputMapEntry?.value?.value;
-    // } else if (
-    //   relevantOutputMapEntry?.value?.transformType === TRANSFORM_TYPE.EXPRESSION
-    // ) {
-    //   embeddingField = get(relevantOutputMapEntry, 'value.nestedVars.0.name');
-    // }
   }
   return embeddingField;
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -27,9 +27,13 @@ import {
   WORKFLOW_STEP_TYPE,
   Workflow,
   WorkflowResource,
+  BEDROCK_DIMENSIONS,
+  COHERE_DIMENSIONS,
+  OPENAI_DIMENSIONS,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
 import {
+  Connector,
   InputMapEntry,
   MDSQueryParams,
   ModelInputMap,
@@ -602,4 +606,26 @@ export function injectParameters(
     );
   });
   return finalQueryString;
+}
+
+// fetch embedding dimensions, if the selected model is a known one
+export function getEmbeddingDimensions(
+  connector: Connector
+): number | undefined {
+  // some APIs allow specifically setting the dimensions at runtime,
+  // so we check for that first.
+  if (connector.parameters?.dimensions !== undefined) {
+    return connector.parameters?.dimensions;
+  } else if (connector.parameters?.model !== undefined) {
+    return (
+      // @ts-ignore
+      COHERE_DIMENSIONS[connector.parameters?.model] ||
+      // @ts-ignore
+      OPENAI_DIMENSIONS[connector.parameters?.model] ||
+      // @ts-ignore
+      BEDROCK_DIMENSIONS[connector.parameters?.model]
+    );
+  } else {
+    return undefined;
+  }
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -5,7 +5,7 @@
 
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
-import { escape, get, isEmpty } from 'lodash';
+import { escape, get, isEmpty, set } from 'lodash';
 import semver from 'semver';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
@@ -30,6 +30,7 @@ import {
   BEDROCK_DIMENSIONS,
   COHERE_DIMENSIONS,
   OPENAI_DIMENSIONS,
+  customStringify,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
 import {
@@ -608,7 +609,7 @@ export function injectParameters(
   return finalQueryString;
 }
 
-// fetch embedding dimensions, if the selected model is a known one
+// Fetch embedding dimensions, if the selected model is a known one
 export function getEmbeddingDimensions(
   connector: Connector
 ): number | undefined {
@@ -627,5 +628,30 @@ export function getEmbeddingDimensions(
     );
   } else {
     return undefined;
+  }
+}
+
+// Check if an index is a knn index
+export function isKnnIndex(existingSettings: string): boolean {
+  try {
+    return get(JSON.parse(existingSettings), 'index.knn', false);
+  } catch (error) {
+    console.error('Could not parse index settings: ', error);
+    return false;
+  }
+}
+
+// Update the index settings based on parameters passed.
+// Currently just used for updating the `knn` flag.
+export function getUpdatedIndexSettings(
+  existingSettings: string,
+  knnBool: boolean
+): string {
+  try {
+    return customStringify(
+      set(JSON.parse(existingSettings), 'index.knn', knnBool)
+    );
+  } catch {
+    return existingSettings;
   }
 }


### PR DESCRIPTION
### Description

This PR adds default index mappings and index settings as ML processors are added / removed from ingest pipelines in real-time. The main idea is to add/remove any `knn_vector` field mappings, and update `index.knn` to `true`/`false` as users add or remove ML-related ingest processors, that contain any known embedding models. These 2 settings are critical and required for proper knn search to happen. Currently, the backend does not show any errors if these aren't configured correctly, and leads to user confusion when later seeing that there are no embeddings added. By adding this, this helps minimize users missing these configurations if knn search is desired.

Testing:
- tested all different output map transformation types on the UI, and how adding / removing one/multiple ML processors, including the individual output maps, ensure the behavior is as expected
- ensured existing presets still work as expected

Demo video, showing all of the different output map transform types, and how adding/removing processors updates the fields in real-time.

[screen-capture (14).webm](https://github.com/user-attachments/assets/39f335bf-8b37-4c2e-8be3-8a3ba19a0c29)

### Issues Resolved

Resolves #547 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
