### PR TITLE
Reformat the Preview workspace

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -214,7 +214,8 @@ export interface IComponentField {
 export interface IComponent {
   type: COMPONENT_CLASS;
   label: string;
-  description: string;
+  iconType?: string;
+  description?: string;
   inputs?: IComponentInput[];
   outputs?: IComponentOutput[];
 }

--- a/public/component_types/indices/base_index.ts
+++ b/public/component_types/indices/base_index.ts
@@ -15,17 +15,17 @@ export class BaseIndex extends BaseComponent {
     super();
     this.type = COMPONENT_CLASS.INDEX;
     this.label = 'Index';
-    this.description = 'An OpenSearch index';
+    this.description =
+      category === COMPONENT_CATEGORY.INGEST
+        ? 'Ingest index'
+        : 'Retrieval index';
     this.inputs = [
       {
         id:
           category === COMPONENT_CATEGORY.INGEST
             ? 'document'
             : 'search_request',
-        label:
-          category === COMPONENT_CATEGORY.INGEST
-            ? 'Document'
-            : 'Search Request',
+        label: category === COMPONENT_CATEGORY.INGEST ? '' : 'Search Request',
         acceptMultiple: false,
       },
     ];

--- a/public/component_types/other/document.tsx
+++ b/public/component_types/other/document.tsx
@@ -15,11 +15,10 @@ export class Document extends BaseComponent {
     super();
     this.type = COMPONENT_CLASS.DOCUMENT;
     this.label = 'Document';
-    this.description = 'A document to be ingested';
     this.outputs = [
       {
         id: 'document',
-        label: 'Document',
+        label: '',
       },
     ];
   }

--- a/public/component_types/other/search_request.tsx
+++ b/public/component_types/other/search_request.tsx
@@ -14,12 +14,12 @@ export class SearchRequest extends BaseComponent {
   constructor() {
     super();
     this.type = COMPONENT_CLASS.SEARCH_REQUEST;
-    this.label = 'Search Request';
-    this.description = 'An OpenSearch search request';
+    this.label = 'Query';
+    this.description = 'Search request';
     this.outputs = [
       {
         id: 'search_request',
-        label: this.label,
+        label: '',
       },
     ];
   }

--- a/public/component_types/other/search_response.tsx
+++ b/public/component_types/other/search_response.tsx
@@ -14,10 +14,7 @@ export class SearchResponse extends BaseComponent {
   constructor() {
     super();
     this.type = COMPONENT_CLASS.SEARCH_RESPONSE;
-    this.label = 'Search Response';
-    this.description = 'OpenSearch search response';
-    this.inputs = [
-      { id: 'search_response', label: this.label, acceptMultiple: false },
-    ];
+    this.label = 'Search Results';
+    this.inputs = [{ id: 'search_response', label: '', acceptMultiple: false }];
   }
 }

--- a/public/component_types/transformer/ml_transformer.ts
+++ b/public/component_types/transformer/ml_transformer.ts
@@ -12,7 +12,7 @@ import { BaseTransformer } from './base_transformer';
  */
 export class MLTransformer extends BaseTransformer {
   constructor(context: PROCESSOR_CONTEXT) {
-    super('ML Processor', 'A general ML processor', context);
+    super('ML Inference', 'A general ML processor', context);
     this.type = COMPONENT_CLASS.ML_TRANSFORMER;
   }
 }

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -28,10 +28,10 @@ $handle-color-invalid: $euiColorDanger;
   border: 'none';
 
   &__ingest {
-    background: rgba($euiColorDarkShade, 0.3);
+    background: rgba($euiColorLightShade, 0.3);
   }
   &__search {
-    background: rgba($euiColorDarkShade, 0.3);
+    background: rgba($euiColorLightShade, 0.3);
   }
 }
 

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -18,8 +18,8 @@ $handle-color-invalid: $euiColorDanger;
 }
 
 .reactflow-workspace .react-flow__node {
-  width: 300px;
-  min-height: 100px;
+  width: 250px;
+  min-height: 25px;
 }
 
 .reactflow__group-node {

--- a/public/pages/workflow_detail/workspace/reactflow-styles.scss
+++ b/public/pages/workflow_detail/workspace/reactflow-styles.scss
@@ -1,4 +1,4 @@
-$handle-color: $euiColorDarkestShade;
+$handle-color: $euiColorLightShade;
 $handle-color-valid: $euiColorSuccess;
 $handle-color-invalid: $euiColorDanger;
 
@@ -28,10 +28,10 @@ $handle-color-invalid: $euiColorDanger;
   border: 'none';
 
   &__ingest {
-    background: rgba($euiColorVis0, 0.3);
+    background: rgba($euiColorDarkShade, 0.3);
   }
   &__search {
-    background: rgba($euiColorVis1, 0.3);
+    background: rgba($euiColorDarkShade, 0.3);
   }
 }
 

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -6,11 +6,9 @@
 import React, { useRef, useCallback, useEffect, useState } from 'react';
 import ReactFlow, {
   Controls,
-  Background,
   useNodesState,
   useEdgesState,
   addEdge,
-  BackgroundVariant,
   MarkerType,
 } from 'reactflow';
 import {
@@ -202,10 +200,6 @@ export function Workspace(props: WorkspaceProps) {
                   showZoom={false}
                   showInteractive={false}
                   position="top-left"
-                ></Controls>
-                <Background
-                  color="#343741"
-                  variant={'dots' as BackgroundVariant}
                 />
               </ReactFlow>
             ) : (

--- a/public/pages/workflow_detail/workspace/workspace_components/group_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/group_component.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
+import { PARENT_NODE_HEIGHT } from '../../../../utils';
 
 interface GroupComponentProps {
   data: { label: string };
@@ -16,15 +17,14 @@ interface GroupComponentProps {
  */
 export function GroupComponent(props: GroupComponentProps) {
   return (
-    // TODO: investigate having custom bounds of child nodes to prevent
-    // overlapping the group node title
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem style={{ backgroundColor: 'transparent' }}>
-        <EuiText size="s">
-          <h2 style={{ marginLeft: '8px' }}>{props.data.label}</h2>
-        </EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem></EuiFlexItem>
-    </EuiFlexGroup>
+    <EuiFlexItem
+      style={{ paddingTop: `${PARENT_NODE_HEIGHT - 40}px`, paddingLeft: 20 }}
+    >
+      <EuiFlexGroup style={{ backgroundColor: 'transparent' }}>
+        <EuiFlexItem grow={false} style={{ backgroundColor: 'transparent' }}>
+          <EuiBadge>{props.data.label}</EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
   );
 }

--- a/public/pages/workflow_detail/workspace/workspace_components/group_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/group_component.tsx
@@ -5,10 +5,11 @@
 
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
-import { PARENT_NODE_HEIGHT } from '../../../../utils';
+import { NODE_SPACING, PARENT_NODE_HEIGHT } from '../../../../utils';
 
 interface GroupComponentProps {
   data: { label: string };
+  color: string;
 }
 
 /**
@@ -18,11 +19,14 @@ interface GroupComponentProps {
 export function GroupComponent(props: GroupComponentProps) {
   return (
     <EuiFlexItem
-      style={{ paddingTop: `${PARENT_NODE_HEIGHT - 40}px`, paddingLeft: 20 }}
+      style={{
+        paddingTop: `${PARENT_NODE_HEIGHT - NODE_SPACING - 10}px`,
+        paddingLeft: NODE_SPACING,
+      }}
     >
       <EuiFlexGroup style={{ backgroundColor: 'transparent' }}>
         <EuiFlexItem grow={false} style={{ backgroundColor: 'transparent' }}>
-          <EuiBadge>{props.data.label}</EuiBadge>
+          <EuiBadge color={props.color}>{props.data.label}</EuiBadge>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlexItem>

--- a/public/pages/workflow_detail/workspace/workspace_components/ingest_group_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/ingest_group_component.tsx
@@ -10,10 +10,12 @@ interface IngestGroupComponentProps {
   data: { label: string };
 }
 
+const INGEST_COLOR = '#54B399'; // euiColorVis0: see https://oui.opensearch.org/1.6/#/guidelines/colors
+
 /**
  * A lightweight wrapper on the group component.
  * Any specific additions to ingest can be specified here.
  */
 export function IngestGroupComponent(props: IngestGroupComponentProps) {
-  return <GroupComponent data={props.data} />;
+  return <GroupComponent data={props.data} color={INGEST_COLOR} />;
 }

--- a/public/pages/workflow_detail/workspace/workspace_components/input_handle.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/input_handle.tsx
@@ -5,7 +5,8 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { Connection, Handle, Position, useReactFlow } from 'reactflow';
-import { EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { IComponent, IComponentInput } from '../../../../../common';
 import { calculateHandlePosition, isValidConnection } from './utils';
 
@@ -18,6 +19,8 @@ export function InputHandle(props: InputHandleProps) {
   const ref = useRef(null);
   const reactFlowInstance = useReactFlow();
   const [position, setPosition] = useState<number>(0);
+  const hasLabel =
+    props.input.label !== undefined && !isEmpty(props.input.label);
 
   useEffect(() => {
     setPosition(calculateHandlePosition(ref));
@@ -26,7 +29,13 @@ export function InputHandle(props: InputHandleProps) {
   return (
     <div ref={ref}>
       <>
-        <EuiText textAlign="left">{props.input.label}</EuiText>
+        {hasLabel && (
+          <EuiFlexGroup direction="row" justifyContent="flexStart">
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{props.input.label}</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
         <Handle
           type="target"
           id={props.input.id}
@@ -35,9 +44,13 @@ export function InputHandle(props: InputHandleProps) {
             // @ts-ignore
             isValidConnection(connection, reactFlowInstance)
           }
-          style={{
-            top: position,
-          }}
+          style={
+            hasLabel
+              ? {
+                  top: position,
+                }
+              : {}
+          }
         />
       </>
     </div>

--- a/public/pages/workflow_detail/workspace/workspace_components/output_handle.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/output_handle.tsx
@@ -5,7 +5,8 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { Connection, Handle, Position, useReactFlow } from 'reactflow';
-import { EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { IComponent, IComponentOutput } from '../../../../../common';
 import { calculateHandlePosition, isValidConnection } from './utils';
 
@@ -18,6 +19,8 @@ export function OutputHandle(props: OutputHandleProps) {
   const ref = useRef(null);
   const reactFlowInstance = useReactFlow();
   const [position, setPosition] = useState<number>(0);
+  const hasLabel =
+    props.output.label !== undefined && !isEmpty(props.output.label);
 
   useEffect(() => {
     setPosition(calculateHandlePosition(ref));
@@ -26,7 +29,13 @@ export function OutputHandle(props: OutputHandleProps) {
   return (
     <div ref={ref}>
       <>
-        <EuiText textAlign="right">{props.output.label}</EuiText>
+        {hasLabel && (
+          <EuiFlexGroup direction="row" justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{props.output.label}</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
         <Handle
           type="source"
           id={props.output.id}
@@ -35,9 +44,13 @@ export function OutputHandle(props: OutputHandleProps) {
             // @ts-ignore
             isValidConnection(connection, reactFlowInstance)
           }
-          style={{
-            top: position,
-          }}
+          style={
+            hasLabel
+              ? {
+                  top: position,
+                }
+              : {}
+          }
         />
       </>
     </div>

--- a/public/pages/workflow_detail/workspace/workspace_components/search_group_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/search_group_component.tsx
@@ -9,11 +9,12 @@ import { GroupComponent } from './group_component';
 interface SearchGroupComponentProps {
   data: { label: string };
 }
+const SEARCH_COLOR = '#6092C0'; // euiColorVis1: see https://oui.opensearch.org/1.6/#/guidelines/colors
 
 /**
  * A lightweight wrapper on the group component.
  * Any specific additions to search can be specified here.
  */
 export function SearchGroupComponent(props: SearchGroupComponentProps) {
-  return <GroupComponent data={props.data} />;
+  return <GroupComponent data={props.data} color={SEARCH_COLOR} />;
 }

--- a/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
+++ b/public/pages/workflow_detail/workspace/workspace_components/workspace_component.tsx
@@ -4,14 +4,21 @@
  */
 
 import React from 'react';
+import { isEmpty } from 'lodash';
 import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCard,
   EuiText,
   EuiSpacer,
+  EuiIcon,
+  IconType,
 } from '@elastic/eui';
-import { IComponentData } from '../../../../../common';
+import {
+  IComponentData,
+  IComponentInput,
+  IComponentOutput,
+} from '../../../../../common';
 import { InputHandle } from './input_handle';
 import { OutputHandle } from './output_handle';
 
@@ -29,29 +36,49 @@ interface WorkspaceComponentProps {
  */
 export function WorkspaceComponent(props: WorkspaceComponentProps) {
   const component = props.data;
+  // we don't render any component body if no metadata, such as no description, or no defined inputs/outputs.
+  const hasDescription =
+    component.description !== undefined && !isEmpty(component.description);
+  const hasIcon =
+    component.iconType !== undefined && !isEmpty(component.iconType);
+  const hasMetadata =
+    hasDescription ||
+    hasLabels(component.inputs) ||
+    hasLabels(component.outputs);
 
   return (
     <EuiCard
       className="react-flow__node"
       textAlign="left"
       title={
-        <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+        <EuiFlexGroup direction="row" justifyContent="flexStart" gutterSize="s">
+          {hasIcon && (
+            <EuiFlexItem grow={false} style={{ marginTop: '8px' }}>
+              <EuiIcon type={component.iconType as IconType} size="m" />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem grow={false}>
             <EuiText size="s">
-              <h3>{component.label}</h3>
+              <h4>{component.label}</h4>
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}></EuiFlexItem>
         </EuiFlexGroup>
       }
     >
-      <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiFlexItem>
-          <EuiText size="s" color="subdued">
-            {component.description}
-          </EuiText>
-          <EuiSpacer size="s" />
-        </EuiFlexItem>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="s"
+        style={hasMetadata ? {} : { marginBottom: '-18px' }}
+      >
+        {hasDescription && (
+          <EuiFlexItem>
+            <EuiText size="s" color="subdued">
+              {component.description}
+            </EuiText>
+            <EuiSpacer size="s" />
+          </EuiFlexItem>
+        )}
         {component.inputs?.map((input, index) => {
           return (
             <EuiFlexItem key={index}>
@@ -68,5 +95,17 @@ export function WorkspaceComponent(props: WorkspaceComponentProps) {
         })}
       </EuiFlexGroup>
     </EuiCard>
+  );
+}
+
+// small utility fn to check if inputs or outputs have labels. Component is dynamically
+// rendered based on these being populated or not.
+function hasLabels(
+  inputsOrOutputs: (IComponentInput | IComponentOutput)[] | undefined
+): boolean {
+  return !isEmpty(
+    inputsOrOutputs
+      ?.map((inputOrOutput) => inputOrOutput.label)
+      .filter((label) => !isEmpty(label))
   );
 }

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -34,7 +34,7 @@ import { generateId } from './utils';
  **************** Config -> workspace utils **********************
  */
 
-const PARENT_NODE_HEIGHT = 325;
+export const PARENT_NODE_HEIGHT = 325;
 const NODE_HEIGHT_Y = 70;
 const NODE_WIDTH = 300; // based off of the value set in reactflow-styles.scss
 const NODE_SPACING = 100; // the margin (in # pixels) between the components
@@ -527,7 +527,7 @@ function generateReactFlowEdge(
 }
 // Adding any instance metadata. Converting the base IComponent obj into
 // an instance-specific IComponentData obj.
-export function initComponentData(
+function initComponentData(
   data: IComponent,
   componentId: string
 ): IComponentData {

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -197,7 +197,7 @@ function searchConfigToWorkspaceFlow(
   // Parent search node
   const parentNode = {
     id: searchConfig.pipelineName.value,
-    position: { x: 400, y: 800 },
+    position: { x: 400, y: 700 },
     type: NODE_CATEGORY.SEARCH_GROUP,
     data: { label: COMPONENT_CATEGORY.SEARCH },
     style: {

--- a/public/utils/config_to_workspace_utils.ts
+++ b/public/utils/config_to_workspace_utils.ts
@@ -34,10 +34,9 @@ import { generateId } from './utils';
  **************** Config -> workspace utils **********************
  */
 
-export const PARENT_NODE_HEIGHT = 325;
-const NODE_HEIGHT_Y = 70;
+export const PARENT_NODE_HEIGHT = 275;
 const NODE_WIDTH = 300; // based off of the value set in reactflow-styles.scss
-const NODE_SPACING = 100; // the margin (in # pixels) between the components
+export const NODE_SPACING = 40; // the margin (in # pixels) between the components
 
 export function uiConfigToWorkspaceFlow(
   config: WorkflowConfig
@@ -106,7 +105,7 @@ function ingestConfigToWorkspaceFlow(
   const docNodeId = generateId(COMPONENT_CLASS.DOCUMENT);
   const docNode = {
     id: docNodeId,
-    position: { x: 100, y: 70 },
+    position: { x: NODE_SPACING, y: NODE_SPACING },
     data: initComponentData(new Document().toObj(), docNodeId),
     type: NODE_CATEGORY.CUSTOM,
     parentNode: parentNode.id,
@@ -117,7 +116,7 @@ function ingestConfigToWorkspaceFlow(
     id: indexNodeId,
     position: {
       x: parentNode?.style?.width - (NODE_WIDTH + NODE_SPACING),
-      y: NODE_HEIGHT_Y,
+      y: NODE_SPACING,
     },
     data: initComponentData(
       new BaseIndex(COMPONENT_CATEGORY.INGEST).toObj(),
@@ -224,7 +223,7 @@ function searchConfigToWorkspaceFlow(
   const searchRequestNodeId = generateId(COMPONENT_CLASS.SEARCH_REQUEST);
   const searchRequestNode = {
     id: searchRequestNodeId,
-    position: { x: 100, y: 70 },
+    position: { x: NODE_SPACING, y: NODE_SPACING },
     data: initComponentData(new SearchRequest().toObj(), searchRequestNodeId),
     type: NODE_CATEGORY.CUSTOM,
     parentNode: parentNode.id,
@@ -238,7 +237,7 @@ function searchConfigToWorkspaceFlow(
         parentNode?.style?.width -
         (NODE_WIDTH + NODE_SPACING) *
           (enrichResponseWorkspaceFlow.nodes.length + 2),
-      y: NODE_HEIGHT_Y,
+      y: NODE_SPACING,
     },
     data: initComponentData(
       new BaseIndex(COMPONENT_CATEGORY.SEARCH).toObj(),
@@ -253,7 +252,7 @@ function searchConfigToWorkspaceFlow(
     id: searchResponseNodeId,
     position: {
       x: parentNode?.style?.width - (NODE_WIDTH + NODE_SPACING),
-      y: NODE_HEIGHT_Y,
+      y: NODE_SPACING,
     },
     data: initComponentData(new SearchResponse().toObj(), searchResponseNodeId),
     type: NODE_CATEGORY.CUSTOM,
@@ -365,7 +364,7 @@ function processorsConfigToWorkspaceFlow(
     const transformerNodeId = generateId(transformer.type);
     nodes.push({
       id: transformerNodeId,
-      position: { x: xPosition, y: NODE_HEIGHT_Y },
+      position: { x: xPosition, y: NODE_SPACING },
       data: initComponentData(transformer, transformerNodeId),
       type: NODE_CATEGORY.CUSTOM,
       parentNode: parentNodeId,


### PR DESCRIPTION
### Description

Reformats coloring / styling / layout / wording of the reactflow workspace in the Preview component. Screenshots below in light and dark modes.

![Screenshot 2025-01-10 at 12 57 45 PM](https://github.com/user-attachments/assets/909dd7d0-802c-47fd-91d0-f49d12286856)

![Screenshot 2025-01-10 at 12 59 22 PM](https://github.com/user-attachments/assets/eb644e81-6df3-4415-a688-19aa9d6b255d)


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
