### PR TITLE
Tune test IDs for integ tests

### DIFF
--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -191,6 +191,7 @@ export function Query(props: QueryProps) {
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiSmallButton
+                      data-test-subj="searchButton"
                       fill={true}
                       isLoading={loading}
                       disabled={

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -802,6 +802,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 )}
                 <EuiFlexItem grow={false}>
                   <EuiSmallButton
+                    data-test-subj="updateAndRunIngestButton"
                     fill={true}
                     iconType="check"
                     iconSide="left"
@@ -848,6 +849,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 {!searchUpdateDisabled && (
                   <EuiFlexItem grow={false}>
                     <EuiSmallButton
+                      data-test-subj="updateSearchButton"
                       fill={true}
                       iconType="check"
                       iconSide="left"


### PR DESCRIPTION
### Description

Update and add a few test IDs to work with the updated integration tests. Corresponding test changes tracked in https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1678


Closes #519 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
