### PR TITLE
hide search query section when version is less than 2.19

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import semver from 'semver';
 import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 import { ConfigureSearchRequest } from './configure_search_request';
 import { EnrichSearchRequest } from './enrich_search_request';
@@ -15,6 +16,7 @@ import {
 } from '../../../../../common';
 import { catIndices, useAppDispatch } from '../../../../store';
 import { getDataSourceId } from '../../../../utils';
+import { getEffectiveVersion } from '../../../workflows/new_workflow/new_workflow';
 
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
@@ -28,12 +30,27 @@ interface SearchInputsProps {
 export function SearchInputs(props: SearchInputsProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const [showTransformQuery, setShowTransformQuery] = useState(true);
   // re-fetch indices on initial load. When users are first creating,
   // they may enter this page without getting the updated index info
   // for a newly-created index, so we re-fetch that here.
   useEffect(() => {
     dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
   }, []);
+
+  useEffect(() => {
+    const checkVersion = async () => {
+      try {
+        const version = await getEffectiveVersion(dataSourceId);
+        setShowTransformQuery(semver.gte(version, '2.19.0'));
+      } catch (error) {
+        console.error('Error checking version:', error);
+        setShowTransformQuery(true);
+      }
+    };
+
+    checkVersion();
+  }, [dataSourceId]);
 
   return (
     <EuiFlexGroup direction="column">
@@ -43,16 +60,20 @@ export function SearchInputs(props: SearchInputsProps) {
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="m" />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EnrichSearchRequest
-          uiConfig={props.uiConfig}
-          setUiConfig={props.setUiConfig}
-          setCachedFormikState={props.setCachedFormikState}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiHorizontalRule margin="m" />
-      </EuiFlexItem>
+      {showTransformQuery && (
+        <>
+          <EuiFlexItem grow={false}>
+            <EnrichSearchRequest
+              uiConfig={props.uiConfig}
+              setUiConfig={props.setUiConfig}
+              setCachedFormikState={props.setCachedFormikState}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiHorizontalRule margin="m" />
+          </EuiFlexItem>
+        </>
+      )}
       <EuiFlexItem grow={false}>
         <EnrichSearchResponse
           uiConfig={props.uiConfig}


### PR DESCRIPTION
### Description

Upon discussion with the UX team, we need to hide the whole transform query section if backend version is less than 2.19. The issue states to hide the processor list section. We need to hide the whole query section instead. 

### Issues Resolved

[550](https://github.com/opensearch-project/dashboards-flow-framework/issues/550)

### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
