### PR TITLE
UX fit-n-finish updates IV

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -166,6 +166,7 @@ export enum WORKFLOW_TYPE {
   MULTIMODAL_SEARCH = 'Multimodal search',
   HYBRID_SEARCH = 'Hybrid search',
   RAG = 'Retrieval-augmented generation',
+  VECTOR_SEARCH_WITH_RAG = 'Vector search with retrieval-augmented generation',
   CUSTOM = 'Custom',
   UNKNOWN = 'Unknown',
 }

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -281,12 +281,13 @@ export const VECTOR = 'vector';
 export const VECTOR_PATTERN = `{{${VECTOR}}}`;
 export const VECTOR_TEMPLATE_PLACEHOLDER = `\$\{${VECTOR}\}`;
 export const DEFAULT_K = 10;
+export const DEFAULT_FETCH_SIZE = 10;
 
 export const FETCH_ALL_QUERY = {
   query: {
     match_all: {},
   },
-  size: 1000,
+  size: DEFAULT_FETCH_SIZE,
 };
 export const TERM_QUERY_TEXT = {
   query: {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -579,6 +579,7 @@ export const EMPTY_FIELD_STRING = '--';
 export const OMIT_SYSTEM_INDEX_PATTERN = '*,-.*';
 export const INDEX_NOT_FOUND_EXCEPTION = 'index_not_found_exception';
 export const ERROR_GETTING_WORKFLOW_MSG = 'Failed to retrieve template';
+export const INVALID_DATASOURCE_MSG = 'No Living connections';
 export const NO_TEMPLATES_FOUND_MSG = 'There are no templates';
 export const NO_MODIFICATIONS_FOUND_TEXT =
   'Template does not contain any modifications';

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -544,7 +544,8 @@ export type PromptPreset = {
 };
 
 export type QuickConfigureFields = {
-  modelId?: string;
+  embeddingModelId?: string;
+  llmId?: string;
   vectorField?: string;
   textField?: string;
   imageField?: string;

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -47,6 +47,7 @@ export function isVectorSearchUseCase(workflow: Workflow | undefined): boolean {
       WORKFLOW_TYPE.HYBRID_SEARCH,
       WORKFLOW_TYPE.MULTIMODAL_SEARCH,
       WORKFLOW_TYPE.SEMANTIC_SEARCH,
+      WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG,
     ].includes(workflow?.ui_metadata?.type)
   );
 }

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -113,6 +113,7 @@ describe('WorkflowDetail Page Functionality (Custom Workflow)', () => {
     jest.clearAllMocks();
   });
   test('tests Export button, Tools panel toggling, and Workspace preview', async () => {
+    global.URL.createObjectURL = jest.fn();
     const { getByText, container, getByTestId } = renderWithRouter(
       workflowId,
       workflowName,

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -79,6 +79,7 @@ export function JsonField(props: JsonFieldProps) {
               value={jsonStr}
               onChange={(input) => {
                 setJsonStr(input);
+                form.setFieldValue(field.name, input);
               }}
               onBlur={() => {
                 try {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -234,6 +234,7 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
                       validate={false}
                       label={'Query template'}
                       fieldPath={'request'}
+                      editorHeight="30vh"
                     />
                     {finalModelOutputs.length > 0 && (
                       <>

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -39,7 +39,7 @@ export function SearchInputs(props: SearchInputsProps) {
         <ConfigureSearchRequest />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiHorizontalRule margin="none" />
+        <EuiHorizontalRule margin="m" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EnrichSearchRequest
@@ -48,7 +48,7 @@ export function SearchInputs(props: SearchInputsProps) {
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiHorizontalRule margin="none" />
+        <EuiHorizontalRule margin="m" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EnrichSearchResponse

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -51,7 +51,6 @@ import {
   sleep,
   getResourcesToBeForceDeleted,
   getDataSourceId,
-  parseErrorsFromIngestResponse,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -508,12 +507,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           dispatch(bulk({ apiBody: { body: bulkBody }, dataSourceId }))
             .unwrap()
             .then(async (resp: any) => {
-              // Ingest errors may be hidden within a 2xx / success response.
-              // But, we want to propagate them more, so we surface it as if it was a server-side error
-              const ingestErr = parseErrorsFromIngestResponse(resp);
-              if (ingestErr !== undefined) {
-                // TODO: propagate to redux store or somehow to Tools component
-              }
               props.setIngestResponse(customStringify(resp));
               props.setIsRunningIngest(false);
               setLastIngested(Date.now());

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -51,6 +51,7 @@ import {
   sleep,
   getResourcesToBeForceDeleted,
   getDataSourceId,
+  parseErrorsFromIngestResponse,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -506,7 +507,13 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           );
           dispatch(bulk({ apiBody: { body: bulkBody }, dataSourceId }))
             .unwrap()
-            .then(async (resp) => {
+            .then(async (resp: any) => {
+              // Ingest errors may be hidden within a 2xx / success response.
+              // But, we want to propagate them more, so we surface it as if it was a server-side error
+              const ingestErr = parseErrorsFromIngestResponse(resp);
+              if (ingestErr !== undefined) {
+                // TODO: propagate to redux store or somehow to Tools component
+              }
               props.setIngestResponse(customStringify(resp));
               props.setIsRunningIngest(false);
               setLastIngested(Date.now());

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -762,3 +762,17 @@ export function removeVectorFieldFromIndexMappings(
     return existingMappings;
   }
 }
+
+// Parse out any hidden errors within a 2xx ingest response
+export function parseErrorsFromIngestResponse(
+  ingestResponse: any
+): string | undefined {
+  if (get(ingestResponse, 'errors', false)) {
+    return get(
+      ingestResponse,
+      'items.0.index.error.reason',
+      'Error ingesting documents'
+    );
+  }
+  return;
+}

--- a/server/resources/templates/custom.json
+++ b/server/resources/templates/custom.json
@@ -4,6 +4,9 @@
   "use_case": "CUSTOM",
   "version": {
     "template": "1.0.0",
-    "compatibility": ["2.18.0", "3.0.0"]
+    "compatibility": [
+      "2.19.0",
+      "3.0.0"
+    ]
   }
 }

--- a/server/resources/templates/hybrid_search.json
+++ b/server/resources/templates/hybrid_search.json
@@ -3,7 +3,10 @@
   "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing hybrid search",
   "version": {
     "template": "1.0.0",
-    "compatibility": ["2.18.0", "3.0.0"]
+    "compatibility": [
+      "2.19.0",
+      "3.0.0"
+    ]
   },
   "ui_metadata": {
     "type": "Hybrid search"

--- a/server/resources/templates/multimodal_search.json
+++ b/server/resources/templates/multimodal_search.json
@@ -3,7 +3,10 @@
   "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing multimodal search",
   "version": {
     "template": "1.0.0",
-    "compatibility": ["2.18.0", "3.0.0"]
+    "compatibility": [
+      "2.19.0",
+      "3.0.0"
+    ]
   },
   "ui_metadata": {
     "type": "Multimodal search"

--- a/server/resources/templates/rag.json
+++ b/server/resources/templates/rag.json
@@ -3,7 +3,10 @@
   "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation (RAG)",
   "version": {
     "template": "1.0.0",
-    "compatibility": ["2.18.0", "3.0.0"]
+    "compatibility": [
+      "2.19.0",
+      "3.0.0"
+    ]
   },
   "ui_metadata": {
     "type": "Retrieval-augmented generation"

--- a/server/resources/templates/semantic_search.json
+++ b/server/resources/templates/semantic_search.json
@@ -3,7 +3,10 @@
   "description": "A basic workflow containing the ingest pipeline, search pipeline, and index configurations for performing semantic search",
   "version": {
     "template": "1.0.0",
-    "compatibility": ["2.18.0", "3.0.0"]
+    "compatibility": [
+      "2.19.0",
+      "3.0.0"
+    ]
   },
   "ui_metadata": {
     "type": "Semantic search"

--- a/server/resources/templates/vector_search_with_rag.json
+++ b/server/resources/templates/vector_search_with_rag.json
@@ -1,0 +1,14 @@
+{
+    "name": "Vector search with RAG",
+    "description": "A basic workflow containing the index and search pipeline configurations for performing vector search with retrieval-augmented generation (RAG)",
+    "version": {
+        "template": "1.0.0",
+        "compatibility": [
+            "2.19.0",
+            "3.0.0"
+        ]
+    },
+    "ui_metadata": {
+        "type": "Vector search with retrieval-augmented generation"
+    }
+}

--- a/server/routes/helpers.ts
+++ b/server/routes/helpers.ts
@@ -8,6 +8,7 @@ import {
   ConnectorDict,
   DEFAULT_NEW_WORKFLOW_STATE_TYPE,
   INDEX_NOT_FOUND_EXCEPTION,
+  INVALID_DATASOURCE_MSG,
   MODEL_ALGORITHM,
   MODEL_STATE,
   Model,
@@ -27,6 +28,14 @@ import {
 // OSD does not provide an interface for this response, but this is following the suggested
 // implementations. To prevent typescript complaining, leaving as loosely-typed 'any'
 export function generateCustomError(res: any, err: any) {
+  if (isDatasourceError(err)) {
+    return res.customError({
+      statusCode: 404,
+      body: {
+        message: 'Data source not found',
+      },
+    });
+  }
   return res.customError({
     statusCode: err.statusCode || 500,
     body: {
@@ -36,6 +45,12 @@ export function generateCustomError(res: any, err: any) {
       },
     },
   });
+}
+
+function isDatasourceError(err: any) {
+  if (err.message !== undefined && typeof err.message === 'string') {
+    return err.message.includes(INVALID_DATASOURCE_MSG);
+  }
 }
 
 // Helper fn to filter out backend errors that we don't want to propagate on the frontend.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -57,7 +57,7 @@ function generateWorkflow({ id, name, type }: WorkflowInput): Workflow {
     template: '1.0.0',
     compatibility: isSearchWorkflow
       ? [MINIMUM_FULL_SUPPORTED_VERSION]
-      : ['2.18.0', '3.0.0'],
+      : ['2.19.0', '3.0.0'],
   };
 
   return {


### PR DESCRIPTION
### Description

Continuation of #559 . Several bug fixes and enhancements.

- adds a new "Vector search + RAG" preset, which allows selecting an LLM and an embedding model from the quick config menu. see demo video below
- removes auto-selected models in quick configure to prevent invalid models (e.g., LLM selected for some embedding model)
- change default fetch_all query's `size` to smaller value
- add fallback if invalid datasourceid / data source not found to prevent 500s from server-side
- propagate errors during bulk ingest as if it was a server-side error. This helps it be consistent and much more visible when troubleshooting errors in ingest pipelines, for example.
- update the form values in JSON fields `onChange`, not just `onBlur`. This prevents issues of button states not being updated until users click out / trigger onBlur, for example.
- allow downloading the JSON / YAML files from the export modal. The filename is the workflow name, and the file type is JSON or YAML depending on the selection
- changes JSON/YAML toggle to a button group instead of radio group in the export modal
- tunes the spacing of the query editor in the override query modal.
- tunes spacing of form components on search flow

Demo of 'Vector search + RAG' usecase:

[screen-capture (15).webm](https://github.com/user-attachments/assets/4b2dac11-88c9-4b0f-bcbc-ed1d0247ade0)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
