### PR TITLE
Integrate with synchronous provisioning feature

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -654,6 +654,7 @@ export const MAX_BYTES_FORMATTED = '1,048,576';
 export const MAX_WORKFLOW_NAME_TO_DISPLAY = 40;
 export const WORKFLOW_NAME_REGEXP = RegExp('^[a-zA-Z0-9_-]*$');
 export const INDEX_NAME_REGEXP = WORKFLOW_NAME_REGEXP;
+export const PROVISION_TIMEOUT = '10s'; // the timeout config for synchronous provisioning. https://github.com/opensearch-project/flow-framework/pull/990
 export const EMPTY_MAP_ENTRY = { key: '', value: '' } as MapEntry;
 export const EMPTY_INPUT_MAP_ENTRY = {
   key: '',
@@ -662,7 +663,6 @@ export const EMPTY_INPUT_MAP_ENTRY = {
     value: '',
   },
 } as InputMapEntry;
-
 export const EMPTY_OUTPUT_MAP_ENTRY = {
   ...EMPTY_INPUT_MAP_ENTRY,
   value: {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -400,8 +400,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               )
                 .unwrap()
                 .then(async (result) => {
-                  await sleep(1000);
-
                   await dispatch(
                     getWorkflow({
                       workflowId: updatedWorkflow.id as string,

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -49,7 +49,6 @@ import {
   hasProvisionedIngestResources,
   hasProvisionedSearchResources,
   generateId,
-  sleep,
   getResourcesToBeForceDeleted,
   getDataSourceId,
 } from '../../../utils';
@@ -341,7 +340,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
       )
         .unwrap()
         .then(async (result) => {
-          await sleep(1000);
           props.setUnsavedIngestProcessors(false);
           props.setUnsavedSearchProcessors(false);
           success = true;
@@ -386,13 +384,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           )
             .unwrap()
             .then(async (result) => {
-              await sleep(1000);
               props.setUnsavedIngestProcessors(false);
               props.setUnsavedSearchProcessors(false);
               await dispatch(
-                // TODO: update to be synchronous provisioning, to prevent
-                // having to wait/sleep before performing next actions.
-                // https://github.com/opensearch-project/flow-framework/pull/1009
                 provisionWorkflow({
                   workflowId: updatedWorkflow.id as string,
                   dataSourceId,

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -626,7 +626,7 @@ export function getEmbeddingModelDimensions(
   // so we check for that first.
   if (connector?.parameters?.dimensions !== undefined) {
     return connector.parameters?.dimensions;
-  } else if (connector.parameters?.model !== undefined) {
+  } else if (connector?.parameters?.model !== undefined) {
     return (
       // @ts-ignore
       COHERE_CONFIGS[connector.parameters?.model]?.dimension ||

--- a/server/cluster/flow_framework_plugin.ts
+++ b/server/cluster/flow_framework_plugin.ts
@@ -7,6 +7,7 @@ import {
   FLOW_FRAMEWORK_SEARCH_WORKFLOWS_ROUTE,
   FLOW_FRAMEWORK_SEARCH_WORKFLOW_STATE_ROUTE,
   FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX,
+  PROVISION_TIMEOUT,
 } from '../../common';
 
 /**
@@ -75,7 +76,7 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
 
   flowFramework.updateWorkflow = ca({
     url: {
-      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>&reprovision=<%=reprovision%>`,
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>`,
       req: {
         workflow_id: {
           type: 'string',
@@ -85,7 +86,21 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
           type: 'boolean',
           required: true,
         },
-        reprovision: {
+      },
+    },
+    needBody: true,
+    method: 'PUT',
+  });
+
+  flowFramework.updateAndReprovisionWorkflow = ca({
+    url: {
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>&reprovision=true&wait_for_completion_timeout=${PROVISION_TIMEOUT}`,
+      req: {
+        workflow_id: {
+          type: 'string',
+          required: true,
+        },
+        update_fields: {
           type: 'boolean',
           required: true,
         },
@@ -97,7 +112,7 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
 
   flowFramework.provisionWorkflow = ca({
     url: {
-      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>/_provision`,
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>/_provision?wait_for_completion_timeout=${PROVISION_TIMEOUT}`,
       req: {
         workflow_id: {
           type: 'string',

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -475,13 +475,21 @@ export class FlowFrameworkRoutesService {
         data_source_id,
         this.client
       );
-      await callWithRequest('flowFramework.updateWorkflow', {
-        workflow_id,
-        // default update_fields to false if not explicitly set otherwise
-        update_fields: update_fields,
-        reprovision: reprovision,
-        body: workflowTemplate,
-      });
+      if (reprovision) {
+        await callWithRequest('flowFramework.updateAndReprovisionWorkflow', {
+          workflow_id,
+          // default update_fields to false if not explicitly set otherwise
+          update_fields,
+          body: workflowTemplate,
+        });
+      } else {
+        await callWithRequest('flowFramework.updateWorkflow', {
+          workflow_id,
+          // default update_fields to false if not explicitly set otherwise
+          update_fields,
+          body: workflowTemplate,
+        });
+      }
 
       return res.ok({ body: { workflowId: workflow_id, workflowTemplate } });
     } catch (err: any) {


### PR DESCRIPTION
### Description

Updates few of the provisioning-related API calls to leverage new params offered to enforce synchronous provisioning with a configurable timeout - see PR: https://github.com/opensearch-project/flow-framework/pull/990

Setting timeout to 10s for now, as we have not run into problems with the existing manual check done after 1s prior.

This improves the plugin in a few ways:
- UX state updates as soon as provisioning/reprovisioning is completed
- UX state has much lower chance of getting out of sync; before, the plugin manually waited a set time and re-fetched the workflow details. Now, it will only fail if provisioning takes > the configured timeout of 10s.

Testing
- ensured existing flows work as expected, including exercising all changed API paths

### Issues Resolved

Makes progress on #571 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
