### PR TITLE
hide the processorList for version <2.19 and context is Search_Request

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/enrich_search_request.tsx
@@ -17,6 +17,7 @@ interface EnrichSearchRequestProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   setCachedFormikState: (cachedFormikState: CachedFormikState) => void;
+  showProcessorSection?: boolean;
 }
 
 /**
@@ -32,14 +33,16 @@ export function EnrichSearchRequest(props: EnrichSearchRequestProps) {
         }
         optional={false}
       />
-      <EuiFlexItem>
-        <ProcessorsList
-          uiConfig={props.uiConfig}
-          setUiConfig={props.setUiConfig}
-          context={PROCESSOR_CONTEXT.SEARCH_REQUEST}
-          setCachedFormikState={props.setCachedFormikState}
-        />
-      </EuiFlexItem>
+      {props.showProcessorSection && (
+        <EuiFlexItem>
+          <ProcessorsList
+            uiConfig={props.uiConfig}
+            setUiConfig={props.setUiConfig}
+            context={PROCESSOR_CONTEXT.SEARCH_REQUEST}
+            setCachedFormikState={props.setCachedFormikState}
+          />
+        </EuiFlexItem>
+      )}
     </EuiFlexGroup>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -20,6 +20,7 @@ interface SearchInputsProps {
   uiConfig: WorkflowConfig;
   setUiConfig: (uiConfig: WorkflowConfig) => void;
   setCachedFormikState: (cachedFormikState: CachedFormikState) => void;
+  showProcessorSection?: boolean;
 }
 
 /**
@@ -50,9 +51,11 @@ export function SearchInputs(props: SearchInputsProps) {
           setCachedFormikState={props.setCachedFormikState}
         />
       </EuiFlexItem>
+
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="m" />
       </EuiFlexItem>
+
       <EuiFlexItem grow={false}>
         <EnrichSearchResponse
           uiConfig={props.uiConfig}


### PR DESCRIPTION
### Description

We are currently showing processor list for all the context. For this enhancement, the processor list is hidden if context is search request and if backend version is less than 2.19.0. Demo about the code change will be sent to the slack channel.

### Issues Resolved

[550](https://github.com/opensearch-project/dashboards-flow-framework/issues/550)


### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
