### PR TITLE
adding prompt when datasource is not compatible

### DIFF
--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -35,3 +35,8 @@ export const BREADCRUMBS = Object.freeze({
 });
 
 export const USE_NEW_HOME_PAGE = getUISettings().get('home:useNewHomePage');
+
+export const getAppBasePath = () => {
+  const currentPath = window.location.pathname;
+  return currentPath.substring(0, currentPath.indexOf('/app/'));
+};


### PR DESCRIPTION
### Description

- This case is applicable to when datasource is enabled. 
- And when the current using datasources are not compatible with opensearch flow. Then datasourceId will not be present in url. 

- In the above mentioned case, displaying prompt message for users saying datasources are incompatible and add more compatible datasources. 

### Issues Resolved

https://github.com/opensearch-project/dashboards-flow-framework/pull/537#issuecomment-2635518053


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
