### PR TITLE
UX fit-n-finish updates IX

### DIFF
--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -437,10 +437,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                   revertUnsavedChanges();
                 }}
               />,
-              <EuiText color="subdued" size="s">
-                {`Last saved: ${workflowLastUpdated}`}
-              </EuiText>,
-              // TODO: placement may change for this
               <EuiSmallButtonEmpty
                 disabled={false}
                 onClick={() => {
@@ -449,6 +445,9 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
               >
                 {`How it works`}
               </EuiSmallButtonEmpty>,
+              <EuiText color="subdued" size="s">
+                {`Last saved: ${workflowLastUpdated}`}
+              </EuiText>,
             ]}
             bottomBorder={false}
             rightSideGroupProps={{


### PR DESCRIPTION
### Description

Continuation of #577, contains various UX fit-n-finish updates:
- move 'How it works' button in header (old UI look)


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
