### PR TITLE
Support 2.17 BWC with latest backend integrations

### DIFF
--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -36,6 +36,7 @@ import {
   containsEmptyValues,
   containsSameValues,
   getDataSourceId,
+  getEffectiveVersion,
   getPlaceholdersFromQuery,
   getSearchPipelineErrors,
   injectParameters,
@@ -64,6 +65,17 @@ const SEARCH_OPTIONS = [
 export function Query(props: QueryProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const [dataSourceVersion, setDataSourceVersion] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    async function getVersion() {
+      if (dataSourceId !== undefined) {
+        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
+      }
+    }
+    getVersion();
+  }, [dataSourceId]);
 
   const { loading } = useSelector((state: AppState) => state.opensearch);
 
@@ -204,6 +216,7 @@ export function Query(props: QueryProps) {
                                 : '_none',
                             },
                             dataSourceId,
+                            dataSourceVersion,
                             verbose: includePipeline,
                           })
                         )

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -29,8 +29,11 @@ import {
   WorkflowConfig,
   WorkflowFormValues,
 } from '../../../../common';
-import { formikToUiConfig, getDataSourceFromURL } from '../../../utils';
-import { getEffectiveVersion } from '../../../pages/workflows/new_workflow/new_workflow';
+import {
+  formikToUiConfig,
+  getDataSourceFromURL,
+  getEffectiveVersion,
+} from '../../../utils';
 import {
   CollapseProcessor,
   CopyIngestProcessor,

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -15,8 +15,7 @@ import {
   WorkflowConfig,
 } from '../../../../../common';
 import { catIndices, useAppDispatch } from '../../../../store';
-import { getDataSourceId } from '../../../../utils';
-import { getEffectiveVersion } from '../../../workflows/new_workflow/new_workflow';
+import { getDataSourceId, getEffectiveVersion } from '../../../../utils';
 
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
@@ -42,8 +41,10 @@ export function SearchInputs(props: SearchInputsProps) {
   useEffect(() => {
     const checkVersion = async () => {
       try {
-        const version = await getEffectiveVersion(dataSourceId);
-        setShowTransformQuery(semver.gte(version, '2.19.0'));
+        if (dataSourceId !== undefined) {
+          const version = await getEffectiveVersion(dataSourceId);
+          setShowTransformQuery(semver.gte(version, '2.19.0'));
+        }
       } catch (error) {
         console.error('Error checking version:', error);
         setShowTransformQuery(true);

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -451,6 +451,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
       )
         .unwrap()
         .then(async (result) => {
+          await sleep(100);
           await dispatch(
             updateWorkflow({
               apiBody: {
@@ -463,6 +464,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           )
             .unwrap()
             .then(async (result) => {
+              await sleep(100);
               props.setUnsavedIngestProcessors(false);
               props.setUnsavedSearchProcessors(false);
               await dispatch(
@@ -474,6 +476,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               )
                 .unwrap()
                 .then(async (result) => {
+                  await sleep(100);
                   // if the datasource < 2.19, only async provisioning/reprovisioning is supported.
                   // so, we manually wait some time before trying to fetch the updated workflow
                   if (isPreV219) {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
 import { isEmpty, isEqual } from 'lodash';
+import semver from 'semver';
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -23,6 +24,7 @@ import {
 import {
   CONFIG_STEP,
   CachedFormikState,
+  MINIMUM_FULL_SUPPORTED_VERSION,
   SimulateIngestPipelineResponseVerbose,
   TemplateNode,
   WORKFLOW_STEP_TYPE,
@@ -56,6 +58,8 @@ import {
   getDataSourceId,
   prepareDocsForSimulate,
   getIngestPipelineErrors,
+  getEffectiveVersion,
+  sleep,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -97,6 +101,21 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   } = useFormikContext<WorkflowFormValues>();
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const [dataSourceVersion, setDataSourceVersion] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    async function getVersion() {
+      if (dataSourceId !== undefined) {
+        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
+      }
+    }
+    getVersion();
+  }, [dataSourceId]);
+  const isPreV219 =
+    dataSourceVersion !== undefined
+      ? semver.lt(dataSourceVersion, MINIMUM_FULL_SUPPORTED_VERSION)
+      : false;
 
   // transient running states
   const [isUpdatingSearchPipeline, setIsUpdatingSearchPipeline] = useState<
@@ -390,10 +409,16 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
             reprovision: true,
           },
           dataSourceId,
+          dataSourceVersion,
         })
       )
         .unwrap()
         .then(async (result) => {
+          // if the datasource < 2.19, only async provisioning/reprovisioning is supported.
+          // so, we manually wait some time before trying to fetch the updated workflow
+          if (isPreV219) {
+            await sleep(1000);
+          }
           props.setUnsavedIngestProcessors(false);
           props.setUnsavedSearchProcessors(false);
           success = true;
@@ -444,10 +469,16 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 provisionWorkflow({
                   workflowId: updatedWorkflow.id as string,
                   dataSourceId,
+                  dataSourceVersion,
                 })
               )
                 .unwrap()
                 .then(async (result) => {
+                  // if the datasource < 2.19, only async provisioning/reprovisioning is supported.
+                  // so, we manually wait some time before trying to fetch the updated workflow
+                  if (isPreV219) {
+                    await sleep(1000);
+                  }
                   await dispatch(
                     getWorkflow({
                       workflowId: updatedWorkflow.id as string,

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -27,11 +27,13 @@ import {
   searchConnectors,
 } from '../../../store';
 import { enrichPresetWorkflowWithUiMetadata } from './utils';
-import { getDataSourceId, isDataSourceReady } from '../../../utils';
+import {
+  getDataSourceId,
+  isDataSourceReady,
+  getEffectiveVersion,
+} from '../../../utils';
 import { getDataSourceEnabled } from '../../../services';
 import semver from 'semver';
-import { DataSourceAttributes } from '../../../../../../src/plugins/data_source/common/data_sources';
-import { getSavedObjectsClient } from '../../../../public/services';
 import {
   WORKFLOW_TYPE,
   MIN_SUPPORTED_VERSION,
@@ -39,27 +41,6 @@ import {
 } from '../../../../common/constants';
 
 interface NewWorkflowProps {}
-
-export const getEffectiveVersion = async (
-  dataSourceId: string | undefined
-): Promise<string> => {
-  try {
-    if (dataSourceId === undefined) {
-      throw new Error('Data source is required');
-    }
-
-    const dataSource = await getSavedObjectsClient().get<DataSourceAttributes>(
-      'data-source',
-      dataSourceId
-    );
-    const version =
-      dataSource?.attributes?.dataSourceVersion || MIN_SUPPORTED_VERSION;
-    return version;
-  } catch (error) {
-    console.error('Error getting version:', error);
-    return MIN_SUPPORTED_VERSION;
-  }
-};
 
 const filterPresetsByVersion = async (
   workflows: WorkflowTemplate[],

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -30,6 +30,7 @@ import {
   INGEST_PIPELINE_NODE_API_PATH,
   GET_INDEX_NODE_API_PATH,
 } from '../common';
+import { getEffectiveVersion } from './utils';
 
 /**
  * A simple client-side service interface containing all of the available node API functions.
@@ -60,11 +61,13 @@ export interface RouteService {
     workflowTemplate: WorkflowTemplate,
     updateFields: boolean,
     reprovision: boolean,
-    dataSourceId?: string
+    dataSourceId?: string,
+    dataSourceVersion?: string
   ) => Promise<any | HttpFetchError>;
   provisionWorkflow: (
     workflowId: string,
-    dataSourceId?: string
+    dataSourceId?: string,
+    dataSourceVersion?: string
   ) => Promise<any | HttpFetchError>;
   deprovisionWorkflow: ({
     workflowId,
@@ -205,7 +208,8 @@ export function configureRoutes(core: CoreStart): RouteService {
       workflowTemplate: WorkflowTemplate,
       updateFields: boolean,
       reprovision: boolean,
-      dataSourceId?: string
+      dataSourceId?: string,
+      dataSourceVersion?: string
     ) => {
       try {
         const url = dataSourceId
@@ -215,6 +219,9 @@ export function configureRoutes(core: CoreStart): RouteService {
           `${url}/${workflowId}/${updateFields}/${reprovision}`,
           {
             body: JSON.stringify(workflowTemplate),
+            query: {
+              data_source_version: dataSourceVersion,
+            },
           }
         );
         return response;
@@ -222,13 +229,22 @@ export function configureRoutes(core: CoreStart): RouteService {
         return e as HttpFetchError;
       }
     },
-    provisionWorkflow: async (workflowId: string, dataSourceId?: string) => {
+    provisionWorkflow: async (
+      workflowId: string,
+      dataSourceId?: string,
+      dataSourceVersion?: string
+    ) => {
       try {
         const url = dataSourceId
           ? `${BASE_NODE_API_PATH}/${dataSourceId}/workflow/provision`
           : PROVISION_WORKFLOW_NODE_API_PATH;
         const response = await core.http.post<{ respString: string }>(
-          `${url}/${workflowId}`
+          `${url}/${workflowId}`,
+          {
+            query: {
+              data_source_version: dataSourceVersion,
+            },
+          }
         );
         return response;
       } catch (e: any) {

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -30,7 +30,6 @@ import {
   INGEST_PIPELINE_NODE_API_PATH,
   GET_INDEX_NODE_API_PATH,
 } from '../common';
-import { getEffectiveVersion } from './utils';
 
 /**
  * A simple client-side service interface containing all of the available node API functions.
@@ -99,12 +98,14 @@ export interface RouteService {
     index,
     body,
     dataSourceId,
+    dataSourceVersion,
     searchPipeline,
     verbose,
   }: {
     index: string;
     body: {};
     dataSourceId?: string;
+    dataSourceVersion?: string;
     searchPipeline?: string;
     verbose?: boolean;
   }) => Promise<any | HttpFetchError>;
@@ -339,12 +340,14 @@ export function configureRoutes(core: CoreStart): RouteService {
       index,
       body,
       dataSourceId,
+      dataSourceVersion,
       searchPipeline,
       verbose,
     }: {
       index: string;
       body: {};
       dataSourceId?: string;
+      dataSourceVersion?: string;
       searchPipeline?: string;
       verbose?: boolean;
     }) => {
@@ -360,6 +363,7 @@ export function configureRoutes(core: CoreStart): RouteService {
           body: JSON.stringify(body),
           query: {
             verbose: verbose ?? false,
+            data_source_version: dataSourceVersion,
           },
         });
         return response;

--- a/public/store/reducers/opensearch_reducer.ts
+++ b/public/store/reducers/opensearch_reducer.ts
@@ -110,10 +110,12 @@ export const searchIndex = createAsyncThunk(
     {
       apiBody,
       dataSourceId,
+      dataSourceVersion,
       verbose,
     }: {
       apiBody: { index: string; body: {}; searchPipeline?: string };
       dataSourceId?: string;
+      dataSourceVersion?: string;
       verbose?: boolean;
     },
     { rejectWithValue }
@@ -123,6 +125,7 @@ export const searchIndex = createAsyncThunk(
       index,
       body,
       dataSourceId,
+      dataSourceVersion,
       searchPipeline,
       verbose,
     });

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -116,6 +116,7 @@ export const updateWorkflow = createAsyncThunk(
     {
       apiBody,
       dataSourceId,
+      dataSourceVersion,
     }: {
       apiBody: {
         workflowId: string;
@@ -124,6 +125,7 @@ export const updateWorkflow = createAsyncThunk(
         reprovision?: boolean;
       };
       dataSourceId?: string;
+      dataSourceVersion?: string;
     },
     { rejectWithValue }
   ) => {
@@ -135,7 +137,8 @@ export const updateWorkflow = createAsyncThunk(
       workflowTemplate,
       updateFields || false,
       reprovision || false,
-      dataSourceId
+      dataSourceId,
+      dataSourceVersion
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue(
@@ -150,14 +153,23 @@ export const updateWorkflow = createAsyncThunk(
 export const provisionWorkflow = createAsyncThunk(
   PROVISION_WORKFLOW_ACTION,
   async (
-    { workflowId, dataSourceId }: { workflowId: string; dataSourceId?: string },
+    {
+      workflowId,
+      dataSourceId,
+      dataSourceVersion,
+    }: {
+      workflowId: string;
+      dataSourceId?: string;
+      dataSourceVersion?: string;
+    },
     { rejectWithValue }
   ) => {
     const response:
       | any
       | HttpFetchError = await getRouteService().provisionWorkflow(
       workflowId,
-      dataSourceId
+      dataSourceId,
+      dataSourceVersion
     );
     if (response instanceof HttpFetchError) {
       return rejectWithValue(

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -194,7 +194,7 @@ export function processorConfigsToTemplateProcessors(
 
         let processor = {
           ml_inference: {
-            model_id: model.id,
+            model_id: model?.id || '',
           },
         } as MLInferenceProcessor;
 
@@ -378,11 +378,11 @@ export function processorConfigsToTemplateProcessors(
           );
         });
         // remove the model field, update to just the required model ID
-        const model = finalFormValues.model;
+        const model = finalFormValues?.model;
         delete finalFormValues.model;
         finalFormValues = {
           ...finalFormValues,
-          model_id: model.id,
+          model_id: model?.id || '',
         };
 
         // add the field map config obj

--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -40,8 +40,13 @@ import {
   LABEL_FIELD_PATTERN,
   MODEL_ID_PATTERN,
   WORKFLOW_TYPE,
+  MIN_SUPPORTED_VERSION,
 } from '../../common';
-import { getCore, getDataSourceEnabled } from '../services';
+import {
+  getCore,
+  getDataSourceEnabled,
+  getSavedObjectsClient,
+} from '../services';
 import {
   Connector,
   IngestPipelineErrors,
@@ -858,3 +863,25 @@ export function getFieldValue(jsonObj: {}, fieldName: string): any | undefined {
   }
   return undefined;
 }
+
+// Get the version from the selected data source
+export const getEffectiveVersion = async (
+  dataSourceId: string | undefined
+): Promise<string> => {
+  try {
+    if (dataSourceId === undefined) {
+      throw new Error('Data source is required');
+    }
+
+    const dataSource = await getSavedObjectsClient().get<DataSourceAttributes>(
+      'data-source',
+      dataSourceId
+    );
+    const version =
+      dataSource?.attributes?.dataSourceVersion || MIN_SUPPORTED_VERSION;
+    return version;
+  } catch (error) {
+    console.error('Error getting version:', error);
+    return MIN_SUPPORTED_VERSION;
+  }
+};

--- a/server/cluster/flow_framework_plugin.ts
+++ b/server/cluster/flow_framework_plugin.ts
@@ -110,9 +110,40 @@ export function flowFrameworkPlugin(Client: any, config: any, components: any) {
     method: 'PUT',
   });
 
+  flowFramework.updateAndReprovisionWorkflowAsync = ca({
+    url: {
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>?update_fields=<%=update_fields%>&reprovision=true`,
+      req: {
+        workflow_id: {
+          type: 'string',
+          required: true,
+        },
+        update_fields: {
+          type: 'boolean',
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: 'PUT',
+  });
+
   flowFramework.provisionWorkflow = ca({
     url: {
       fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>/_provision?wait_for_completion_timeout=${PROVISION_TIMEOUT}`,
+      req: {
+        workflow_id: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'POST',
+  });
+
+  flowFramework.provisionWorkflowAsync = ca({
+    url: {
+      fmt: `${FLOW_FRAMEWORK_WORKFLOW_ROUTE_PREFIX}/<%=workflow_id%>/_provision`,
       req: {
         workflow_id: {
           type: 'string',

--- a/server/routes/flow_framework_routes_service.ts
+++ b/server/routes/flow_framework_routes_service.ts
@@ -174,7 +174,7 @@ export function registerFlowFrameworkRoutes(
         }),
         body: schema.any(),
         query: schema.object({
-          data_source_version: schema.string(),
+          data_source_version: schema.maybe(schema.string()),
         }),
       },
     },
@@ -202,7 +202,7 @@ export function registerFlowFrameworkRoutes(
           data_source_id: schema.string(),
         }),
         query: schema.object({
-          data_source_version: schema.string(),
+          data_source_version: schema.maybe(schema.string()),
         }),
       },
     },

--- a/server/routes/opensearch_routes_service.ts
+++ b/server/routes/opensearch_routes_service.ts
@@ -140,7 +140,7 @@ export function registerOpenSearchRoutes(
         body: schema.any(),
         query: schema.object({
           verbose: schema.boolean(),
-          data_source_version: schema.string(),
+          data_source_version: schema.maybe(schema.string()),
         }),
       },
     },
@@ -174,7 +174,7 @@ export function registerOpenSearchRoutes(
         body: schema.any(),
         query: schema.object({
           verbose: schema.boolean(),
-          data_source_version: schema.string(),
+          data_source_version: schema.maybe(schema.string()),
         }),
       },
     },


### PR DESCRIPTION
### Description

#591 and #598 added integrations with backend API enhancements only available in 2.19+. Since we want to support 2.17 backend datasources as well, we need to have conditional logic for executing these updated APIs. This PR adds that logic by:
1. Only running synchronous provisioning if the data source version is >=2.19
2. Only running the search with `verbose_pipeline=true` if the data source version is >=2.19.
It does this by propagating the data source version where applicable, and executing different APIs based on the semver checks.

Also adds an NPE check on the model fields in the legacy processors during template conversion.

Testing:
- tested without any datasource, with datasource 2.19+, and with datasource <2.19 for both APIs
- audited all places where API is triggered from client-side for both APIs to ensure we pass the datasource version where applicable

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
