### PR TITLE
Improve RAG preset experience

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -281,8 +281,8 @@ export type SearchPipelineConfig = {
 export type MLInferenceProcessor = IngestProcessor & {
   ml_inference: {
     model_id: string;
-    input_map?: {};
-    output_map?: {};
+    input_map?: {}[];
+    output_map?: {}[];
     [key: string]: any;
   };
 };

--- a/public/general_components/results/ml_outputs.tsx
+++ b/public/general_components/results/ml_outputs.tsx
@@ -18,34 +18,26 @@ import {
   ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK,
 } from '../../../common';
 
-interface MLResponseProps {
-  mlResponse: {};
+interface MLOutputsProps {
+  mlOutputs: {};
 }
 
 /**
- * Small component to render the ML response within a raw search response.
+ * Small component to render the ML outputs within a raw search response.
  */
-export function MLResponse(props: MLResponseProps) {
+export function MLOutputs(props: MLOutputsProps) {
   return (
     <>
       <EuiSpacer size="s" />
-      <EuiText size="s">
-        Showing results stored in <EuiCode>ext.ml_inference</EuiCode> from the
-        search response.{' '}
-        <EuiLink href={ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK} target="_blank">
-          See an example
-        </EuiLink>
-      </EuiText>
-      <EuiSpacer size="m" />
-      {isEmpty(props.mlResponse) ? (
-        <EuiEmptyPrompt title={<h2>No response found</h2>} titleSize="s" />
+      {isEmpty(props.mlOutputs) ? (
+        <EuiEmptyPrompt title={<h2>No outputs found</h2>} titleSize="s" />
       ) : (
         <EuiCodeEditor
           mode="json"
           theme="textmate"
           width="100%"
           height="100%"
-          value={customStringify(props.mlResponse)}
+          value={customStringify(props.mlOutputs)}
           readOnly={true}
           setOptions={{
             fontSize: '12px',
@@ -55,6 +47,14 @@ export function MLResponse(props: MLResponseProps) {
           tabSize={2}
         />
       )}
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        Showing ML outputs stored in <EuiCode>ext.ml_inference</EuiCode> from
+        the search response.{' '}
+        <EuiLink href={ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK} target="_blank">
+          See an example
+        </EuiLink>
+      </EuiText>
     </>
   );
 }

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -741,8 +741,7 @@ function updateRAGSearchResponseProcessors(
   llmInterface: ModelInterface | undefined
 ): WorkflowConfig {
   config.search.enrichResponse.processors.forEach((processor, idx) => {
-    // prefill ML inference. By default, store the inference results
-    // under the `ext.ml_inference` response body.
+    // prefill ML inference
     if (processor.type === PROCESSOR_TYPE.ML) {
       config.search.enrichResponse.processors[idx].fields.forEach((field) => {
         if (field.id === 'model' && fields.llmId) {
@@ -785,7 +784,7 @@ function updateRAGSearchResponseProcessors(
                 ...outputMap[0],
                 value: {
                   transformType: TRANSFORM_TYPE.FIELD,
-                  value: `ext.ml_inference.${fields.llmResponseField}`,
+                  value: fields.llmResponseField,
                 },
               };
             } else {


### PR DESCRIPTION
### Description

This improves the RAG preset experience in a few ways:
1. Changes the default behavior of ML response processors (when configured for many-to-one), to store the outputs under `ext.ml_inference` by default. This way, a single ML response is returned in the overall response by default for these scenarios. Existing functionality for ML response processors in other contexts, and/or when one-to-one is configured, remains unchanged.
2. Auto-navigate to the 'ML outputs' tab if there is values found
3. Re-ordering and minor renaming of the tabs under 'Results'
4. Minor reformatting the 'ML outputs' tab content

Demo video, showing the end-to-end RAG preset experience and propagation of the LLM response:

[screen-capture (24).webm](https://github.com/user-attachments/assets/b05de284-b380-4655-af73-85f237d04009)


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
