### PR TITLE
fix error that local cluster cannot get version

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -119,7 +119,7 @@ export function ProcessorsList(props: ProcessorsListProps) {
       return;
     }
 
-    if (dataSourceId) {
+    if (dataSourceId !== undefined) {
       getEffectiveVersion(dataSourceId)
         .then((ver) => {
           setVersion(ver);

--- a/public/pages/workflows/new_workflow/new_workflow.test.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.test.tsx
@@ -40,6 +40,10 @@ const initialState = {
     presetWorkflows: loadPresetWorkflowTemplates(),
   },
   workflows: INITIAL_WORKFLOWS_STATE,
+  opensearch: {
+    loading: false,
+    localClusterVersion: null,
+  },
 };
 
 const mockDispatch = jest.fn();

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -116,6 +116,7 @@ export function NewWorkflow(props: NewWorkflowProps) {
   // 1. fetch the workflow presets persisted on server-side
   // 2. fetch the ML models and connectors. these may be used in quick-create views when selecting a preset,
   //    so we optimize by fetching once at the top-level here.
+  // 3. fetch local cluster version if applicable
   useEffect(() => {
     dispatch(getWorkflowPresets());
     if (isDataSourceReady(dataSourceId)) {
@@ -124,6 +125,7 @@ export function NewWorkflow(props: NewWorkflowProps) {
         searchConnectors({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId })
       );
     }
+    // if use local cluster
     if (dataSourceId === '') {
       dispatch(getLocalClusterVersion());
     }

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -148,6 +148,7 @@ export interface RouteService {
     pipelineId: string,
     dataSourceId?: string
   ) => Promise<any | HttpFetchError>;
+  getLocalClusterVersion: () => Promise<any | HttpFetchError>;
 }
 
 export function configureRoutes(core: CoreStart): RouteService {
@@ -323,6 +324,17 @@ export function configureRoutes(core: CoreStart): RouteService {
         return e as HttpFetchError;
       }
     },
+    getLocalClusterVersion: async () => {
+      try {
+        const response = await core.http.post('/api/console/proxy', {
+          query: { path: '/', method: 'GET', dataSourceId: '' },
+        });
+        return response.version.number;
+      } catch (e: any) {
+        return e as HttpFetchError;
+      }
+    },
+
     getIndex: async (index: string, dataSourceId?: string) => {
       try {
         const url = dataSourceId

--- a/public/store/reducers/presets_reducer.ts
+++ b/public/store/reducers/presets_reducer.ts
@@ -51,8 +51,8 @@ const presetsSlice = createSlice({
         state.errorMessage = '';
       })
       .addCase(getWorkflowPresets.rejected, (state, action) => {
-        state.errorMessage = action.payload as string;
         state.loading = false;
+        state.errorMessage = action.payload as string;
       });
   },
 });

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -47,6 +47,7 @@ import {
 import {
   getCore,
   getDataSourceEnabled,
+  getRouteService,
   getSavedObjectsClient,
 } from '../services';
 import {
@@ -891,6 +892,11 @@ export const getEffectiveVersion = async (
   try {
     if (dataSourceId === undefined) {
       throw new Error('Data source is required');
+    }
+
+    if (dataSourceId === '') {
+      // Use route service for local cluster case
+      return await getRouteService().getLocalClusterVersion();
     }
 
     const dataSource = await getSavedObjectsClient().get<DataSourceAttributes>(


### PR DESCRIPTION
### Description

Currently in the new work flow page, when user click local data source, it shows a loading state and does not render any presets. This PR fix this issue by getting version from the datasource and render the presets based on the data source version.

### Issues Resolved

None

### UI changes after code change
#### for version 2.19
![Xnip2025-02-07_00-07-07](https://github.com/user-attachments/assets/1cd7c0ce-7231-438b-8c49-0ca630377cf9)
#### for version 2.17
![Xnip2025-02-07_00-16-27](https://github.com/user-attachments/assets/2d6fa04f-21df-4b93-8b02-ed3bff0125cc)


### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
