### PR TITLE
Add NPE checks on Object.values() calls

### DIFF
--- a/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
+++ b/public/pages/workflow_detail/components/edit_workflow_metadata_modal.tsx
@@ -78,7 +78,7 @@ export function EditWorkflowMetadataModal(
         'This workflow name is already in use. Use a different name',
         (name) => {
           return !(
-            Object.values(workflows)
+            Object.values(workflows || {})
               .map((workflow) => workflow.name)
               .includes(name || '') && name !== props.workflow?.name
           );

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -71,7 +71,7 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
       props.workflow.resourcesCreated.forEach((resource) => {
         resourcesMap[resource.id] = resource;
       });
-      setAllResources(Object.values(resourcesMap));
+      setAllResources(Object.values(resourcesMap || {}));
     }
   }, [props.workflow?.resourcesCreated]);
 

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -37,7 +37,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
   const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
   const { models, connectors } = useSelector((state: AppState) => state.ml);
   const ingestMLProcessors = (Object.values(
-    values?.ingest?.enrich
+    values?.ingest?.enrich || {}
   ) as any[]).filter((ingestProcessor) => ingestProcessor?.model !== undefined);
   const ingestProcessorModelIds = ingestMLProcessors
     .map((ingestProcessor) => ingestProcessor?.model?.id as string | undefined)
@@ -52,7 +52,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
   useEffect(() => {
     if (ingestProcessorModelIds.length > 0) {
       ingestProcessorModelIds.forEach((ingestProcessorModelId) => {
-        const processorModel = Object.values(models).find(
+        const processorModel = Object.values(models || {}).find(
           (model) => model.id === ingestProcessorModelId
         );
         if (processorModel?.connectorId !== undefined) {
@@ -91,7 +91,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
   useEffect(() => {
     if (ingestMLProcessors.length > 0) {
       ingestMLProcessors.forEach((ingestMLProcessor) => {
-        const processorModel = Object.values(models).find(
+        const processorModel = Object.values(models || {}).find(
           (model) => model.id === ingestMLProcessor?.model?.id
         );
         if (processorModel?.connectorId !== undefined) {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -266,7 +266,7 @@ export function SourceDataModal(props: SourceDataProps) {
                     <EuiCompressedComboBox
                       placeholder="Select an index"
                       singleSelection={{ asPlainText: true }}
-                      options={Object.values(indices).map((option) => {
+                      options={Object.values(indices || {}).map((option) => {
                         return { label: option.name };
                       })}
                       onChange={(options) => {

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -75,7 +75,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
               />
             ) : (
               <EuiCompressedSuperSelect
-                options={Object.values(indices).map(
+                options={Object.values(indices || {}).map(
                   (option) =>
                     ({
                       value: option.name,

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -76,7 +76,7 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
       workflowNameExists
     );
   }
-  const workflowNameExists = Object.values(workflows)
+  const workflowNameExists = Object.values(workflows || {})
     .map((workflow) => workflow.name)
     .includes(workflowName);
 

--- a/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_inputs.tsx
@@ -57,7 +57,7 @@ export function QuickConfigureInputs(props: QuickConfigureInputsProps) {
   useEffect(() => {
     if (models) {
       setDeployedModels(
-        Object.values(models).filter(
+        Object.values(models || {}).filter(
           (model) => model.state === MODEL_STATE.DEPLOYED
         )
       );

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -87,7 +87,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const [workflowNameTouched, setWorkflowNameTouched] = useState<boolean>(
     false
   );
-  const workflowNameExists = Object.values(workflows)
+  const workflowNameExists = Object.values(workflows || {})
     .map((workflow) => workflow.name)
     .includes(workflowName);
 

--- a/public/pages/workflows/workflow_list/resource_list.tsx
+++ b/public/pages/workflows/workflow_list/resource_list.tsx
@@ -73,7 +73,7 @@ export function ResourceList(props: ResourceListProps) {
       props.workflow.resourcesCreated.forEach((resource) => {
         resourcesMap[resource.id] = resource;
       });
-      setAllResources(Object.values(resourcesMap));
+      setAllResources(Object.values(resourcesMap || {}));
     }
   }, [props.workflow?.resourcesCreated]);
 

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -77,7 +77,7 @@ function indexConfigToSchema(
       'name',
       'This index name is already in use. Use a different name',
       (name) => {
-        return !Object.values(indices)
+        return !Object.values(indices || {})
           .map((index) => index.name)
           .includes(name || '');
       }


### PR DESCRIPTION
### Description

There are certain edge cases where the values called in `Object.values()` may be undefined or null, which crashes the webpage. This adds checks on all instances of `Object.values()` with a default value if the value is undefined/null.

There is an edge case of no workflows created (no system index) that leads to server-side error, which is incorrectly setting the redux store value of `workflows` to undefined, and causing a crash when trying to create a workflow, where `QuickConfigureModal` does a validation check on the workflow names, which is where an NPE can occur. This fixes that by auditing all instances of `Object.values()`.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
