### PR TITLE
UX fit-n-finish updates III

### DIFF
--- a/public/general_components/index.ts
+++ b/public/general_components/index.ts
@@ -7,5 +7,6 @@ export { MultiSelectFilter } from './multi_select_filter';
 export { ProcessorsTitle } from './processors_title';
 export { QueryParamsList } from './query_params_list';
 export { JsonPathExamplesTable } from './jsonpath_examples_table';
+export { ProcessingBadge } from './processing_badge';
 export * from './results';
 export * from './service_card';

--- a/public/general_components/processing_badge.tsx
+++ b/public/general_components/processing_badge.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBadge, EuiFlexItem } from '@elastic/eui';
+import { PROCESSOR_CONTEXT } from '../../common';
+
+interface ProcessingBadgeProps {
+  context: PROCESSOR_CONTEXT;
+  oneToOne: boolean;
+}
+
+/**
+ * Simple component to display a badge describing how the input data is processed
+ */
+export function ProcessingBadge(props: ProcessingBadgeProps) {
+  return (
+    <>
+      {props.context !== PROCESSOR_CONTEXT.SEARCH_REQUEST && (
+        <EuiFlexItem grow={false}>
+          <EuiBadge>{`${
+            props.context === PROCESSOR_CONTEXT.INGEST
+              ? 'One to one processing'
+              : props.oneToOne
+              ? 'One to one processing'
+              : 'Many to one processing'
+          }`}</EuiBadge>
+        </EuiFlexItem>
+      )}
+    </>
+  );
+}

--- a/public/global-styles.scss
+++ b/public/global-styles.scss
@@ -11,3 +11,8 @@
   height: 100%;
   width: 100%;
 }
+
+.configuration-modal {
+  width: 70vw;
+  height: 70vh;
+}

--- a/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
+++ b/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import * as yup from 'yup';
+import { Formik, getIn, useFormikContext } from 'formik';
+import { isEmpty } from 'lodash';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiSmallButtonEmpty,
+  EuiSmallButton,
+} from '@elastic/eui';
+import {
+  MAX_STRING_LENGTH,
+  Workflow,
+  WORKFLOW_NAME_REGEXP,
+  WorkflowConfig,
+  WorkflowFormValues,
+  WorkflowTemplate,
+} from '../../../../common';
+import {
+  formikToUiConfig,
+  getDataSourceId,
+  getInitialValue,
+} from '../../../utils';
+import { TextField } from '../workflow_inputs/input_fields';
+import { getWorkflow, updateWorkflow, useAppDispatch } from '../../../store';
+
+interface EditWorkflowMetadataModalProps {
+  workflow?: Workflow;
+  setIsModalOpen(isOpen: boolean): void;
+}
+/**
+ * Modal to allow editing workflow metadata, like name & description.
+ */
+export function EditWorkflowMetadataModal(
+  props: EditWorkflowMetadataModalProps
+) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+  const { values } = useFormikContext<WorkflowFormValues>();
+
+  // sub-form values/schema
+  const metadataFormValues = {
+    name: getInitialValue('string'),
+    description: getInitialValue('string'),
+  };
+  const metadataFormSchema = yup.object({
+    name: yup
+      .string()
+      .test('workflowName', 'Invalid workflow name', (name) => {
+        return !(
+          name === undefined ||
+          name === '' ||
+          name.length > 100 ||
+          WORKFLOW_NAME_REGEXP.test(name) === false
+        );
+      })
+      .required('Required') as yup.Schema,
+    desription: yup
+      .string()
+      .trim()
+      .min(0)
+      .max(MAX_STRING_LENGTH, 'Too long')
+      .optional() as yup.Schema,
+  }) as yup.Schema;
+
+  // persist standalone values
+  const [tempName, setTempName] = useState<string>(props.workflow?.name || '');
+  const [tempDescription, setTempDescription] = useState<string>(
+    props.workflow?.description || ''
+  );
+  const [tempErrors, setTempErrors] = useState<boolean>(false);
+
+  // button updating state
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
+  // if saving, take the updated name/description (along with any other unsaved form values)
+  // and execute the update.
+  async function onSave() {
+    setIsUpdating(true);
+    const updatedTemplate = {
+      name: tempName,
+      description: tempDescription,
+      ui_metadata: {
+        ...props.workflow?.ui_metadata,
+        config: formikToUiConfig(
+          values,
+          props.workflow?.ui_metadata?.config as WorkflowConfig
+        ),
+      },
+    } as WorkflowTemplate;
+    await dispatch(
+      updateWorkflow({
+        apiBody: {
+          workflowId: props.workflow?.id as string,
+          workflowTemplate: updatedTemplate,
+          updateFields: true,
+          reprovision: false,
+        },
+        dataSourceId,
+      })
+    )
+      .unwrap()
+      .then(async (result) => {
+        new Promise((f) => setTimeout(f, 1000)).then(async () => {
+          dispatch(
+            getWorkflow({
+              workflowId: props.workflow?.id as string,
+              dataSourceId,
+            })
+          );
+        });
+      })
+      .catch((error: any) => {
+        console.error('Error updating workflow: ', error);
+      })
+      .finally(() => {
+        setIsUpdating(false);
+        props.setIsModalOpen(false);
+      });
+  }
+
+  return (
+    <Formik
+      enableReinitialize={false}
+      initialValues={metadataFormValues}
+      validationSchema={metadataFormSchema}
+      onSubmit={(values) => {}}
+      validate={(values) => {}}
+    >
+      {(formikProps) => {
+        // override to parent form values when changes detected
+        useEffect(() => {
+          formikProps.setFieldValue('name', props.workflow?.name);
+        }, [props.workflow?.name]);
+        useEffect(() => {
+          formikProps.setFieldValue('description', props.workflow?.description);
+        }, [props.workflow?.description]);
+
+        // update temp vars when form changes are detected
+        useEffect(() => {
+          setTempName(getIn(formikProps.values, 'name'));
+        }, [getIn(formikProps.values, 'name')]);
+        useEffect(() => {
+          setTempDescription(getIn(formikProps.values, 'description'));
+        }, [getIn(formikProps.values, 'description')]);
+
+        // update tempErrors if errors detected
+        useEffect(() => {
+          setTempErrors(!isEmpty(formikProps.errors));
+        }, [formikProps.errors]);
+
+        return (
+          <EuiModal
+            maxWidth={false}
+            style={{ width: '50vw' }}
+            onClose={() => props.setIsModalOpen(false)}
+          >
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <p>Update workflow metadata</p>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <TextField
+                    label="Workflow name"
+                    fullWidth={false}
+                    fieldPath={`name`}
+                    showError={true}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <TextField
+                    label="Workflow description"
+                    fullWidth={true}
+                    fieldPath={`description`}
+                    showError={true}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiSmallButtonEmpty
+                onClick={() => props.setIsModalOpen(false)}
+                color="primary"
+                data-testid="closeEditMetadataButton"
+              >
+                Cancel
+              </EuiSmallButtonEmpty>
+              <EuiSmallButton
+                onClick={() => {
+                  formikProps
+                    .submitForm()
+                    .then(() => {
+                      onSave();
+                    })
+                    .catch((err: any) => {});
+                }}
+                isLoading={isUpdating}
+                isDisabled={tempErrors} // blocking update until valid input is given
+                fill={true}
+                color="primary"
+                data-testid="updateEditMetadataButton"
+              >
+                Save
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        );
+      }}
+    </Formik>
+  );
+}

