### PR TITLE
Simplify RAG presets

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -250,6 +250,8 @@ export const BULK_API_DOCS_LINK =
   'https://opensearch.org/docs/latest/api-reference/document-apis/bulk/';
 export const SEARCH_PIPELINE_DOCS_LINK =
   'https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/';
+export const ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK =
+  'https://opensearch.org/docs/latest/search-plugins/search-pipelines/ml-inference-search-response/#example-externally-hosted-text-embedding-model';
 
 /**
  * Text chunking algorithm constants

--- a/public/general_components/results/ml_response.tsx
+++ b/public/general_components/results/ml_response.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { isEmpty } from 'lodash';
+import {
+  EuiCode,
+  EuiCodeEditor,
+  EuiEmptyPrompt,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import {
+  customStringify,
+  ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK,
+} from '../../../common';
+
+interface MLResponseProps {
+  mlResponse: {};
+}
+
+/**
+ * Small component to render the ML response within a raw search response.
+ */
+export function MLResponse(props: MLResponseProps) {
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiText size="s">
+        Showing results stored in <EuiCode>ext.ml_inference</EuiCode> from the
+        search response.{' '}
+        <EuiLink href={ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK} target="_blank">
+          See an example
+        </EuiLink>
+      </EuiText>
+      <EuiSpacer size="m" />
+      {isEmpty(props.mlResponse) ? (
+        <EuiEmptyPrompt title={<h2>No response found</h2>} titleSize="s" />
+      ) : (
+        <EuiCodeEditor
+          mode="json"
+          theme="textmate"
+          width="100%"
+          height="100%"
+          value={customStringify(props.mlResponse)}
+          readOnly={true}
+          setOptions={{
+            fontSize: '12px',
+            autoScrollEditorIntoView: true,
+            wrap: true,
+          }}
+          tabSize={2}
+        />
+      )}
+    </>
+  );
+}

--- a/public/general_components/results/results.tsx
+++ b/public/general_components/results/results.tsx
@@ -13,6 +13,8 @@ import {
 import { SearchResponse } from '../../../common';
 import { ResultsTable } from './results_table';
 import { ResultsJSON } from './results_json';
+import { MLResponse } from './ml_response';
+import { get } from 'lodash';
 
 interface ResultsProps {
   response: SearchResponse;
@@ -21,6 +23,7 @@ interface ResultsProps {
 enum VIEW {
   HITS_TABLE = 'hits_table',
   RAW_JSON = 'raw_json',
+  ML_RESPONSE = 'ml_response',
 }
 
 /**
@@ -55,6 +58,10 @@ export function Results(props: ResultsProps) {
                 id: VIEW.RAW_JSON,
                 label: 'Raw JSON',
               },
+              {
+                id: VIEW.ML_RESPONSE,
+                label: 'ML response',
+              },
             ]}
             idSelected={selectedView}
             onChange={(id) => setSelectedView(id as VIEW)}
@@ -69,9 +76,18 @@ export function Results(props: ResultsProps) {
             {selectedView === VIEW.RAW_JSON && (
               <ResultsJSON response={props.response} />
             )}
+            {selectedView === VIEW.ML_RESPONSE && (
+              <MLResponse
+                mlResponse={getMLResponseFromSearchResponse(props.response)}
+              />
+            )}
           </>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>
   );
+}
+
+function getMLResponseFromSearchResponse(searchResponse: SearchResponse): {} {
+  return get(searchResponse, 'ext.ml_inference', {});
 }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -741,7 +741,8 @@ function updateRAGSearchResponseProcessors(
   llmInterface: ModelInterface | undefined
 ): WorkflowConfig {
   config.search.enrichResponse.processors.forEach((processor, idx) => {
-    // prefill ML inference
+    // prefill ML inference. By default, store the inference results
+    // under the `ext.ml_inference` response body.
     if (processor.type === PROCESSOR_TYPE.ML) {
       config.search.enrichResponse.processors[idx].fields.forEach((field) => {
         if (field.id === 'model' && fields.llmId) {
@@ -784,7 +785,7 @@ function updateRAGSearchResponseProcessors(
                 ...outputMap[0],
                 value: {
                   transformType: TRANSFORM_TYPE.FIELD,
-                  value: fields.llmResponseField,
+                  value: `ext.ml_inference.${fields.llmResponseField}`,
                 },
               };
             } else {

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  CollapseProcessor,
   MLIngestProcessor,
   MLSearchRequestProcessor,
   MLSearchResponseProcessor,
@@ -253,7 +252,6 @@ export function fetchRAGMetadata(version: string): UIState {
   baseState.config.search.request.value = customStringify(FETCH_ALL_QUERY);
   baseState.config.search.enrichResponse.processors = [
     new MLSearchResponseProcessor().toObj(),
-    new CollapseProcessor().toObj(),
   ];
   return baseState;
 }
@@ -278,7 +276,6 @@ export function fetchVectorSearchWithRAGMetadata(version: string): UIState {
   ];
   baseState.config.search.enrichResponse.processors = [
     new MLSearchResponseProcessor().toObj(),
-    new CollapseProcessor().toObj(),
   ];
   return baseState;
 }


### PR DESCRIPTION
### Description

This PR simplifies the RAG presets by leveraging the `ext.ml_inference` result storing offered from ML inference search response processors. As a result, the workaround `collapse` processor can be removed. The presets have been updated, and the ML processor output now has a dedicated tab for displaying the results.



### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
