### PR TITLE
UX fit-n-finish updates V

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -591,6 +591,7 @@ export enum SORT_ORDER {
   DESC = 'desc',
 }
 export const MAX_DOCS = 1000;
+export const MAX_DOCS_TO_IMPORT = 100;
 export const MAX_STRING_LENGTH = 100;
 export const MAX_JSON_STRING_LENGTH = 10000;
 export const MAX_TEMPLATE_STRING_LENGTH = 10000;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -571,7 +571,6 @@ export enum TRANSFORM_TYPE {
   TEMPLATE = 'Template',
 }
 export const NO_TRANSFORMATION = 'No transformation';
-export const START_FROM_SCRATCH_WORKFLOW_NAME = 'Start From Scratch';
 export const DEFAULT_NEW_WORKFLOW_NAME = 'new_workflow';
 export const DEFAULT_NEW_WORKFLOW_DESCRIPTION = 'My new workflow';
 export const DEFAULT_NEW_WORKFLOW_STATE_TYPE = ('NOT_STARTED' as any) as typeof WORKFLOW_STATE;

--- a/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
+++ b/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
@@ -192,19 +192,19 @@ export function EditWorkflowMetadataModal(
         return (
           <EuiModal
             maxWidth={false}
-            style={{ width: '50vw' }}
+            style={{ width: '30vw' }}
             onClose={() => props.setIsModalOpen(false)}
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
-                <p>Update workflow metadata</p>
+                <p>Workflow settings</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiFlexItem style={{ paddingLeft: '24px', paddingRight: '24px' }}>
               <EuiFlexGroup direction="column">
                 <EuiFlexItem>
                   <TextField
-                    label="Workflow name"
+                    label="Name"
                     fullWidth={false}
                     fieldPath={`name`}
                     showError={true}
@@ -212,10 +212,12 @@ export function EditWorkflowMetadataModal(
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <TextField
-                    label="Workflow description"
-                    fullWidth={true}
+                    label="Description - optional"
+                    fullWidth={false}
                     fieldPath={`description`}
                     showError={true}
+                    placeholder="Provide a description for identifying this workflow."
+                    textArea={true}
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
+++ b/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
@@ -14,7 +14,6 @@ import {
   EuiModal,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiModalBody,
   EuiModalFooter,
   EuiSmallButtonEmpty,
   EuiSmallButton,
@@ -201,7 +200,7 @@ export function EditWorkflowMetadataModal(
                 <p>Update workflow metadata</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
-            <EuiModalBody>
+            <EuiFlexItem style={{ paddingLeft: '24px', paddingRight: '24px' }}>
               <EuiFlexGroup direction="column">
                 <EuiFlexItem>
                   <TextField
@@ -220,7 +219,7 @@ export function EditWorkflowMetadataModal(
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>
-            </EuiModalBody>
+            </EuiFlexItem>
             <EuiModalFooter>
               <EuiSmallButtonEmpty
                 onClick={() => props.setIsModalOpen(false)}

--- a/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
+++ b/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
@@ -73,13 +73,17 @@ export function EditWorkflowMetadataModal(
           WORKFLOW_NAME_REGEXP.test(name) === false
         );
       })
-      .test('workflowName', 'Workflow name exists', (name) => {
-        return !(
-          Object.values(workflows)
-            .map((workflow) => workflow.name)
-            .includes(name || '') && name !== props.workflow?.name
-        );
-      })
+      .test(
+        'workflowName',
+        'This workflow name is already in use. Use a different name',
+        (name) => {
+          return !(
+            Object.values(workflows)
+              .map((workflow) => workflow.name)
+              .includes(name || '') && name !== props.workflow?.name
+          );
+        }
+      )
       .required('Required') as yup.Schema,
     desription: yup
       .string()

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -13,6 +13,7 @@ import {
   EuiText,
   EuiCodeBlock,
   EuiSmallButtonEmpty,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import {
   MapEntry,
@@ -103,11 +104,11 @@ export function SourceData(props: SourceDataProps) {
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <EuiText size="s">
-                <h3>Import data</h3>
+                <h3>Import sample data</h3>
               </EuiText>
             </EuiFlexItem>
-            {docsPopulated && (
-              <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false}>
+              {docsPopulated ? (
                 <EuiSmallButtonEmpty
                   onClick={() => setIsEditModalOpen(true)}
                   data-testid="editSourceDataButton"
@@ -116,8 +117,17 @@ export function SourceData(props: SourceDataProps) {
                 >
                   Edit
                 </EuiSmallButtonEmpty>
-              </EuiFlexItem>
-            )}
+              ) : (
+                <EuiSmallButton
+                  fill={false}
+                  style={{ width: '100px' }}
+                  onClick={() => setIsEditModalOpen(true)}
+                  data-testid="selectDataToImportButton"
+                >
+                  {`Select data`}
+                </EuiSmallButton>
+              )}
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
         {props.lastIngested !== undefined && (
@@ -127,21 +137,7 @@ export function SourceData(props: SourceDataProps) {
             </EuiText>
           </EuiFlexItem>
         )}
-
-        {!docsPopulated && (
-          <EuiFlexItem grow={false}>
-            <EuiSmallButton
-              fill={false}
-              style={{ width: '100px' }}
-              onClick={() => setIsEditModalOpen(true)}
-              data-testid="selectDataToImportButton"
-            >
-              {`Select data`}
-            </EuiSmallButton>
-          </EuiFlexItem>
-        )}
-
-        {docsPopulated && (
+        {docsPopulated ? (
           <>
             <EuiSpacer size="s" />
             <EuiFlexItem grow={true}>
@@ -157,6 +153,16 @@ export function SourceData(props: SourceDataProps) {
               </EuiCodeBlock>
             </EuiFlexItem>
           </>
+        ) : (
+          <EuiEmptyPrompt
+            title={<h2>No data selected</h2>}
+            titleSize="s"
+            body={
+              <>
+                <EuiText size="s">Select some sample data to import.</EuiText>
+              </>
+            }
+          />
         )}
       </EuiFlexGroup>
     </>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -120,11 +120,13 @@ export function SourceData(props: SourceDataProps) {
               ) : (
                 <EuiSmallButton
                   fill={false}
-                  style={{ width: '100px' }}
+                  style={{ width: '75px' }}
                   onClick={() => setIsEditModalOpen(true)}
                   data-testid="selectDataToImportButton"
+                  iconType="plus"
+                  iconSide="left"
                 >
-                  {`Select data`}
+                  {`Import`}
                 </EuiSmallButton>
               )}
             </EuiFlexItem>
@@ -155,11 +157,15 @@ export function SourceData(props: SourceDataProps) {
           </>
         ) : (
           <EuiEmptyPrompt
-            title={<h2>No data selected</h2>}
+            iconType="document"
+            title={<h2>No data imported</h2>}
             titleSize="s"
             body={
               <>
-                <EuiText size="s">Select some sample data to import.</EuiText>
+                <EuiText size="s">
+                  Import a sample of your data to begin configuring your
+                  ingestion flow.
+                </EuiText>
               </>
             }
           />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -196,7 +196,7 @@ export function SourceDataModal(props: SourceDataProps) {
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
-                <p>{`Import data`}</p>
+                <p>{`Import sample data`}</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiModalBody>
@@ -236,7 +236,7 @@ export function SourceDataModal(props: SourceDataProps) {
                     }
                     data-testid="selectIndexSourceDataButton"
                   >
-                    Existing index
+                    From existing index
                   </EuiSmallFilterButton>
                 </EuiFilterGroup>
                 <EuiSpacer size="m" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -18,11 +18,9 @@ import {
   EuiModalHeaderTitle,
   EuiSpacer,
   EuiText,
-  EuiFilterGroup,
-  EuiSmallFilterButton,
-  EuiSuperSelectOption,
-  EuiCompressedSuperSelect,
   EuiSmallButtonEmpty,
+  EuiButtonGroup,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -32,6 +30,8 @@ import {
   IndexMappings,
   IngestDocsFormValues,
   isVectorSearchUseCase,
+  MAX_BYTES,
+  MAX_DOCS_TO_IMPORT,
   SearchHit,
   SOURCE_OPTIONS,
   Workflow,
@@ -176,7 +176,7 @@ export function SourceDataModal(props: SourceDataProps) {
               .unwrap()
               .then((resp) => {
                 const docObjs = resp?.hits?.hits
-                  ?.slice(0, 5)
+                  ?.slice(0, MAX_DOCS_TO_IMPORT)
                   ?.map((hit: SearchHit) => hit?._source);
                 formikProps.setFieldValue('docs', customStringify(docObjs));
               });
@@ -201,44 +201,35 @@ export function SourceDataModal(props: SourceDataProps) {
             </EuiModalHeader>
             <EuiModalBody>
               <>
-                <EuiFilterGroup>
-                  <EuiSmallFilterButton
-                    id={SOURCE_OPTIONS.MANUAL}
-                    hasActiveFilters={
-                      props.selectedOption === SOURCE_OPTIONS.MANUAL
-                    }
-                    onClick={() =>
-                      props.setSelectedOption(SOURCE_OPTIONS.MANUAL)
-                    }
-                    data-testid="manualEditSourceDataButton"
-                  >
-                    Manual
-                  </EuiSmallFilterButton>
-                  <EuiSmallFilterButton
-                    id={SOURCE_OPTIONS.UPLOAD}
-                    hasActiveFilters={
-                      props.selectedOption === SOURCE_OPTIONS.UPLOAD
-                    }
-                    onClick={() =>
-                      props.setSelectedOption(SOURCE_OPTIONS.UPLOAD)
-                    }
-                    data-testid="uploadSourceDataButton"
-                  >
-                    Upload
-                  </EuiSmallFilterButton>
-                  <EuiSmallFilterButton
-                    id={SOURCE_OPTIONS.EXISTING_INDEX}
-                    hasActiveFilters={
-                      props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX
-                    }
-                    onClick={() =>
-                      props.setSelectedOption(SOURCE_OPTIONS.EXISTING_INDEX)
-                    }
-                    data-testid="selectIndexSourceDataButton"
-                  >
-                    From existing index
-                  </EuiSmallFilterButton>
-                </EuiFilterGroup>
+                <EuiText size="s" color="subdued">
+                  Import a sample of your data to help you start configuring
+                  your ingestion flow. You may ingest the full set of data with
+                  the bulk API after configuring the ingestion flow.
+                </EuiText>
+                <EuiSpacer size="s" />
+                <EuiButtonGroup
+                  legend="Import options"
+                  buttonSize="compressed"
+                  idSelected={props.selectedOption}
+                  options={[
+                    {
+                      id: SOURCE_OPTIONS.MANUAL,
+                      label: 'Manual',
+                    },
+
+                    {
+                      id: SOURCE_OPTIONS.UPLOAD,
+                      label: 'Upload file',
+                    },
+                    {
+                      id: SOURCE_OPTIONS.EXISTING_INDEX,
+                      label: 'From existing index',
+                    },
+                  ]}
+                  onChange={(id) =>
+                    props.setSelectedOption(id as SOURCE_OPTIONS)
+                  }
+                />
                 <EuiSpacer size="m" />
                 {props.selectedOption === SOURCE_OPTIONS.UPLOAD && (
                   <>
@@ -263,32 +254,35 @@ export function SourceDataModal(props: SourceDataProps) {
                       }}
                       display="default"
                     />
+                    <EuiText
+                      size="xs"
+                      color="subdued"
+                    >{`File size must not exceed ${MAX_BYTES} bytes.`}</EuiText>
                     <EuiSpacer size="s" />
                   </>
                 )}
                 {props.selectedOption === SOURCE_OPTIONS.EXISTING_INDEX && (
                   <>
-                    <EuiText color="subdued" size="s">
-                      Up to 5 sample documents will be automatically populated.
-                    </EuiText>
-                    <EuiSpacer size="s" />
-                    <EuiCompressedSuperSelect
-                      options={Object.values(indices).map(
-                        (option) =>
-                          ({
-                            value: option.name,
-                            inputDisplay: (
-                              <EuiText size="s">{option.name}</EuiText>
-                            ),
-                            disabled: false,
-                          } as EuiSuperSelectOption<string>)
-                      )}
-                      valueOfSelected={selectedIndex}
-                      onChange={(option) => {
-                        setSelectedIndex(option);
+                    <EuiCompressedComboBox
+                      placeholder="Select an index"
+                      singleSelection={{ asPlainText: true }}
+                      options={Object.values(indices).map((option) => {
+                        return { label: option.name };
+                      })}
+                      onChange={(options) => {
+                        setSelectedIndex(getIn(options, '0.label'));
                       }}
-                      isInvalid={false}
+                      selectedOptions={
+                        selectedIndex !== undefined
+                          ? [{ label: selectedIndex }]
+                          : []
+                      }
+                      isClearable={true}
                     />
+                    <EuiText
+                      size="xs"
+                      color="subdued"
+                    >{`Only the top ${MAX_DOCS_TO_IMPORT} documents will be imported.`}</EuiText>
                     <EuiSpacer size="xs" />
                   </>
                 )}
@@ -296,7 +290,7 @@ export function SourceDataModal(props: SourceDataProps) {
                   label="Documents to be imported"
                   fieldPath={'docs'}
                   helpText="Documents should be formatted as a valid JSON array."
-                  editorHeight="25vh"
+                  editorHeight="40vh"
                   readOnly={false}
                 />
               </>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -18,6 +18,7 @@ interface SelectFieldProps {
   field: IConfigField;
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onSelectChange?: (option: string) => void;
+  showInvalid?: boolean;
 }
 
 /**
@@ -29,8 +30,15 @@ export function SelectField(props: SelectFieldProps) {
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
+        const isInvalid =
+          (props.showInvalid ?? true) &&
+          getIn(errors, field.name) &&
+          getIn(touched, field.name);
         return (
-          <EuiCompressedFormRow label={camelCaseToTitleString(props.field.id)}>
+          <EuiCompressedFormRow
+            label={camelCaseToTitleString(props.field.id)}
+            isInvalid={isInvalid}
+          >
             <EuiCompressedSuperSelect
               options={
                 props.field.selectOptions
@@ -57,11 +65,7 @@ export function SelectField(props: SelectFieldProps) {
                   props.onSelectChange(option);
                 }
               }}
-              isInvalid={
-                getIn(errors, field.name) && getIn(touched, field.name)
-                  ? true
-                  : undefined
-              }
+              isInvalid={isInvalid}
             />
           </EuiCompressedFormRow>
         );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_with_custom_options.tsx
@@ -14,6 +14,7 @@ interface SelectWithCustomOptionsProps {
   placeholder: string;
   options: { label: string }[];
   allowCreate?: boolean;
+  showInvalid?: boolean;
   onChange?: () => void;
 }
 
@@ -21,9 +22,18 @@ interface SelectWithCustomOptionsProps {
  * A generic select field from a list of preconfigured options, and the functionality to add more options
  */
 export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
-  const { values, setFieldTouched, setFieldValue } = useFormikContext<
-    WorkflowFormValues
-  >();
+  const {
+    values,
+    errors,
+    touched,
+    setFieldTouched,
+    setFieldValue,
+  } = useFormikContext<WorkflowFormValues>();
+
+  const isInvalid =
+    (props.showInvalid ?? true) &&
+    getIn(errors, props.fieldPath) &&
+    getIn(touched, props.fieldPath);
 
   // selected option state
   const [selectedOption, setSelectedOption] = useState<any[]>([]);
@@ -88,6 +98,7 @@ export function SelectWithCustomOptions(props: SelectWithCustomOptionsProps) {
       customOptionText={
         props.allowCreate ? 'Add {searchValue} as a custom option' : undefined
       }
+      isInvalid={isInvalid}
     />
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -8,6 +8,7 @@ import { Field, FieldProps, getIn, useFormikContext } from 'formik';
 import {
   EuiCompressedFieldText,
   EuiCompressedFormRow,
+  EuiCompressedTextArea,
   EuiLink,
   EuiText,
 } from '@elastic/eui';
@@ -23,6 +24,7 @@ interface TextFieldProps {
   showError?: boolean;
   showInvalid?: boolean;
   fullWidth?: boolean;
+  textArea?: boolean;
 }
 
 /**
@@ -56,16 +58,29 @@ export function TextField(props: TextFieldProps) {
             error={props.showError && getIn(errors, field.name)}
             isInvalid={isInvalid}
           >
-            <EuiCompressedFieldText
-              fullWidth={props.fullWidth}
-              {...field}
-              placeholder={props.placeholder || ''}
-              value={field.value || getInitialValue('string')}
-              onChange={(e) => {
-                form.setFieldValue(props.fieldPath, e.target.value);
-              }}
-              isInvalid={isInvalid}
-            />
+            {props.textArea ? (
+              <EuiCompressedTextArea
+                fullWidth={props.fullWidth}
+                {...field}
+                placeholder={props.placeholder || ''}
+                value={field.value || getInitialValue('string')}
+                onChange={(e) => {
+                  form.setFieldValue(props.fieldPath, e.target.value);
+                }}
+                isInvalid={isInvalid}
+              />
+            ) : (
+              <EuiCompressedFieldText
+                fullWidth={props.fullWidth}
+                {...field}
+                placeholder={props.placeholder || ''}
+                value={field.value || getInitialValue('string')}
+                onChange={(e) => {
+                  form.setFieldValue(props.fieldPath, e.target.value);
+                }}
+                isInvalid={isInvalid}
+              />
+            )}
           </EuiCompressedFormRow>
         );
       }}

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -21,6 +21,7 @@ interface TextFieldProps {
   helpText?: string;
   placeholder?: string;
   showError?: boolean;
+  showInvalid?: boolean;
   fullWidth?: boolean;
 }
 
@@ -32,8 +33,13 @@ export function TextField(props: TextFieldProps) {
   return (
     <Field name={props.fieldPath}>
       {({ field, form }: FieldProps) => {
+        const isInvalid =
+          (props.showInvalid ?? true) &&
+          getIn(errors, field.name) &&
+          getIn(touched, field.name);
         return (
           <EuiCompressedFormRow
+            id={field.name}
             fullWidth={props.fullWidth}
             key={props.fieldPath}
             label={props.label}
@@ -48,7 +54,7 @@ export function TextField(props: TextFieldProps) {
             }
             helpText={props.helpText || undefined}
             error={props.showError && getIn(errors, field.name)}
-            isInvalid={getIn(errors, field.name) && getIn(touched, field.name)}
+            isInvalid={isInvalid}
           >
             <EuiCompressedFieldText
               fullWidth={props.fullWidth}
@@ -58,6 +64,7 @@ export function TextField(props: TextFieldProps) {
               onChange={(e) => {
                 form.setFieldValue(props.fieldPath, e.target.value);
               }}
+              isInvalid={isInvalid}
             />
           </EuiCompressedFormRow>
         );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -182,24 +182,6 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
       {!isEmpty(getIn(values, modelFieldPath)?.id) && (
         <>
           <EuiSpacer size="s" />
-          {props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST && (
-            <>
-              <EuiText
-                size="m"
-                style={{ marginTop: '4px' }}
-              >{`Override query (Optional)`}</EuiText>
-              <EuiSpacer size="s" />
-              <EuiSmallButton
-                style={{ width: '100px' }}
-                fill={false}
-                onClick={() => setIsQueryModalOpen(true)}
-                data-testid="overrideQueryButton"
-              >
-                Override
-              </EuiSmallButton>
-              <EuiSpacer size="l" />
-            </>
-          )}
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <EuiFlexGroup direction="row" gutterSize="xs">
@@ -275,6 +257,24 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               />
             )}
           <EuiSpacer size="s" />
+          {props.context === PROCESSOR_CONTEXT.SEARCH_REQUEST && (
+            <>
+              <EuiText
+                size="m"
+                style={{ marginTop: '4px' }}
+              >{`Rewrite query`}</EuiText>
+              <EuiSpacer size="s" />
+              <EuiSmallButton
+                style={{ width: '100px' }}
+                fill={false}
+                onClick={() => setIsQueryModalOpen(true)}
+                data-testid="overrideQueryButton"
+              >
+                Rewrite
+              </EuiSmallButton>
+              <EuiSpacer size="l" />
+            </>
+          )}
           <EuiAccordion
             id={`advancedSettings${props.config.id}`}
             buttonContent="Advanced settings"

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -353,7 +353,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                 iconSide="right"
                                 iconType="arrowDown"
                               >
-                                Choose from a preset
+                                Query samples
                               </EuiSmallButton>
                             }
                             isOpen={presetsPopoverOpen}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -175,7 +175,7 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
                           iconSide="right"
                           iconType="arrowDown"
                         >
-                          Choose from a preset
+                          Query samples
                         </EuiSmallButton>
                       }
                       isOpen={presetsPopoverOpen}

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -33,6 +33,7 @@ import {
   LABEL_FIELD_PATTERN,
   MODEL_ID_PATTERN,
   ModelInterface,
+  NO_TRANSFORMATION,
   OutputMapEntry,
   QUERY_IMAGE_PATTERN,
   QUERY_PRESETS,
@@ -40,6 +41,7 @@ import {
   QueryPreset,
   RequestFormValues,
   TEXT_FIELD_PATTERN,
+  TRANSFORM_TYPE,
   VECTOR_FIELD_PATTERN,
   VECTOR_PATTERN,
   WorkflowFormValues,
@@ -81,13 +83,37 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
   // get some current form values
   const modelOutputs = parseModelOutputs(props.modelInterface);
   const queryFieldPath = `${props.baseConfigPath}.${props.config.id}.query_template`;
+
+  // compile all of the different output map values that can be injected into the query rewrite.
+  // need special logic to process each transform type (e.g., transform type may add multiple outputs per entry)
   const outputMap = getIn(
     values,
     `${props.baseConfigPath}.${props.config.id}.output_map`
   );
-  const outputMapValues = getIn(outputMap, '0', []).map(
-    (mapEntry: OutputMapEntry) => mapEntry.value.value
-  ) as string[];
+  let outputMapNoTransformValues = [] as string[];
+  let outputMapFieldValues = [] as string[];
+  let outputMapExpressionValues = [] as string[];
+
+  getIn(outputMap, '0', []).forEach((mapEntry: OutputMapEntry) => {
+    // @ts-ignore
+    if (mapEntry.value.transformType === NO_TRANSFORMATION) {
+      outputMapNoTransformValues.push(mapEntry.key);
+    } else if (mapEntry.value.transformType === TRANSFORM_TYPE.FIELD) {
+      outputMapFieldValues.push(mapEntry.value?.value as string);
+    } else {
+      outputMapExpressionValues = [
+        ...outputMapExpressionValues,
+        ...(mapEntry.value.nestedVars
+          ? mapEntry.value.nestedVars.map((nestedVar) => nestedVar.name)
+          : []),
+      ];
+    }
+  });
+  const outputMapValues = [
+    ...outputMapNoTransformValues,
+    ...outputMapFieldValues,
+    ...outputMapExpressionValues,
+  ];
   const finalModelOutputs =
     outputMapValues.length > 0
       ? outputMapValues.map((outputMapValue) => {
@@ -127,13 +153,14 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
-                <p>{`Override query`}</p>
+                <p>{`Rewrite query`}</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
             <EuiModalBody style={{ height: '40vh' }}>
               <EuiText color="subdued">
-                Configure a custom query template to override the existing one.
-                Optionally inject dynamic model outputs into the new query.
+                Rewrite the existing query definition by defining a query
+                template. You can also inject dynamic model inputs into the
+                query template.
               </EuiText>
               <EuiFlexGroup direction="column">
                 <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -439,7 +439,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     // Ideally we handle Promise accept/rejects with submitForm(), but there is
     // open issues for that - see https://github.com/jaredpalmer/formik/issues/2057
     // The workaround is to additionally execute validateForm() which will return any errors found.
-    submitForm();
+    await submitForm();
     await validateForm()
       .then(async (validationResults: { ingest?: {}; search?: {} }) => {
         const { ingest, search } = validationResults;

--- a/public/pages/workflows/new_workflow/new_workflow.test.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.test.tsx
@@ -14,7 +14,10 @@ import configureStore from 'redux-mock-store';
 import * as ReactReduxHooks from '../../../store/store';
 import '@testing-library/jest-dom';
 import { loadPresetWorkflowTemplates } from '../../../../test/utils';
-import { INITIAL_ML_STATE } from '../../../../public/store';
+import {
+  INITIAL_ML_STATE,
+  INITIAL_WORKFLOWS_STATE,
+} from '../../../../public/store';
 
 jest.mock('../../../utils', () => ({
   ...jest.requireActual('../../../utils'),
@@ -36,6 +39,7 @@ const initialState = {
     loading: false,
     presetWorkflows: loadPresetWorkflowTemplates(),
   },
+  workflows: INITIAL_WORKFLOWS_STATE,
 };
 
 const mockDispatch = jest.fn();

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -161,310 +161,315 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
         // we will always have a selectable embedding model.
         <>
           <EuiSpacer size="m" />
+          <EuiCompressedFormRow
+            fullWidth={true}
+            label={
+              props.workflowType === WORKFLOW_TYPE.RAG
+                ? 'Large language model'
+                : 'Embedding model'
+            }
+            isInvalid={false}
+            helpText={
+              isEmpty(deployedModels)
+                ? undefined
+                : props.workflowType === WORKFLOW_TYPE.RAG
+                ? 'The large language model to generate user-friendly responses'
+                : 'The model to generate embeddings'
+            }
+          >
+            {isEmpty(deployedModels) ? (
+              <EuiCallOut
+                color="primary"
+                size="s"
+                title={
+                  <EuiText size="s">
+                    You have no model currently set up yet,{' '}
+                    <EuiLink href={ML_REMOTE_MODEL_LINK}>Learn more</EuiLink> to
+                    understand how to integrate ML models.
+                  </EuiText>
+                }
+              />
+            ) : (
+              <EuiCompressedSuperSelect
+                data-testid="selectDeployedModel"
+                fullWidth={true}
+                options={deployedModels.map(
+                  (option) =>
+                    ({
+                      value: option.id,
+                      inputDisplay: (
+                        <>
+                          <EuiText size="s">{option.name}</EuiText>
+                        </>
+                      ),
+                      dropdownDisplay: (
+                        <>
+                          <EuiText size="s">{option.name}</EuiText>
+                          <EuiText size="xs" color="subdued">
+                            Deployed
+                          </EuiText>
+                          <EuiText size="xs" color="subdued">
+                            {option.algorithm}
+                          </EuiText>
+                        </>
+                      ),
+                      disabled: false,
+                    } as EuiSuperSelectOption<string>)
+                )}
+                valueOfSelected={
+                  props.workflowType === WORKFLOW_TYPE.RAG
+                    ? fieldValues?.llmId
+                    : fieldValues?.embeddingModelId || ''
+                }
+                onChange={(option: string) => {
+                  if (props.workflowType === WORKFLOW_TYPE.RAG) {
+                    setFieldValues({
+                      ...fieldValues,
+                      llmId: option,
+                    });
+                  } else {
+                    setFieldValues({
+                      ...fieldValues,
+                      embeddingModelId: option,
+                    });
+                  }
+                }}
+                isInvalid={false}
+              />
+            )}
+          </EuiCompressedFormRow>
+          <EuiSpacer size="s" />
+          {
+            // For vector search + RAG, include the LLM model selection as well
+            props.workflowType === WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG && (
+              <>
+                <EuiCompressedFormRow
+                  fullWidth={true}
+                  label={'Large language model'}
+                  isInvalid={false}
+                  helpText={
+                    isEmpty(deployedModels)
+                      ? undefined
+                      : 'The large language model to generate user-friendly responses'
+                  }
+                >
+                  {isEmpty(deployedModels) ? (
+                    <EuiCallOut
+                      color="primary"
+                      size="s"
+                      title={
+                        <EuiText size="s">
+                          You have no model currently set up yet,{' '}
+                          <EuiLink href={ML_REMOTE_MODEL_LINK}>
+                            Learn more
+                          </EuiLink>{' '}
+                          to understand how to integrate ML models.
+                        </EuiText>
+                      }
+                    />
+                  ) : (
+                    <EuiCompressedSuperSelect
+                      data-testid="selectDeployedModelLLM"
+                      fullWidth={true}
+                      options={deployedModels.map(
+                        (option) =>
+                          ({
+                            value: option.id,
+                            inputDisplay: (
+                              <>
+                                <EuiText size="s">{option.name}</EuiText>
+                              </>
+                            ),
+                            dropdownDisplay: (
+                              <>
+                                <EuiText size="s">{option.name}</EuiText>
+                                <EuiText size="xs" color="subdued">
+                                  Deployed
+                                </EuiText>
+                                <EuiText size="xs" color="subdued">
+                                  {option.algorithm}
+                                </EuiText>
+                              </>
+                            ),
+                            disabled: false,
+                          } as EuiSuperSelectOption<string>)
+                      )}
+                      valueOfSelected={fieldValues?.llmId || ''}
+                      onChange={(option: string) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          llmId: option,
+                        });
+                      }}
+                      isInvalid={false}
+                    />
+                  )}
+                </EuiCompressedFormRow>
+                <EuiSpacer size="s" />
+              </>
+            )
+          }
+          <EuiSpacer size="s" />
           <EuiAccordion
             id="optionalConfiguration"
             buttonContent="Optional configuration"
             initialIsOpen={false}
             data-testid="optionalConfigurationButton"
           >
-            <EuiSpacer size="m" />
-            <EuiCompressedFormRow
-              fullWidth={true}
-              label={
-                props.workflowType === WORKFLOW_TYPE.RAG
-                  ? 'Large language model'
-                  : 'Embedding model'
-              }
-              isInvalid={false}
-              helpText={
-                isEmpty(deployedModels)
-                  ? undefined
-                  : props.workflowType === WORKFLOW_TYPE.RAG
-                  ? 'The large language model to generate user-friendly responses'
-                  : 'The model to generate embeddings'
-              }
-            >
-              {isEmpty(deployedModels) ? (
-                <EuiCallOut
-                  color="primary"
-                  size="s"
-                  title={
-                    <EuiText size="s">
-                      You have no model currently set up yet,{' '}
-                      <EuiLink href={ML_REMOTE_MODEL_LINK}>Learn more</EuiLink>{' '}
-                      to understand how to integrate ML models.
-                    </EuiText>
-                  }
-                />
-              ) : (
-                <EuiCompressedSuperSelect
-                  data-testid="selectDeployedModel"
+            <>
+              <EuiSpacer size="s" />
+              <EuiCompressedFormRow
+                fullWidth={true}
+                label={'Text field'}
+                isInvalid={false}
+                helpText={`The name of the text document field to be ${
+                  props.workflowType === WORKFLOW_TYPE.RAG
+                    ? 'used as context to the large language model (LLM)'
+                    : 'embedded'
+                }`}
+              >
+                <EuiCompressedFieldText
+                  data-testid="textFieldQuickConfigure"
                   fullWidth={true}
-                  options={deployedModels.map(
-                    (option) =>
-                      ({
-                        value: option.id,
-                        inputDisplay: (
-                          <>
-                            <EuiText size="s">{option.name}</EuiText>
-                          </>
-                        ),
-                        dropdownDisplay: (
-                          <>
-                            <EuiText size="s">{option.name}</EuiText>
-                            <EuiText size="xs" color="subdued">
-                              Deployed
-                            </EuiText>
-                            <EuiText size="xs" color="subdued">
-                              {option.algorithm}
-                            </EuiText>
-                          </>
-                        ),
-                        disabled: false,
-                      } as EuiSuperSelectOption<string>)
-                  )}
-                  valueOfSelected={
-                    props.workflowType === WORKFLOW_TYPE.RAG
-                      ? fieldValues?.llmId
-                      : fieldValues?.embeddingModelId || ''
-                  }
-                  onChange={(option: string) => {
-                    if (props.workflowType === WORKFLOW_TYPE.RAG) {
-                      setFieldValues({
-                        ...fieldValues,
-                        llmId: option,
-                      });
-                    } else {
-                      setFieldValues({
-                        ...fieldValues,
-                        embeddingModelId: option,
-                      });
-                    }
+                  value={fieldValues?.textField || ''}
+                  onChange={(e) => {
+                    setFieldValues({
+                      ...fieldValues,
+                      textField: e.target.value,
+                    });
                   }}
-                  isInvalid={false}
                 />
-              )}
-            </EuiCompressedFormRow>
-            <EuiSpacer size="s" />
-            {
-              // For vector search + RAG, include the LLM model selection as well
-              props.workflowType === WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG && (
+              </EuiCompressedFormRow>
+              <EuiSpacer size="s" />
+              {props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH && (
                 <>
                   <EuiCompressedFormRow
                     fullWidth={true}
-                    label={'Large language model'}
+                    label={'Image field'}
                     isInvalid={false}
-                    helpText={
-                      isEmpty(deployedModels)
-                        ? undefined
-                        : 'The large language model to generate user-friendly responses'
-                    }
+                    helpText="The name of the document field containing the image binary"
                   >
-                    {isEmpty(deployedModels) ? (
-                      <EuiCallOut
-                        color="primary"
-                        size="s"
-                        title={
-                          <EuiText size="s">
-                            You have no model currently set up yet,{' '}
-                            <EuiLink href={ML_REMOTE_MODEL_LINK}>
-                              Learn more
-                            </EuiLink>{' '}
-                            to understand how to integrate ML models.
-                          </EuiText>
-                        }
-                      />
-                    ) : (
-                      <EuiCompressedSuperSelect
-                        data-testid="selectDeployedModelLLM"
-                        fullWidth={true}
-                        options={deployedModels.map(
-                          (option) =>
-                            ({
-                              value: option.id,
-                              inputDisplay: (
-                                <>
-                                  <EuiText size="s">{option.name}</EuiText>
-                                </>
-                              ),
-                              dropdownDisplay: (
-                                <>
-                                  <EuiText size="s">{option.name}</EuiText>
-                                  <EuiText size="xs" color="subdued">
-                                    Deployed
-                                  </EuiText>
-                                  <EuiText size="xs" color="subdued">
-                                    {option.algorithm}
-                                  </EuiText>
-                                </>
-                              ),
-                              disabled: false,
-                            } as EuiSuperSelectOption<string>)
-                        )}
-                        valueOfSelected={fieldValues?.llmId || ''}
-                        onChange={(option: string) => {
-                          setFieldValues({
-                            ...fieldValues,
-                            llmId: option,
-                          });
-                        }}
-                        isInvalid={false}
-                      />
-                    )}
+                    <EuiCompressedFieldText
+                      fullWidth={true}
+                      value={fieldValues?.imageField || ''}
+                      onChange={(e) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          imageField: e.target.value,
+                        });
+                      }}
+                    />
                   </EuiCompressedFormRow>
                   <EuiSpacer size="s" />
                 </>
-              )
-            }
-            <EuiCompressedFormRow
-              fullWidth={true}
-              label={'Text field'}
-              isInvalid={false}
-              helpText={`The name of the text document field to be ${
-                props.workflowType === WORKFLOW_TYPE.RAG
-                  ? 'used as context to the large language model (LLM)'
-                  : 'embedded'
-              }`}
-            >
-              <EuiCompressedFieldText
-                data-testid="textFieldQuickConfigure"
-                fullWidth={true}
-                value={fieldValues?.textField || ''}
-                onChange={(e) => {
-                  setFieldValues({
-                    ...fieldValues,
-                    textField: e.target.value,
-                  });
-                }}
-              />
-            </EuiCompressedFormRow>
-            <EuiSpacer size="s" />
-            {props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH && (
-              <>
-                <EuiCompressedFormRow
-                  fullWidth={true}
-                  label={'Image field'}
-                  isInvalid={false}
-                  helpText="The name of the document field containing the image binary"
-                >
-                  <EuiCompressedFieldText
+              )}
+              {(props.workflowType === WORKFLOW_TYPE.SEMANTIC_SEARCH ||
+                props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH ||
+                props.workflowType === WORKFLOW_TYPE.HYBRID_SEARCH ||
+                props.workflowType ===
+                  WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG) && (
+                <>
+                  <EuiCompressedFormRow
                     fullWidth={true}
-                    value={fieldValues?.imageField || ''}
-                    onChange={(e) => {
-                      setFieldValues({
-                        ...fieldValues,
-                        imageField: e.target.value,
-                      });
-                    }}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="s" />
-              </>
-            )}
-            {(props.workflowType === WORKFLOW_TYPE.SEMANTIC_SEARCH ||
-              props.workflowType === WORKFLOW_TYPE.MULTIMODAL_SEARCH ||
-              props.workflowType === WORKFLOW_TYPE.HYBRID_SEARCH ||
-              props.workflowType === WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG) && (
-              <>
-                <EuiCompressedFormRow
-                  fullWidth={true}
-                  label={'Vector field'}
-                  isInvalid={false}
-                  helpText="The name of the document field containing the vector embedding"
-                >
-                  <EuiCompressedFieldText
-                    fullWidth={true}
-                    value={fieldValues?.vectorField || ''}
-                    onChange={(e) => {
-                      setFieldValues({
-                        ...fieldValues,
-                        vectorField: e.target.value,
-                      });
-                    }}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="s" />
-                <EuiCompressedFormRow
-                  fullWidth={true}
-                  label={'Embedding length'}
-                  isInvalid={false}
-                  helpText="The length / dimension of the generated vector embeddings. Autofilled values may be inaccurate."
-                >
-                  <EuiCompressedFieldNumber
-                    fullWidth={true}
-                    value={fieldValues?.embeddingLength || ''}
-                    onChange={(e) => {
-                      setFieldValues({
-                        ...fieldValues,
-                        embeddingLength: Number(e.target.value),
-                      });
-                    }}
-                  />
-                </EuiCompressedFormRow>
-              </>
-            )}
-            {(props.workflowType === WORKFLOW_TYPE.RAG ||
-              props.workflowType === WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG) && (
-              <>
-                <EuiCompressedFormRow
-                  fullWidth={true}
-                  label={'Prompt field'}
-                  isInvalid={false}
-                  helpText={'The model input field representing the prompt'}
-                >
-                  <EuiCompressedSuperSelect
-                    data-testid="selectPromptField"
-                    fullWidth={true}
-                    options={parseModelInputs(selectedLLMInterface).map(
-                      (option) =>
-                        ({
-                          value: option.label,
-                          inputDisplay: (
-                            <>
-                              <EuiText size="s">{option.label}</EuiText>
-                            </>
-                          ),
-                          dropdownDisplay: (
-                            <>
-                              <EuiText size="s">{option.label}</EuiText>
-                              <EuiText size="xs" color="subdued">
-                                {option.type}
-                              </EuiText>
-                            </>
-                          ),
-                          disabled: false,
-                        } as EuiSuperSelectOption<string>)
-                    )}
-                    valueOfSelected={fieldValues?.promptField || ''}
-                    onChange={(option: string) => {
-                      setFieldValues({
-                        ...fieldValues,
-                        promptField: option,
-                      });
-                    }}
+                    label={'Vector field'}
                     isInvalid={false}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="s" />
-                <EuiCompressedFormRow
-                  fullWidth={true}
-                  label={'LLM response field'}
-                  isInvalid={false}
-                  helpText="The name of the field containing the large language model (LLM) response"
-                >
-                  <EuiCompressedFieldText
+                    helpText="The name of the document field containing the vector embedding"
+                  >
+                    <EuiCompressedFieldText
+                      fullWidth={true}
+                      value={fieldValues?.vectorField || ''}
+                      onChange={(e) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          vectorField: e.target.value,
+                        });
+                      }}
+                    />
+                  </EuiCompressedFormRow>
+                  <EuiSpacer size="s" />
+                  <EuiCompressedFormRow
                     fullWidth={true}
-                    value={fieldValues?.llmResponseField || ''}
-                    onChange={(e) => {
-                      setFieldValues({
-                        ...fieldValues,
-                        llmResponseField: e.target.value,
-                      });
-                    }}
-                  />
-                </EuiCompressedFormRow>
-              </>
-            )}
+                    label={'Embedding length'}
+                    isInvalid={false}
+                    helpText="The length / dimension of the generated vector embeddings. Autofilled values may be inaccurate."
+                  >
+                    <EuiCompressedFieldNumber
+                      fullWidth={true}
+                      value={fieldValues?.embeddingLength || ''}
+                      onChange={(e) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          embeddingLength: Number(e.target.value),
+                        });
+                      }}
+                    />
+                  </EuiCompressedFormRow>
+                </>
+              )}
+              {(props.workflowType === WORKFLOW_TYPE.RAG ||
+                props.workflowType ===
+                  WORKFLOW_TYPE.VECTOR_SEARCH_WITH_RAG) && (
+                <>
+                  <EuiCompressedFormRow
+                    fullWidth={true}
+                    label={'Prompt field'}
+                    isInvalid={false}
+                    helpText={'The model input field representing the prompt'}
+                  >
+                    <EuiCompressedSuperSelect
+                      data-testid="selectPromptField"
+                      fullWidth={true}
+                      options={parseModelInputs(selectedLLMInterface).map(
+                        (option) =>
+                          ({
+                            value: option.label,
+                            inputDisplay: (
+                              <>
+                                <EuiText size="s">{option.label}</EuiText>
+                              </>
+                            ),
+                            dropdownDisplay: (
+                              <>
+                                <EuiText size="s">{option.label}</EuiText>
+                                <EuiText size="xs" color="subdued">
+                                  {option.type}
+                                </EuiText>
+                              </>
+                            ),
+                            disabled: false,
+                          } as EuiSuperSelectOption<string>)
+                      )}
+                      valueOfSelected={fieldValues?.promptField || ''}
+                      onChange={(option: string) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          promptField: option,
+                        });
+                      }}
+                      isInvalid={false}
+                    />
+                  </EuiCompressedFormRow>
+                  <EuiSpacer size="s" />
+                  <EuiCompressedFormRow
+                    fullWidth={true}
+                    label={'LLM response field'}
+                    isInvalid={false}
+                    helpText="The name of the field containing the large language model (LLM) response"
+                  >
+                    <EuiCompressedFieldText
+                      fullWidth={true}
+                      value={fieldValues?.llmResponseField || ''}
+                      onChange={(e) => {
+                        setFieldValues({
+                          ...fieldValues,
+                          llmResponseField: e.target.value,
+                        });
+                      }}
+                    />
+                  </EuiCompressedFormRow>
+                </>
+              )}
+            </>
           </EuiAccordion>
         </>
       ) : undefined}

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { isEmpty } from 'lodash';
+import { isEmpty, snakeCase } from 'lodash';
 import { useSelector } from 'react-redux';
 import { flattie } from 'flattie';
 import {
@@ -47,7 +47,6 @@ import {
   isVectorSearchUseCase,
 } from '../../../../common';
 import { APP_PATH } from '../../../utils';
-import { processWorkflowName } from './utils';
 import { AppState, createWorkflow, useAppDispatch } from '../../../store';
 import {
   constructUrlWithParams,
@@ -80,8 +79,9 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   );
 
   // workflow name state
-  const [workflowName, setWorkflowName] = useState<string>(
-    processWorkflowName(props.workflow.name)
+  const [workflowName, setWorkflowName] = useState<string>('');
+  const [workflowNameTouched, setWorkflowNameTouched] = useState<boolean>(
+    false
   );
 
   const [quickConfigureFields, setQuickConfigureFields] = useState<
@@ -123,15 +123,16 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
           fullWidth={true}
           label={'Name'}
           error={'Invalid name'}
-          isInvalid={isInvalidName(workflowName)}
+          isInvalid={workflowNameTouched && isInvalidName(workflowName)}
         >
           <EuiCompressedFieldText
             fullWidth={true}
-            placeholder={processWorkflowName(props.workflow.name)}
+            placeholder={snakeCase(props.workflow.name)}
             value={workflowName}
             onChange={(e) => {
               setWorkflowName(e.target.value);
             }}
+            onBlur={() => setWorkflowNameTouched(true)}
           />
         </EuiCompressedFormRow>
         <QuickConfigureInputs

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -69,6 +69,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const dataSourceId = getDataSourceId();
   const history = useHistory();
   const { models } = useSelector((state: AppState) => state.ml);
+  const { workflows } = useSelector((state: AppState) => state.workflows);
 
   // model interface states
   const [embeddingModelInterface, setEmbeddingModelInterface] = useState<
@@ -83,6 +84,9 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const [workflowNameTouched, setWorkflowNameTouched] = useState<boolean>(
     false
   );
+  const workflowNameExists = Object.values(workflows)
+    .map((workflow) => workflow.name)
+    .includes(workflowName);
 
   const [quickConfigureFields, setQuickConfigureFields] = useState<
     QuickConfigureFields
@@ -96,7 +100,8 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
     return (
       name === '' ||
       name.length > 100 ||
-      WORKFLOW_NAME_REGEXP.test(name) === false
+      WORKFLOW_NAME_REGEXP.test(name) === false ||
+      workflowNameExists
     );
   }
 
@@ -122,7 +127,11 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
         <EuiCompressedFormRow
           fullWidth={true}
           label={'Name'}
-          error={'Invalid name'}
+          error={
+            workflowNameExists
+              ? 'Workflow name already exists'
+              : 'Invalid workflow name'
+          }
           isInvalid={workflowNameTouched && isInvalidName(workflowName)}
         >
           <EuiCompressedFieldText
@@ -130,6 +139,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
             placeholder={snakeCase(props.workflow.name)}
             value={workflowName}
             onChange={(e) => {
+              setWorkflowNameTouched(true);
               setWorkflowName(e.target.value);
             }}
             onBlur={() => setWorkflowNameTouched(true)}

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { isEmpty, snakeCase } from 'lodash';
+import { isEmpty } from 'lodash';
 import { useSelector } from 'react-redux';
 import { flattie } from 'flattie';
 import {
@@ -129,14 +129,14 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
           label={'Name'}
           error={
             workflowNameExists
-              ? 'Workflow name already exists'
+              ? 'This workflow name is already in use. Use a different name'
               : 'Invalid workflow name'
           }
           isInvalid={workflowNameTouched && isInvalidName(workflowName)}
         >
           <EuiCompressedFieldText
             fullWidth={true}
-            placeholder={snakeCase(props.workflow.name)}
+            placeholder={'Enter a name for this workflow'}
             value={workflowName}
             onChange={(e) => {
               setWorkflowNameTouched(true);

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { snakeCase } from 'lodash';
 import {
   CollapseProcessor,
   MLIngestProcessor,
@@ -15,8 +14,6 @@ import {
 } from '../../../configs';
 import {
   WorkflowTemplate,
-  START_FROM_SCRATCH_WORKFLOW_NAME,
-  DEFAULT_NEW_WORKFLOW_NAME,
   UIState,
   WORKFLOW_TYPE,
   FETCH_ALL_QUERY,
@@ -284,15 +281,6 @@ export function fetchVectorSearchWithRAGMetadata(version: string): UIState {
     new CollapseProcessor().toObj(),
   ];
   return baseState;
-}
-
-// Utility fn to process workflow names from their presentable/readable titles
-// on the UI, to a valid name format.
-// This leads to less friction if users decide to save the name later on.
-export function processWorkflowName(workflowName: string): string {
-  return workflowName === START_FROM_SCRATCH_WORKFLOW_NAME
-    ? DEFAULT_NEW_WORKFLOW_NAME
-    : snakeCase(workflowName);
 }
 
 // populate the `query_template` config value with a given query template

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -123,7 +123,7 @@ export function Workflows(props: WorkflowsProps) {
         dispatch(
           searchWorkflows({
             apiBody: FETCH_ALL_QUERY,
-            dataSourceId: dataSourceId,
+            dataSourceId,
           })
         );
       }
@@ -148,7 +148,7 @@ export function Workflows(props: WorkflowsProps) {
       dispatch(
         searchWorkflows({
           apiBody: FETCH_ALL_QUERY,
-          dataSourceId: dataSourceId,
+          dataSourceId,
         })
       );
     }
@@ -171,7 +171,7 @@ export function Workflows(props: WorkflowsProps) {
       dispatch(
         searchWorkflows({
           apiBody: FETCH_ALL_QUERY,
-          dataSourceId: dataSourceId,
+          dataSourceId,
         })
       );
     }

--- a/server/resources/templates/rag.json
+++ b/server/resources/templates/rag.json
@@ -1,6 +1,6 @@
 {
-  "name": "Retrieval-Augmented Generation",
-  "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation (RAG)",
+  "name": "Lexical Search with RAG",
+  "description": "A basic workflow containing the index and search pipeline configurations for performing basic lexical search with retrieval-augmented generation (RAG)",
   "version": {
     "template": "1.0.0",
     "compatibility": [

--- a/server/resources/templates/rag.json
+++ b/server/resources/templates/rag.json
@@ -1,5 +1,5 @@
 {
-  "name": "Retrieval-Augmented Generation (RAG)",
+  "name": "Retrieval-Augmented Generation",
   "description": "A basic workflow containing the index and search pipeline configurations for performing basic retrieval-augmented generation (RAG)",
   "version": {
     "template": "1.0.0",


### PR DESCRIPTION
### Description

Continuation of #565, various UX bug fixes and minor improvements.

- surface sub-field-level form validation to help users uncover missing/invalid fields, particularly when configuring the ML transforms
- move model selection to top-level of quick config modal
- set default name to empty to prevent easily creating duplicate workflow names
- prevent duplicate workflow name (both in quick-config modal and in update workflow metadata modal)
- move the location and rename the override query modal
- fix bugs of model outputs not visible in the override query modal depending on certain transform types
- several component updates and wording changes to import data component + import data modal

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
