### PR TITLE
Integrate legacy presets with quick-configure fields

### DIFF
--- a/public/configs/ingest_processors/text_embedding_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_embedding_ingest_processor.ts
@@ -10,8 +10,8 @@ export class TextEmbeddingIngestProcessor extends Processor {
     this.id = generateId('text_embedding_processor_ingest');
     this.fields = [
       {
-        id: 'model_id',
-        type: 'string',
+        id: 'model',
+        type: 'model',
       },
       {
         id: 'field_map',

--- a/public/configs/ingest_processors/text_image_embedding_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_image_embedding_ingest_processor.ts
@@ -10,8 +10,8 @@ export class TextImageEmbeddingIngestProcessor extends Processor {
     this.id = generateId('text_image_embedding_processor_ingest');
     this.fields = [
       {
-        id: 'model_id',
-        type: 'string',
+        id: 'model',
+        type: 'model',
       },
       {
         id: 'embedding',

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -33,6 +33,8 @@ import {
   getWorkflow,
   searchConnectors,
   searchModels,
+  setIngestPipelineErrors,
+  setSearchPipelineErrors,
   useAppDispatch,
 } from '../../store';
 import { ResizableWorkspace } from './resizable_workspace';
@@ -82,6 +84,7 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   // - fetch workflow
   // - fetch available models & connectors as their IDs may be used when building flows
   // - fetch all indices
+  // - clear any processor-level errors
   useEffect(() => {
     dispatch(getWorkflow({ workflowId, dataSourceId }));
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId }));
@@ -89,6 +92,8 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
       searchConnectors({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId })
     );
     dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
+    dispatch(setIngestPipelineErrors({ errors: {} }));
+    dispatch(setSearchPipelineErrors({ errors: {} }));
   }, []);
 
   // data-source-related states

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -12,6 +12,7 @@ import {
   NumberField,
   JsonField,
   MapField,
+  ModelField,
 } from './input_fields';
 import { IConfigField } from '../../../../common';
 import { camelCaseToTitleString } from '../../../utils';
@@ -115,6 +116,19 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                 <MapField
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={fieldPath}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'model': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <ModelField
+                  field={field}
+                  fieldPath={fieldPath}
+                  showMissingInterfaceCallout={false}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -11,6 +11,7 @@ import {
   BooleanField,
   NumberField,
   JsonField,
+  MapField,
 } from './input_fields';
 import { IConfigField } from '../../../../common';
 import { camelCaseToTitleString } from '../../../utils';
@@ -100,6 +101,18 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
               <EuiFlexItem key={idx}>
                 <JsonField
                   validate={false}
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={fieldPath}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
+          case 'map': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <MapField
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={fieldPath}
                 />

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/map_field.tsx
@@ -182,18 +182,14 @@ export function MapField(props: MapFieldProps) {
                                   <SelectWithCustomOptions
                                     fieldPath={`${props.fieldPath}.${idx}.key`}
                                     options={props.keyOptions as any[]}
-                                    placeholder={
-                                      props.keyPlaceholder || 'Input'
-                                    }
+                                    placeholder={props.keyPlaceholder || 'Key'}
                                     allowCreate={true}
                                   />
                                 ) : (
                                   <TextField
                                     fullWidth={true}
                                     fieldPath={`${props.fieldPath}.${idx}.key`}
-                                    placeholder={
-                                      props.keyPlaceholder || 'Input'
-                                    }
+                                    placeholder={props.keyPlaceholder || 'Key'}
                                     showError={false}
                                   />
                                 )}
@@ -220,7 +216,7 @@ export function MapField(props: MapFieldProps) {
                                     fieldPath={`${props.fieldPath}.${idx}.value`}
                                     options={props.valueOptions || []}
                                     placeholder={
-                                      props.valuePlaceholder || 'Output'
+                                      props.valuePlaceholder || 'Value'
                                     }
                                     allowCreate={true}
                                   />
@@ -229,7 +225,7 @@ export function MapField(props: MapFieldProps) {
                                     fullWidth={true}
                                     fieldPath={`${props.fieldPath}.${idx}.value`}
                                     placeholder={
-                                      props.valuePlaceholder || 'Output'
+                                      props.valuePlaceholder || 'Value'
                                     }
                                     showError={false}
                                   />

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -30,8 +30,9 @@ import { AppState } from '../../../../store';
 interface ModelFieldProps {
   field: IConfigField;
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
-  hasModelInterface: boolean;
-  onModelChange: (modelId: string) => void;
+  hasModelInterface?: boolean;
+  onModelChange?: (modelId: string) => void;
+  showMissingInterfaceCallout?: boolean;
 }
 
 type ModelItem = ModelFormValue & {
@@ -47,7 +48,10 @@ export function ModelField(props: ModelFieldProps) {
   // re-fetch here as it could overload client-side if user clicks back and forth /
   // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
   const models = useSelector((state: AppState) => state.ml.models);
-  //const models = {};
+
+  // Set defaults for optional props
+  const showMissingInterfaceCallout = props.showMissingInterfaceCallout ?? true;
+  const hasModelInterface = props.hasModelInterface ?? false;
 
   const { errors, touched, values } = useFormikContext<WorkflowFormValues>();
 
@@ -74,7 +78,8 @@ export function ModelField(props: ModelFieldProps) {
 
   return (
     <>
-      {!props.hasModelInterface &&
+      {showMissingInterfaceCallout &&
+        !hasModelInterface &&
         !isEmpty(getIn(values, props.fieldPath)?.id) && (
           <>
             <EuiCallOut
@@ -156,7 +161,9 @@ export function ModelField(props: ModelFieldProps) {
                   form.setFieldValue(props.fieldPath, {
                     id: option,
                   } as ModelFormValue);
-                  props.onModelChange(option);
+                  if (props.onModelChange) {
+                    props.onModelChange(option);
+                  }
                 }}
                 isInvalid={
                   getIn(errors, field.name) && getIn(touched, field.name)

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -137,11 +137,10 @@ export function ProcessorsList(props: ProcessorsListProps) {
   }, [props.context, props.uiConfig]);
 
   const getMenuItems = () => {
-    // const isPreV219 =
-    //   semver.gte(version, MIN_SUPPORTED_VERSION) &&
-    //   semver.lt(version, MINIMUM_FULL_SUPPORTED_VERSION);
+    const isPreV219 =
+      semver.gte(version, MIN_SUPPORTED_VERSION) &&
+      semver.lt(version, MINIMUM_FULL_SUPPORTED_VERSION);
 
-    const isPreV219 = true;
     const ingestProcessors = [
       ...(isPreV219
         ? [

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -137,9 +137,11 @@ export function ProcessorsList(props: ProcessorsListProps) {
   }, [props.context, props.uiConfig]);
 
   const getMenuItems = () => {
-    const isPreV219 =
-      semver.gte(version, MIN_SUPPORTED_VERSION) &&
-      semver.lt(version, MINIMUM_FULL_SUPPORTED_VERSION);
+    // const isPreV219 =
+    //   semver.gte(version, MIN_SUPPORTED_VERSION) &&
+    //   semver.lt(version, MINIMUM_FULL_SUPPORTED_VERSION);
+
+    const isPreV219 = true;
     const ingestProcessors = [
       ...(isPreV219
         ? [

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -81,8 +81,7 @@ const filterPresetsByVersion = async (
     WORKFLOW_TYPE.HYBRID_SEARCH,
   ];
 
-  //const version = await getEffectiveVersion(dataSourceId);
-  const version = '2.17.0';
+  const version = await getEffectiveVersion(dataSourceId);
 
   if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
     return [];
@@ -151,23 +150,12 @@ export function NewWorkflow(props: NewWorkflowProps) {
       const dataSourceEnabled = getDataSourceEnabled().enabled;
 
       if (!dataSourceEnabled) {
-        const enrichedWorkflows = presetWorkflows
-          .filter((workflow) => {
-            const workflowType =
-              workflow.ui_metadata?.type ?? WORKFLOW_TYPE.UNKNOWN;
-            return [
-              WORKFLOW_TYPE.SEMANTIC_SEARCH,
-              WORKFLOW_TYPE.MULTIMODAL_SEARCH,
-              WORKFLOW_TYPE.HYBRID_SEARCH,
-            ].includes(workflowType as WORKFLOW_TYPE);
-          })
-          .map((presetWorkflow) =>
-            enrichPresetWorkflowWithUiMetadata(
-              presetWorkflow,
-              '2.17.0'
-              //MINIMUM_FULL_SUPPORTED_VERSION
-            )
-          );
+        const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
+          enrichPresetWorkflowWithUiMetadata(
+            presetWorkflow,
+            MINIMUM_FULL_SUPPORTED_VERSION
+          )
+        );
         setAllWorkflows(enrichedWorkflows);
         setFilteredWorkflows(enrichedWorkflows);
         setIsVersionLoading(false);
@@ -183,8 +171,7 @@ export function NewWorkflow(props: NewWorkflowProps) {
 
       setIsVersionLoading(true);
 
-      //const version = await getEffectiveVersion(dataSourceId);
-      const version = '2.17.0';
+      const version = await getEffectiveVersion(dataSourceId);
 
       const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
         enrichPresetWorkflowWithUiMetadata(presetWorkflow, version)

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -81,7 +81,8 @@ const filterPresetsByVersion = async (
     WORKFLOW_TYPE.HYBRID_SEARCH,
   ];
 
-  const version = await getEffectiveVersion(dataSourceId);
+  //const version = await getEffectiveVersion(dataSourceId);
+  const version = '2.17.0';
 
   if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
     return [];
@@ -150,12 +151,23 @@ export function NewWorkflow(props: NewWorkflowProps) {
       const dataSourceEnabled = getDataSourceEnabled().enabled;
 
       if (!dataSourceEnabled) {
-        const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
-          enrichPresetWorkflowWithUiMetadata(
-            presetWorkflow,
-            MINIMUM_FULL_SUPPORTED_VERSION
-          )
-        );
+        const enrichedWorkflows = presetWorkflows
+          .filter((workflow) => {
+            const workflowType =
+              workflow.ui_metadata?.type ?? WORKFLOW_TYPE.UNKNOWN;
+            return [
+              WORKFLOW_TYPE.SEMANTIC_SEARCH,
+              WORKFLOW_TYPE.MULTIMODAL_SEARCH,
+              WORKFLOW_TYPE.HYBRID_SEARCH,
+            ].includes(workflowType as WORKFLOW_TYPE);
+          })
+          .map((presetWorkflow) =>
+            enrichPresetWorkflowWithUiMetadata(
+              presetWorkflow,
+              '2.17.0'
+              //MINIMUM_FULL_SUPPORTED_VERSION
+            )
+          );
         setAllWorkflows(enrichedWorkflows);
         setFilteredWorkflows(enrichedWorkflows);
         setIsVersionLoading(false);
@@ -171,7 +183,8 @@ export function NewWorkflow(props: NewWorkflowProps) {
 
       setIsVersionLoading(true);
 
-      const version = await getEffectiveVersion(dataSourceId);
+      //const version = await getEffectiveVersion(dataSourceId);
+      const version = '2.17.0';
 
       const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
         enrichPresetWorkflowWithUiMetadata(presetWorkflow, version)

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -48,6 +48,7 @@ import {
   isVectorSearchUseCase,
   WORKFLOW_NAME_RESTRICTIONS,
   MAX_DESCRIPTION_LENGTH,
+  MapFormValue,
 } from '../../../../common';
 import { APP_PATH } from '../../../utils';
 import { AppState, createWorkflow, useAppDispatch } from '../../../store';
@@ -409,6 +410,20 @@ function updateIngestProcessors(
             }
           }
           field.value = [outputMap] as OutputMapArrayFormValue;
+        }
+      });
+    } else if (processor.type === PROCESSOR_TYPE.TEXT_EMBEDDING) {
+      config.ingest.enrich.processors[idx].fields.forEach((field) => {
+        if (field.id === 'model' && fields.embeddingModelId) {
+          field.value = { id: fields.embeddingModelId };
+        }
+        if (field.id === 'field_map') {
+          field.value = [
+            {
+              key: fields.textField || '',
+              value: fields.vectorField || '',
+            },
+          ] as MapFormValue;
         }
       });
     }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -426,6 +426,27 @@ function updateIngestProcessors(
           ] as MapFormValue;
         }
       });
+    } else if (processor.type === PROCESSOR_TYPE.TEXT_IMAGE_EMBEDDING) {
+      config.ingest.enrich.processors[idx].fields.forEach((field) => {
+        if (field.id === 'model' && fields.embeddingModelId) {
+          field.value = { id: fields.embeddingModelId };
+        }
+        if (field.id === 'field_map') {
+          field.value = [
+            {
+              key: 'text',
+              value: fields.textField || '',
+            },
+            {
+              key: 'image',
+              value: fields.imageField || '',
+            },
+          ] as MapFormValue;
+        }
+        if (field.id === 'embedding') {
+          field.value = fields.vectorField || '';
+        }
+      });
     }
   });
   return config;

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -377,6 +377,14 @@ export function processorConfigsToTemplateProcessors(
             formValue
           );
         });
+        // remove the model field, update to just the required model ID
+        const model = finalFormValues.model;
+        delete finalFormValues.model;
+        finalFormValues = {
+          ...finalFormValues,
+          model_id: model.id,
+        };
+
         // add the field map config obj
         finalFormValues = {
           ...finalFormValues,

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -363,9 +363,36 @@ export function processorConfigsToTemplateProcessors(
         });
         break;
       }
+      case PROCESSOR_TYPE.TEXT_EMBEDDING:
+      case PROCESSOR_TYPE.TEXT_IMAGE_EMBEDDING: {
+        const formValues = processorConfigToFormik(processorConfig);
+        let finalFormValues = {} as FormikValues;
+        // iterate through the form values, ignoring any empty
+        // field (empty fields can be possible if the field is optional)
+        Object.keys(formValues).forEach((formKey: string) => {
+          const formValue = formValues[formKey];
+          finalFormValues = optionallyAddToFinalForm(
+            finalFormValues,
+            formKey,
+            formValue
+          );
+        });
+        // add the field map config obj
+        finalFormValues = {
+          ...finalFormValues,
+          field_map: mergeMapIntoSingleObj(
+            formValues['field_map'] as MapFormValue
+          ),
+        };
+        processorsList.push({
+          [processorConfig.type]: finalFormValues,
+        });
+        break;
+      }
       case PROCESSOR_TYPE.SPLIT:
       case PROCESSOR_TYPE.SORT:
       case PROCESSOR_TYPE.COLLAPSE:
+      case PROCESSOR_TYPE.COPY:
       default: {
         const formValues = processorConfigToFormik(processorConfig);
         let finalFormValues = {} as FormikValues;

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -728,14 +728,14 @@ export function getUpdatedIndexSettings(
 function getEmbeddingFieldFromConnector(
   connector: Connector
 ): string | undefined {
-  if (connector.parameters?.model !== undefined) {
+  if (connector?.parameters?.model !== undefined) {
     return (
       // @ts-ignore
-      COHERE_CONFIGS[connector.parameters?.model]?.fieldName ||
+      COHERE_CONFIGS[connector?.parameters?.model]?.fieldName ||
       // @ts-ignore
-      OPENAI_CONFIGS[connector.parameters?.model]?.fieldName ||
+      OPENAI_CONFIGS[connector?.parameters?.model]?.fieldName ||
       // @ts-ignore
-      BEDROCK_CONFIGS[connector.parameters?.model]?.fieldName
+      BEDROCK_CONFIGS[connector?.parameters?.model]?.fieldName
     );
   } else {
     return undefined;


### PR DESCRIPTION
### Description

This PR allows the legacy presets (and associated legacy processors) to work as expected end-to-end. More details:
- exposes all required fields in the processor form
- updates the raw `model_id` field to be a `model` for consistency and user friendliness
- ensures the processors have special logic in the template conversion utils to form a proper/valid definition
- integrates with the quick-configure modal, such that the input fields are propagated to auto-fill everything, including the processor form values, and the query. See demo video below.

Other minor fixes:
- adds NPE check on undefined connector
- clears processor error state if navigating off of details page

Demo video, showing the presets with the pre-populated values for the legacy processors.

[screen-capture (19).webm](https://github.com/user-attachments/assets/0010fafc-ec79-4e37-b505-ef232aa9bc84)

### Issues Resolved

Closes #546 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
