### PR TITLE
UX fit-n-finish updates VI

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -244,6 +244,8 @@ export const NORMALIZATION_PROCESSOR_LINK =
 export const GITHUB_FEEDBACK_LINK =
   'https://github.com/opensearch-project/dashboards-flow-framework/issues/new/choose';
 export const JSONPATH_DOCS_LINK = 'https://www.npmjs.com/package/jsonpath';
+export const KNN_VECTOR_DOCS_LINK =
+  'https://opensearch.org/docs/latest/field-types/supported-field-types/knn-vector/';
 
 /**
  * Text chunking algorithm constants

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -54,7 +54,10 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
         );
         if (processorModel?.connectorId !== undefined) {
           const processorConnector = connectors[processorModel?.connectorId];
-          const dimension = getEmbeddingModelDimensions(processorConnector);
+          const dimension =
+            processorConnector !== undefined
+              ? getEmbeddingModelDimensions(processorConnector)
+              : undefined;
 
           // If a dimension is found, it is a known embedding model.
           // Ensure the index is configured to be knn-enabled.

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -19,13 +19,16 @@ import { AppState } from '../../../../store';
 import {
   getEmbeddingField,
   getEmbeddingModelDimensions,
+  getFieldValue,
   getUpdatedIndexMappings,
   getUpdatedIndexSettings,
   isKnnIndex,
   removeVectorFieldFromIndexMappings,
 } from '../../../../utils';
 
-interface AdvancedSettingsProps {}
+interface AdvancedSettingsProps {
+  setHasInvalidDimensions: (hasInvalidDimensions: boolean) => void;
+}
 
 /**
  * Input component for configuring ingest-side advanced settings
@@ -117,6 +120,17 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
       );
     }
   }, [getIn(values, 'ingest.enrich')]);
+
+  // listener to check if there is a dimension value set, and if so, check its validity
+  useEffect(() => {
+    try {
+      const mappingsObj = JSON.parse(getIn(values, indexMappingsPath));
+      const dimensionVal = getFieldValue(mappingsObj, 'dimension');
+      props.setHasInvalidDimensions(
+        dimensionVal !== undefined && typeof dimensionVal !== 'number'
+      );
+    } catch (e) {}
+  }, [getIn(values, indexMappingsPath)]);
 
   return (
     <EuiFlexGroup direction="column">

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import React, { useState } from 'react';
+import {
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiText,
+} from '@elastic/eui';
 import { TextField } from '../input_fields';
 import { AdvancedSettings } from './advanced_settings';
+import { KNN_VECTOR_DOCS_LINK } from '../../../../../common';
 
 interface IngestDataProps {}
 
@@ -14,6 +21,10 @@ interface IngestDataProps {}
  * Input component for configuring the data ingest (the OpenSearch index)
  */
 export function IngestData(props: IngestDataProps) {
+  const [hasInvalidDimensions, setHasInvalidDimensions] = useState<boolean>(
+    false
+  );
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={false}>
@@ -21,11 +32,25 @@ export function IngestData(props: IngestDataProps) {
           <h3>Ingest data</h3>
         </EuiText>
       </EuiFlexItem>
+      {hasInvalidDimensions && (
+        <EuiCallOut
+          style={{ marginLeft: '14px' }}
+          size="s"
+          title={
+            <EuiText size="s">
+              Invalid dimension detected for a vector field mapping. Ensure the
+              dimension value is set correctly.{' '}
+              <EuiLink href={KNN_VECTOR_DOCS_LINK}>Learn more</EuiLink>
+            </EuiText>
+          }
+          color="warning"
+        />
+      )}
       <EuiFlexItem>
         <TextField label="Index name" fieldPath={'ingest.index.name'} />
       </EuiFlexItem>
       <EuiFlexItem>
-        <AdvancedSettings />
+        <AdvancedSettings setHasInvalidDimensions={setHasInvalidDimensions} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/override_query_modal.tsx
@@ -28,25 +28,20 @@ import {
 } from '@elastic/eui';
 import {
   IConfigField,
-  IMAGE_FIELD_PATTERN,
   IProcessorConfig,
-  LABEL_FIELD_PATTERN,
-  MODEL_ID_PATTERN,
   ModelInterface,
   NO_TRANSFORMATION,
   OutputMapEntry,
-  QUERY_IMAGE_PATTERN,
   QUERY_PRESETS,
-  QUERY_TEXT_PATTERN,
   QueryPreset,
   RequestFormValues,
-  TEXT_FIELD_PATTERN,
   TRANSFORM_TYPE,
-  VECTOR_FIELD_PATTERN,
-  VECTOR_PATTERN,
   WorkflowFormValues,
 } from '../../../../../../../common';
-import { parseModelOutputs } from '../../../../../../utils/utils';
+import {
+  injectPlaceholdersInQueryString,
+  parseModelOutputs,
+} from '../../../../../../utils/utils';
 import { JsonField } from '../../../input_fields';
 import { getFieldSchema, getInitialValue } from '../../../../../../utils';
 import '../../../../../../global-styles.scss';
@@ -193,60 +188,7 @@ export function OverrideQueryModal(props: OverrideQueryModalProps) {
                               onClick: () => {
                                 formikProps.setFieldValue(
                                   'request',
-                                  preset.query
-                                    // sanitize the query preset string into valid template placeholder format, for
-                                    // any placeholder values in the query.
-                                    // for example, replacing `"{{vector}}"` with `${vector}`
-                                    .replace(
-                                      new RegExp(
-                                        `"${VECTOR_FIELD_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{vector_field\}`
-                                    )
-                                    .replace(
-                                      new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
-                                      `\$\{vector\}`
-                                    )
-                                    .replace(
-                                      new RegExp(
-                                        `"${TEXT_FIELD_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{text_field\}`
-                                    )
-                                    .replace(
-                                      new RegExp(
-                                        `"${IMAGE_FIELD_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{image_field\}`
-                                    )
-                                    .replace(
-                                      new RegExp(
-                                        `"${LABEL_FIELD_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{label_field\}`
-                                    )
-                                    .replace(
-                                      new RegExp(
-                                        `"${QUERY_TEXT_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{query_text\}`
-                                    )
-                                    .replace(
-                                      new RegExp(
-                                        `"${QUERY_IMAGE_PATTERN}"`,
-                                        'g'
-                                      ),
-                                      `\$\{query_image\}`
-                                    )
-                                    .replace(
-                                      new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'),
-                                      `\$\{model_id\}`
-                                    )
+                                  injectPlaceholdersInQueryString(preset.query)
                                 );
                                 formikProps.setFieldTouched('request', true);
                                 setPresetsPopoverOpen(false);

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -42,6 +42,7 @@ import {
   getInitialValue,
   getPlaceholdersFromQuery,
   injectParameters,
+  injectPlaceholdersInQueryString,
 } from '../../../../utils';
 import { AppState, searchIndex, useAppDispatch } from '../../../../store';
 import { QueryParamsList, Results } from '../../../../general_components';
@@ -206,7 +207,9 @@ export function EditQueryModal(props: EditQueryModalProps) {
                                           onClick: () => {
                                             formikProps.setFieldValue(
                                               'request',
-                                              preset.query
+                                              injectPlaceholdersInQueryString(
+                                                preset.query
+                                              )
                                             );
                                             setPopoverOpen(false);
                                           },

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -181,7 +181,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
             <>
               <EuiCallOut
                 size="s"
-                title="No embedding length found. Make sure to manually configure"
+                title="No embedding length found. Make sure to manually configure below."
                 color="warning"
               />
               <EuiSpacer size="s" />

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -117,7 +117,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   }, [models, quickConfigureFields?.llmId]);
 
   return (
-    <EuiModal onClose={() => props.onClose()} style={{ width: '30vw' }}>
+    <EuiModal onClose={() => props.onClose()} style={{ width: '40vw' }}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           <p>{`Quick configure`}</p>

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -33,6 +33,12 @@ import {
   customStringify,
   NO_TRANSFORMATION,
   TRANSFORM_TYPE,
+  VECTOR_FIELD_PATTERN,
+  VECTOR_PATTERN,
+  TEXT_FIELD_PATTERN,
+  IMAGE_FIELD_PATTERN,
+  LABEL_FIELD_PATTERN,
+  MODEL_ID_PATTERN,
 } from '../../common';
 import { getCore, getDataSourceEnabled } from '../services';
 import {
@@ -775,4 +781,16 @@ export function parseErrorsFromIngestResponse(
     );
   }
   return;
+}
+
+// Update the target query string placeholders into valid placeholder format. Used to disambiguate
+// placeholders (${text_field}) vs. dynamic parameters (e.g., "{{query_text}}")
+export function injectPlaceholdersInQueryString(query: string): string {
+  return query
+    .replace(new RegExp(`"${VECTOR_FIELD_PATTERN}"`, 'g'), `\$\{vector_field\}`)
+    .replace(new RegExp(`"${VECTOR_PATTERN}"`, 'g'), `\$\{vector\}`)
+    .replace(new RegExp(`"${TEXT_FIELD_PATTERN}"`, 'g'), `\$\{text_field\}`)
+    .replace(new RegExp(`"${IMAGE_FIELD_PATTERN}"`, 'g'), `\$\{image_field\}`)
+    .replace(new RegExp(`"${LABEL_FIELD_PATTERN}"`, 'g'), `\$\{label_field\}`)
+    .replace(new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'), `\$\{model_id\}`);
 }

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -618,7 +618,7 @@ export function getEmbeddingModelDimensions(
 ): number | undefined {
   // some APIs allow specifically setting the dimensions at runtime,
   // so we check for that first.
-  if (connector.parameters?.dimensions !== undefined) {
+  if (connector?.parameters?.dimensions !== undefined) {
     return connector.parameters?.dimensions;
   } else if (connector.parameters?.model !== undefined) {
     return (

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -794,3 +794,19 @@ export function injectPlaceholdersInQueryString(query: string): string {
     .replace(new RegExp(`"${LABEL_FIELD_PATTERN}"`, 'g'), `\$\{label_field\}`)
     .replace(new RegExp(`"${MODEL_ID_PATTERN}"`, 'g'), `\$\{model_id\}`);
 }
+
+// Utility fn to parse out a JSON obj and find some value for a given field.
+// Primarily used to traverse index mappings and check that values are valid.
+export function getFieldValue(jsonObj: {}, fieldName: string): any | undefined {
+  if (typeof jsonObj !== 'object' || jsonObj === undefined) return undefined;
+  if (fieldName in jsonObj) {
+    return get(jsonObj, fieldName) as any;
+  }
+  for (const key in jsonObj) {
+    const result = getFieldValue(get(jsonObj, key), fieldName);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
### Description

Continuation of #567, various UX improvements and bug fixes:
- add guardrails on selecting an embedding model with unknown dimensions details, including a callout, and automatically opening the accordion from the quick configure menu
- gracefully handle partial provisioning failures. deprovision and show toast
- disambiguate parameters vs. placeholders in the query presets. The main idea is, the only dynamic values in the query that the users want to test with, should be separated from the placeholders that should be set to static fields, like a model id or text field, for example. Additionally, this prevents saving / updating the preset query, until such values are populated.
- add callout if an invalid dimension value is set.

Relevant screenshots:
![Screenshot 2025-01-17 at 11 24 18 AM](https://github.com/user-attachments/assets/403de9ed-a87e-42f7-b58b-2d56050dd302)

![Screenshot 2025-01-17 at 11 33 17 AM](https://github.com/user-attachments/assets/9d70b478-53ff-4041-b57d-b19aded21e4c)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