--- a/public/pages/workflow_detail/components/export_modal.tsx
+++ b/public/pages/workflow_detail/components/export_modal.tsx
@@ -28,6 +28,7 @@ import {
   getCharacterLimitedString,
 } from '../../../../common';
 import { reduceToTemplate } from '../../../utils';
+import '../../../global-styles.scss';
 
 interface ExportModalProps {
   workflow?: Workflow;
@@ -77,7 +78,7 @@ export function ExportModal(props: ExportModalProps) {
   return (
     <EuiModal
       maxWidth={false}
-      style={{ width: '70vw' }}
+      className="configuration-modal"
       onClose={() => props.setIsExportModalOpen(false)}
     >
       <EuiModalHeader>

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -13,6 +13,7 @@ import {
   EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiSmallButtonIcon,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import {
   PLUGIN_ID,
@@ -54,6 +55,7 @@ import { MountPoint } from '../../../../../../src/core/public';
 import { getWorkflow, updateWorkflow, useAppDispatch } from '../../../store';
 import { useFormikContext } from 'formik';
 import { isEmpty, isEqual } from 'lodash';
+import { EditWorkflowMetadataModal } from './edit_workflow_metadata_modal';
 
 interface WorkflowDetailHeaderProps {
   workflow?: Workflow;
@@ -86,8 +88,11 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     props.workflow?.lastUpdated
   ).toString();
 
-  // export modal state
+  // modal states
   const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);
+  const [isEditWorkflowModalOpen, setIsEditWorkflowModalOpen] = useState<
+    boolean
+  >(false);
 
   const dataSourceEnabled = getDataSourceEnabled().enabled;
   const dataSourceId = getDataSourceId();
@@ -276,6 +281,12 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
           setIsExportModalOpen={setIsExportModalOpen}
         />
       )}
+      {isEditWorkflowModalOpen && (
+        <EditWorkflowMetadataModal
+          workflow={props.workflow}
+          setIsModalOpen={setIsEditWorkflowModalOpen}
+        />
+      )}
       {USE_NEW_HOME_PAGE ? (
         <>
           <TopNavMenu
@@ -358,8 +369,17 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
           {dataSourceEnabled && DataSourceComponent}
           <EuiPageHeader
             pageTitle={
-              <EuiFlexGroup direction="row" alignItems="flexEnd" gutterSize="m">
+              <EuiFlexGroup direction="row" gutterSize="s">
                 <EuiFlexItem grow={false}>{workflowName}</EuiFlexItem>
+                <EuiFlexItem grow={false} style={{ marginTop: '18px' }}>
+                  <EuiButtonIcon
+                    iconType={'gear'}
+                    aria-label="editWorkflowMetadata"
+                    onClick={() => {
+                      setIsEditWorkflowModalOpen(true);
+                    }}
+                  />
+                </EuiFlexItem>
               </EuiFlexGroup>
             }
             rightSideItems={[

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -50,6 +50,7 @@ import {
   getInitialValue,
 } from '../../../../utils';
 import { getProcessorInfo } from './source_data';
+import '../../../../global-styles.scss';
 
 interface SourceDataProps {
   workflow: Workflow | undefined;
@@ -191,7 +192,7 @@ export function SourceDataModal(props: SourceDataProps) {
           <EuiModal
             maxWidth={false}
             onClose={() => onClose()}
-            style={{ width: '70vw' }}
+            className="configuration-modal"
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -18,6 +18,7 @@ interface BooleanFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   label: string;
   type: ComponentType;
+  inverse?: boolean; // We may label something as the inverse of how the field is persisted, regarding "on/off" or "true/false"
   helpText?: string;
 }
 
@@ -30,6 +31,7 @@ export function BooleanField(props: BooleanFieldProps) {
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
+        const fieldValue = props.inverse ? !field.value : field.value;
         return props.type === 'Checkbox' ? (
           <EuiCompressedCheckbox
             data-testid={`checkbox-${field.name}`}
@@ -51,7 +53,7 @@ export function BooleanField(props: BooleanFieldProps) {
                 </EuiFlexGroup>
               </>
             }
-            checked={field.value === undefined || field.value === true}
+            checked={fieldValue === undefined || fieldValue === true}
             onChange={() => {
               form.setFieldValue(field.name, !field.value);
               form.setFieldTouched(field.name, true);
@@ -78,7 +80,7 @@ export function BooleanField(props: BooleanFieldProps) {
                 </EuiFlexGroup>
               </>
             }
-            checked={field.value === undefined || field.value === true}
+            checked={fieldValue === undefined || fieldValue === true}
             onChange={() => {
               form.setFieldValue(field.name, !field.value);
               form.setFieldTouched(field.name, true);

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -283,7 +283,10 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             <EuiSpacer size="s" />
             <ConfigFieldList
               configId={props.config.id}
-              configFields={props.config.optionalFields || []}
+              configFields={(props.config.optionalFields || []).filter(
+                // we specially render the one_to_one field in <ModelInputs/>, hence we discard it here to prevent confusion.
+                (optionalField) => optionalField.id !== 'one_to_one'
+              )}
               baseConfigPath={props.baseConfigPath}
             />
           </EuiAccordion>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -281,14 +281,16 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
             paddingSize="none"
           >
             <EuiSpacer size="s" />
-            <ConfigFieldList
-              configId={props.config.id}
-              configFields={(props.config.optionalFields || []).filter(
-                // we specially render the one_to_one field in <ModelInputs/>, hence we discard it here to prevent confusion.
-                (optionalField) => optionalField.id !== 'one_to_one'
-              )}
-              baseConfigPath={props.baseConfigPath}
-            />
+            <EuiFlexItem style={{ marginLeft: '28px' }}>
+              <ConfigFieldList
+                configId={props.config.id}
+                configFields={(props.config.optionalFields || []).filter(
+                  // we specially render the one_to_one field in <ModelInputs/>, hence we discard it here to prevent confusion.
+                  (optionalField) => optionalField.id !== 'one_to_one'
+                )}
+                baseConfigPath={props.baseConfigPath}
+              />
+            </EuiFlexItem>
           </EuiAccordion>
         </>
       )}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -16,6 +16,7 @@ import {
   EuiText,
   EuiSmallButton,
   EuiIconTip,
+  EuiLink,
 } from '@elastic/eui';
 import {
   IProcessorConfig,
@@ -25,12 +26,11 @@ import {
   WorkflowFormValues,
   ModelInterface,
   EMPTY_INPUT_MAP_ENTRY,
-  REQUEST_PREFIX,
-  REQUEST_PREFIX_WITH_JSONPATH_ROOT_SELECTOR,
   OutputMapEntry,
   OutputMapFormValue,
   OutputMapArrayFormValue,
   EMPTY_OUTPUT_MAP_ENTRY,
+  ML_REMOTE_MODEL_LINK,
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
@@ -159,12 +159,26 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           onClose={() => setIsQueryModalOpen(false)}
         />
       )}
-      <ModelField
-        field={modelField}
-        fieldPath={modelFieldPath}
-        hasModelInterface={modelInterface !== undefined}
-        onModelChange={onModelChange}
-      />
+      {isEmpty(models) ? (
+        <EuiCallOut
+          color="primary"
+          size="s"
+          title={
+            <EuiText size="s">
+              You have no model currently set up yet,{' '}
+              <EuiLink href={ML_REMOTE_MODEL_LINK}>Learn more</EuiLink> to
+              understand how to integrate ML models.
+            </EuiText>
+          }
+        />
+      ) : (
+        <ModelField
+          field={modelField}
+          fieldPath={modelFieldPath}
+          hasModelInterface={modelInterface !== undefined}
+          onModelChange={onModelChange}
+        />
+      )}
       {!isEmpty(getIn(values, modelFieldPath)?.id) && (
         <>
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -318,9 +318,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                             justifyContent="spaceBetween"
                           >
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Expression`}
-                              </EuiText>
+                              <EuiText size="s">{`Expression`}</EuiText>
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiPopover
@@ -350,9 +348,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                          <EuiText size="s" color="subdued">
-                            {`Model input name`}
-                          </EuiText>
+                          <EuiText size="s">{`Model input name`}</EuiText>
                         </EuiFlexItem>
                       </EuiFlexGroup>
                       <EuiSpacer size="s" />
@@ -370,7 +366,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                             {props.context ===
                               PROCESSOR_CONTEXT.SEARCH_RESPONSE && (
                               <EuiFlexItem grow={false}>
-                                <EuiText size="xs" color="subdued">
+                                <EuiText size="xs">
                                   {`Tip: to include data from the the original query request, prefix your expression with "${REQUEST_PREFIX}" - for example, "_request.query.match.my_field"`}
                                 </EuiText>
                               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -66,6 +66,7 @@ import {
   ProcessingBadge,
   QueryParamsList,
 } from '../../../../../../general_components';
+import '../../../../../../global-styles.scss';
 
 interface ConfigureExpressionModalProps {
   uiConfig: WorkflowConfig;
@@ -298,7 +299,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
           <EuiModal
             maxWidth={false}
             onClose={props.onClose}
-            style={{ width: '70vw' }}
+            className="configuration-modal"
             id={props.fieldPath}
           >
             <EuiModalHeader>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -23,7 +23,6 @@ import {
   EuiSpacer,
   EuiIconTip,
   EuiPopover,
-  EuiBadge,
 } from '@elastic/eui';
 import {
   customStringify,
@@ -64,6 +63,7 @@ import {
 import { getCore } from '../../../../../../services';
 import {
   JsonPathExamplesTable,
+  ProcessingBadge,
   QueryParamsList,
 } from '../../../../../../general_components';
 
@@ -567,11 +567,10 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                         <EuiFlexItem grow={false}>
                           <EuiText size="s">Sample of source data</EuiText>
                         </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiBadge>{`${
-                            oneToOne ? 'One' : 'Many'
-                          } to one processing`}</EuiBadge>
-                        </EuiFlexItem>
+                        <ProcessingBadge
+                          context={props.context}
+                          oneToOne={oneToOne}
+                        />
                       </EuiFlexGroup>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -374,7 +374,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                          <EuiText>{props.modelInputFieldName}</EuiText>
+                          <EuiText>{props.modelInputFieldName || '-'}</EuiText>
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -290,9 +290,7 @@ export function ConfigureMultiExpressionModal(
                             justifyContent="spaceBetween"
                           >
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Expression`}
-                              </EuiText>
+                              <EuiText size="s">{`Expression`}</EuiText>
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiPopover
@@ -322,7 +320,7 @@ export function ConfigureMultiExpressionModal(
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
-                          <EuiText size="s" color="subdued">
+                          <EuiText size="s">
                             {props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST
                               ? `New query field`
                               : `New document field`}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -63,6 +63,7 @@ import {
   JsonPathExamplesTable,
   QueryParamsList,
 } from '../../../../../../general_components';
+import '../../../../../../global-styles.scss';
 
 interface ConfigureMultiExpressionModalProps {
   uiConfig: WorkflowConfig;
@@ -271,7 +272,7 @@ export function ConfigureMultiExpressionModal(
           <EuiModal
             maxWidth={false}
             onClose={props.onClose}
-            style={{ width: '70vw' }}
+            className="configuration-modal"
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -96,7 +96,7 @@ export function ConfigureMultiExpressionModal(
 
   // sub-form values/schema
   const expressionsFormValues = {
-    expressions: [],
+    expressions: [{ name: '', transform: '' } as ExpressionVar],
   } as MultiExpressionFormValues;
   const expressionsFormSchema = yup.object({
     expressions: yup
@@ -226,12 +226,14 @@ export function ConfigureMultiExpressionModal(
       validate={(values) => {}}
     >
       {(formikProps) => {
-        // override to parent form values when changes detected
+        // override to parent form values when changes detected (when non-empty)
         useEffect(() => {
-          formikProps.setFieldValue(
-            'expressions',
-            getIn(values, `${props.fieldPath}.nestedVars`)
-          );
+          if (!isEmpty(getIn(values, `${props.fieldPath}.nestedVars`))) {
+            formikProps.setFieldValue(
+              'expressions',
+              getIn(values, `${props.fieldPath}.nestedVars`)
+            );
+          }
         }, [getIn(values, props.fieldPath)]);
 
         // update temp vars when form changes are detected

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -450,9 +450,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={KEY_FLEX_RATIO}>
-                          <EuiText size="s" color="subdued">
-                            {`Name`}
-                          </EuiText>
+                          <EuiText size="s">{`Name`}</EuiText>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                           <EuiFlexGroup
@@ -460,9 +458,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                             justifyContent="spaceBetween"
                           >
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Expression`}
-                              </EuiText>
+                              <EuiText size="s">{`Expression`}</EuiText>
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
                               <EuiPopover

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -70,6 +70,7 @@ import {
   ProcessingBadge,
   QueryParamsList,
 } from '../../../../../../general_components';
+import '../../../../../../global-styles.scss';
 
 interface ConfigureTemplateModalProps {
   uiConfig: WorkflowConfig;
@@ -323,7 +324,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
           <EuiModal
             maxWidth={false}
             onClose={props.onClose}
-            style={{ width: '70vw' }}
+            className="configuration-modal"
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -895,7 +895,7 @@ function getPlaceholderString(label: string) {
 
 function injectValuesIntoTemplate(
   template: string,
-  parameters: { [key: string]: string }
+  parameters: { [key: string]: any }
 ): string {
   let finalTemplate = template;
   // replace any parameter placeholders in the prompt with any values found in the
@@ -903,7 +903,7 @@ function injectValuesIntoTemplate(
   // we do 2 checks - one for the regular prompt, and one with "toString()" appended.
   // this is required for parameters that have values as a list, for example.
   Object.keys(parameters).forEach((parameterKey) => {
-    const parameterValue = parameters[parameterKey];
+    const parameterValue = JSON.stringify(parameters[parameterKey]);
     const regex = new RegExp(`\\$\\{parameters.${parameterKey}\\}`, 'g');
     const regexWithToString = new RegExp(
       `\\$\\{parameters.${parameterKey}.toString\\(\\)\\}`,

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -24,7 +24,6 @@ import {
   EuiSmallButtonIcon,
   EuiSpacer,
   EuiIconTip,
-  EuiBadge,
 } from '@elastic/eui';
 import {
   customStringify,
@@ -68,6 +67,7 @@ import {
 import { getCore } from '../../../../../../services';
 import {
   JsonPathExamplesTable,
+  ProcessingBadge,
   QueryParamsList,
 } from '../../../../../../general_components';
 
@@ -798,11 +798,10 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                         <EuiFlexItem grow={false}>
                           <EuiText size="s">Sample of source data</EuiText>
                         </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiBadge>{`${
-                            oneToOne ? 'One' : 'Many'
-                          } to one processing`}</EuiBadge>
-                        </EuiFlexItem>
+                        <ProcessingBadge
+                          context={props.context}
+                          oneToOne={oneToOne}
+                        />
                       </EuiFlexGroup>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -47,6 +47,7 @@ import {
 import { parseModelOutputs } from '../../../../../../utils/utils';
 import { JsonField } from '../../../input_fields';
 import { getFieldSchema, getInitialValue } from '../../../../../../utils';
+import '../../../../../../global-styles.scss';
 
 interface OverrideQueryModalProps {
   config: IProcessorConfig;
@@ -122,7 +123,7 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
           <EuiModal
             maxWidth={false}
             onClose={props.onClose}
-            style={{ width: '70vw' }}
+            className="configuration-modal"
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -13,7 +13,6 @@ import {
   EuiCompressedFormRow,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiPanel,
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -310,27 +309,21 @@ export function ModelInputs(props: ModelInputsProps) {
                         <EuiFlexItem grow={KEY_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Name`}
-                              </EuiText>
+                              <EuiText size="s">{`Name`}</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={TYPE_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Transform type`}
-                              </EuiText>
+                              <EuiText size="s">{`Transform type`}</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                Value
-                              </EuiText>
+                              <EuiText size="s">Value</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
@@ -390,12 +383,6 @@ export function ModelInputs(props: ModelInputsProps) {
                                           />
                                         )}
                                       </>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                      style={{ marginTop: '10px' }}
-                                    >
-                                      <EuiIcon type={'sortLeft'} />
                                     </EuiFlexItem>
                                   </>
                                 </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -31,7 +31,6 @@ import {
   EuiCompressedFormRow,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiPanel,
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -183,25 +182,21 @@ export function ModelOutputs(props: ModelOutputsProps) {
                         <EuiFlexItem grow={KEY_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Name`}
-                              </EuiText>
+                              <EuiText size="s">{`Name`}</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={TYPE_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
-                                {`Transform type`}
-                              </EuiText>
+                              <EuiText size="s">{`Transform type`}</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
                         <EuiFlexItem grow={VALUE_FLEX_RATIO}>
                           <EuiFlexGroup direction="row" gutterSize="xs">
                             <EuiFlexItem grow={false}>
-                              <EuiText size="s" color="subdued">
+                              <EuiText size="s">
                                 {props.context ===
                                 PROCESSOR_CONTEXT.SEARCH_REQUEST
                                   ? 'Query field'
@@ -267,12 +262,6 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                           />
                                         )}
                                       </>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                      style={{ marginTop: '10px' }}
-                                    >
-                                      <EuiIcon type={'sortLeft'} />
                                     </EuiFlexItem>
                                   </>
                                 </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
@@ -44,22 +44,24 @@ export function NormalizationProcessorInputs(
       buttonContent="Advanced settings"
       paddingSize="none"
     >
-      <EuiSpacer size="s" />
-      <EuiFlexItem>
-        <TextField
-          label={'Weights'}
-          helpText={`A comma-separated array of floating-point values specifying the weight for each query. For example: '0.8, 0.2'`}
-          helpLink={NORMALIZATION_PROCESSOR_LINK}
-          fieldPath={weightsFieldPath}
-          showError={true}
+      <EuiFlexItem style={{ marginLeft: '28px' }}>
+        <EuiSpacer size="s" />
+        <EuiFlexItem>
+          <TextField
+            label={'Weights'}
+            helpText={`A comma-separated array of floating-point values specifying the weight for each query. For example: '0.8, 0.2'`}
+            helpLink={NORMALIZATION_PROCESSOR_LINK}
+            fieldPath={weightsFieldPath}
+            showError={true}
+          />
+        </EuiFlexItem>
+        <EuiSpacer size="s" />
+        <ConfigFieldList
+          configId={props.config.id}
+          configFields={optionalFieldsWithoutWeights}
+          baseConfigPath={props.baseConfigPath}
         />
       </EuiFlexItem>
-      <EuiSpacer size="s" />
-      <ConfigFieldList
-        configId={props.config.id}
-        configFields={optionalFieldsWithoutWeights}
-        baseConfigPath={props.baseConfigPath}
-      />
     </EuiAccordion>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -95,11 +95,13 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
                       paddingSize="none"
                     >
                       <EuiSpacer size="s" />
-                      <ConfigFieldList
-                        configId={props.config.id}
-                        configFields={props.config.optionalFields || []}
-                        baseConfigPath={props.baseConfigPath}
-                      />
+                      <EuiFlexItem style={{ marginLeft: '28px' }}>
+                        <ConfigFieldList
+                          configId={props.config.id}
+                          configFields={props.config.optionalFields || []}
+                          baseConfigPath={props.baseConfigPath}
+                        />
+                      </EuiFlexItem>
                     </EuiAccordion>
                   )}
                 </>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/text_chunking_processor_inputs.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
-import { EuiAccordion, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { EuiAccordion, EuiCallOut, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import {
   IProcessorConfig,
   IConfigField,
@@ -102,21 +102,23 @@ export function TextChunkingProcessorInputs(
         buttonContent="Advanced settings"
         paddingSize="none"
       >
-        <EuiSpacer size="s" />
-        <ConfigFieldList
-          configId={props.config.id}
-          // construct the final set of optional fields by combining the current
-          // algorithm's set of optional fields, with the commonly shared fields
-          configFields={[
-            ...(props.config.optionalFields?.filter((optionalField) =>
-              algorithmOptionalFields.includes(optionalField.id)
-            ) || []),
-            ...(props.config.optionalFields?.filter((optionalField) =>
-              SHARED_OPTIONAL_FIELDS.includes(optionalField.id)
-            ) || []),
-          ]}
-          baseConfigPath={props.baseConfigPath}
-        />
+        <EuiFlexItem style={{ marginLeft: '28px' }}>
+          <EuiSpacer size="s" />
+          <ConfigFieldList
+            configId={props.config.id}
+            // construct the final set of optional fields by combining the current
+            // algorithm's set of optional fields, with the commonly shared fields
+            configFields={[
+              ...(props.config.optionalFields?.filter((optionalField) =>
+                algorithmOptionalFields.includes(optionalField.id)
+              ) || []),
+              ...(props.config.optionalFields?.filter((optionalField) =>
+                SHARED_OPTIONAL_FIELDS.includes(optionalField.id)
+              ) || []),
+            ]}
+            baseConfigPath={props.baseConfigPath}
+          />
+        </EuiFlexItem>
       </EuiAccordion>
     </>
   );

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../../../utils';
 import { AppState, searchIndex, useAppDispatch } from '../../../../store';
 import { QueryParamsList, Results } from '../../../../general_components';
+import '../../../../global-styles.scss';
 
 interface EditQueryModalProps {
   queryFieldPath: string;
@@ -154,7 +155,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
         return (
           <EuiModal
             onClose={() => props.setModalOpen(false)}
-            style={{ width: '70vw', height: '70vh' }}
+            className="configuration-modal"
             data-testid="editQueryModal"
             maxWidth={false}
           >

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -155,6 +155,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     boolean
   >(false);
 
+  // If a workflow is imported, but not yet provisioned, the template nodes will exist, but the resources themselves won't be created.
+  // We persist this to ensure that the update search button is enabled to allow provisioning on the UI.
+  const isProposingSearchResourcesButNotProvisioned =
+    !isEmpty(persistedSearchTemplateNodes) && !searchProvisioned;
+
   // fetch the total template nodes
   useEffect(() => {
     setPersistedTemplateNodes(
@@ -254,7 +259,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     docsPopulated &&
     (ingestTemplatesDifferent || props.isRunningIngest);
   const showSearchBottomBar =
-    onSearch && (searchTemplatesDifferent || isUpdatingSearchPipeline);
+    onSearch &&
+    (searchTemplatesDifferent ||
+      isUpdatingSearchPipeline ||
+      isProposingSearchResourcesButNotProvisioned);
 
   // Utility fn to revert any unsaved changes, reset the form
   function revertUnsavedChanges(): void {
@@ -655,7 +663,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                                 props.setSelectedStep(CONFIG_STEP.SEARCH);
                               }}
                               data-testid="searchPipelineButton"
-                              disabled={ingestTemplatesDifferent}
+                              disabled={
+                                !ingestEnabled
+                                  ? false
+                                  : ingestTemplatesDifferent
+                              }
                               iconSide="right"
                               iconType="arrowRight"
                             >
@@ -783,7 +795,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       fill={true}
                       iconType="check"
                       iconSide="left"
-                      disabled={!searchTemplatesDifferent}
+                      disabled={
+                        isProposingSearchResourcesButNotProvisioned
+                          ? false
+                          : !searchTemplatesDifferent
+                      }
                       isLoading={isUpdatingSearchPipeline}
                       onClick={async () => {
                         if (await validateAndUpdateSearchResources()) {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -585,7 +585,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     fieldPath="ingest.enabled"
                     label="Enable ingestion"
                     type="Switch"
-                    helpText="Create a new ingest pipeline and index"
                   />
                 </EuiFlexItem>
               )}

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { get, isEmpty } from 'lodash';
 import {
   EuiCompressedFormRow,
   EuiText,
@@ -14,12 +15,15 @@ import {
   EuiAccordion,
   EuiCompressedFieldText,
   EuiCompressedFieldNumber,
+  EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import {
   DEFAULT_IMAGE_FIELD,
   DEFAULT_LLM_RESPONSE_FIELD,
   DEFAULT_TEXT_FIELD,
   DEFAULT_VECTOR_FIELD,
+  ML_REMOTE_MODEL_LINK,
   MODEL_STATE,
   Model,
   ModelInterface,
@@ -28,7 +32,6 @@ import {
 } from '../../../../common';
 import { AppState } from '../../../store';
 import { getEmbeddingModelDimensions, parseModelInputs } from '../../../utils';
-import { get } from 'lodash';
 
 interface QuickConfigureInputsProps {
   workflowType?: WORKFLOW_TYPE;
@@ -160,46 +163,62 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
               }
               isInvalid={false}
               helpText={
-                props.workflowType === WORKFLOW_TYPE.RAG
+                isEmpty(deployedModels)
+                  ? undefined
+                  : props.workflowType === WORKFLOW_TYPE.RAG
                   ? 'The large language model to generate user-friendly responses'
                   : 'The model to generate embeddings'
               }
             >
-              <EuiCompressedSuperSelect
-                data-testid="selectDeployedModel"
-                fullWidth={true}
-                options={deployedModels.map(
-                  (option) =>
-                    ({
-                      value: option.id,
-                      inputDisplay: (
-                        <>
-                          <EuiText size="s">{option.name}</EuiText>
-                        </>
-                      ),
-                      dropdownDisplay: (
-                        <>
-                          <EuiText size="s">{option.name}</EuiText>
-                          <EuiText size="xs" color="subdued">
-                            Deployed
-                          </EuiText>
-                          <EuiText size="xs" color="subdued">
-                            {option.algorithm}
-                          </EuiText>
-                        </>
-                      ),
-                      disabled: false,
-                    } as EuiSuperSelectOption<string>)
-                )}
-                valueOfSelected={fieldValues?.modelId || ''}
-                onChange={(option: string) => {
-                  setFieldValues({
-                    ...fieldValues,
-                    modelId: option,
-                  });
-                }}
-                isInvalid={false}
-              />
+              {isEmpty(deployedModels) ? (
+                <EuiCallOut
+                  color="primary"
+                  size="s"
+                  title={
+                    <EuiText size="s">
+                      You have no model currently set up yet,{' '}
+                      <EuiLink href={ML_REMOTE_MODEL_LINK}>Learn more</EuiLink>{' '}
+                      to understand how to integrate ML models.
+                    </EuiText>
+                  }
+                />
+              ) : (
+                <EuiCompressedSuperSelect
+                  data-testid="selectDeployedModel"
+                  fullWidth={true}
+                  options={deployedModels.map(
+                    (option) =>
+                      ({
+                        value: option.id,
+                        inputDisplay: (
+                          <>
+                            <EuiText size="s">{option.name}</EuiText>
+                          </>
+                        ),
+                        dropdownDisplay: (
+                          <>
+                            <EuiText size="s">{option.name}</EuiText>
+                            <EuiText size="xs" color="subdued">
+                              Deployed
+                            </EuiText>
+                            <EuiText size="xs" color="subdued">
+                              {option.algorithm}
+                            </EuiText>
+                          </>
+                        ),
+                        disabled: false,
+                      } as EuiSuperSelectOption<string>)
+                  )}
+                  valueOfSelected={fieldValues?.modelId || ''}
+                  onChange={(option: string) => {
+                    setFieldValues({
+                      ...fieldValues,
+                      modelId: option,
+                    });
+                  }}
+                  isInvalid={false}
+                />
+              )}
             </EuiCompressedFormRow>
             <EuiSpacer size="s" />
             <EuiCompressedFormRow

--- a/public/pages/workflows/new_workflow/use_case.tsx
+++ b/public/pages/workflows/new_workflow/use_case.tsx
@@ -9,7 +9,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCard,
-  EuiHorizontalRule,
   EuiSmallButton,
 } from '@elastic/eui';
 import { Workflow } from '../../../../common';
@@ -39,14 +38,10 @@ export function UseCase(props: UseCaseProps) {
         }
         titleSize="s"
         paddingSize="l"
-        layout="horizontal"
-      >
-        <EuiFlexGroup direction="column" gutterSize="l">
-          <EuiHorizontalRule size="full" margin="m" />
-          <EuiFlexItem grow={true}>
-            <EuiText size="s">{props.workflow.description}</EuiText>
-          </EuiFlexItem>
-          <EuiFlexGroup direction="column" alignItems="center">
+        textAlign="left"
+        description={props.workflow?.description || ''}
+        footer={
+          <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
               <EuiSmallButton
                 disabled={false}
@@ -56,12 +51,12 @@ export function UseCase(props: UseCaseProps) {
                 }}
                 data-testid="goButton"
               >
-                Go
+                Create
               </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFlexGroup>
-      </EuiCard>
+        }
+      ></EuiCard>
     </>
   );
 }

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -42,7 +42,6 @@ import {
 } from '../../services';
 import { prettifyErrorMessage } from '../../../common/utils';
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
-import { TopNavControlData } from '../../../../../src/plugins/navigation/public';
 
 export interface WorkflowsRouterProps {}
 
@@ -92,7 +91,7 @@ export function Workflows(props: WorkflowsProps) {
     chrome: { setBreadcrumbs },
   } = getCore();
   const { HeaderControl } = getNavigationUI();
-  const { setAppDescriptionControls, setAppCenterControls } = getApplication();
+  const { setAppDescriptionControls } = getApplication();
 
   // import modal state
   const [isImportModalOpen, setIsImportModalOpen] = useState<boolean>(false);
@@ -279,7 +278,7 @@ export function Workflows(props: WorkflowsProps) {
             bottomBorder={true}
           />
 
-          <EuiPageContent>
+          <EuiPageContent grow={false}>
             <EuiPageHeader
               style={{ marginTop: '-8px' }}
               pageTitle={


### PR DESCRIPTION
### Description

Continuation of #549, #554.

Variety of small UX updates / fixes:

- adds a gear button & corresponding modal to update workflow metadata, including the workflow name and description
- updates layout of one-to-one button to a top-level switch on the "inputs" section for ML search response processors
- fixes button state issues on ingest and search when importing a workflow with previously-provisioned resources
- fixes the many-to-one / one-to-one labels for all processor contexts
- removes or updates help text in few places
- layout and minor UX updates to ML processor inputs/outputs
- layout updates to Workflow List and New Workflow pages
- layout updates to modals, move styling to central scss file
- layout updates to New Workflow use case cards
- add default expression entry in multi-expression modal, when empty on initial load
- update accordion contents left-hand spacing for advanced settings sub-fields

Related screenshots:
![Screenshot 2025-01-08 at 4 17 57 PM](https://github.com/user-attachments/assets/778e6454-fe09-4ee0-9535-1be6235e8544)

![Screenshot 2025-01-08 at 4 18 05 PM](https://github.com/user-attachments/assets/cf6ef115-5dbf-44f4-8a11-14689941c829)

![Screenshot 2025-01-08 at 4 18 27 PM](https://github.com/user-attachments/assets/45d4b87a-dcda-49a9-beba-c8b323b2a3c6)

![Screenshot 2025-01-08 at 4 18 50 PM](https://github.com/user-attachments/assets/a1662c8a-2a91-49e7-93c2-6f5e60bc8617)

![Screenshot 2025-01-08 at 4 18 59 PM](https://github.com/user-attachments/assets/5dddf19f-f0a8-4f31-b2d5-d875e7f7bbc2)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
