### PR TITLE
UX fit-n-finish updates XII

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -170,6 +170,13 @@ export enum WORKFLOW_TYPE {
   CUSTOM = 'Custom Search',
   UNKNOWN = 'Unknown',
 }
+export enum WORKFLOW_TYPE_LEGACY {
+  SEMANTIC_SEARCH = 'Semantic Search',
+  MULTIMODAL_SEARCH = 'Multimodal Search',
+  HYBRID_SEARCH = 'Hybrid Search',
+  CUSTOM = 'Custom Search',
+  UNKNOWN = 'Unknown',
+}
 // If no datasource version is found, we default to 2.17.0
 export const MIN_SUPPORTED_VERSION = '2.17.0';
 // Min version to support ML processors

--- a/public/pages/workflow_detail/tools/errors/errors.tsx
+++ b/public/pages/workflow_detail/tools/errors/errors.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   EuiCodeBlock,
   EuiEmptyPrompt,
@@ -12,7 +12,7 @@ import {
 } from '@elastic/eui';
 
 interface ErrorsProps {
-  errorMessages: string[];
+  errorMessages: (string | ReactNode)[];
 }
 
 /**

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../../store';
 import { isEmpty } from 'lodash';
@@ -26,6 +26,7 @@ import { Query } from './query';
 import { Ingest } from './ingest';
 import { Errors } from './errors';
 import {
+  formatProcessorError,
   hasProvisionedIngestResources,
   hasProvisionedSearchResources,
 } from '../../../utils';
@@ -52,7 +53,9 @@ export function Tools(props: ToolsProps) {
     ingestPipeline: ingestPipelineErrors,
     searchPipeline: searchPipelineErrors,
   } = useSelector((state: AppState) => state.errors);
-  const [curErrorMessages, setCurErrorMessages] = useState<string[]>([]);
+  const [curErrorMessages, setCurErrorMessages] = useState<
+    (string | ReactNode)[]
+  >([]);
 
   // Propagate any errors coming from opensearch API calls, including ingest/search pipeline verbose calls.
   useEffect(() => {
@@ -66,12 +69,16 @@ export function Tools(props: ToolsProps) {
       } else if (!isEmpty(ingestPipelineErrors)) {
         setCurErrorMessages([
           'Data not ingested. Errors found with the following ingest processor(s):',
-          ...Object.values(ingestPipelineErrors).map((value) => value.errorMsg),
+          ...Object.values(ingestPipelineErrors).map((ingestPipelineError) =>
+            formatProcessorError(ingestPipelineError)
+          ),
         ]);
       } else if (!isEmpty(searchPipelineErrors)) {
         setCurErrorMessages([
           'Errors found with the following search processor(s)',
-          ...Object.values(searchPipelineErrors).map((value) => value.errorMsg),
+          ...Object.values(searchPipelineErrors).map((searchPipelineError) =>
+            formatProcessorError(searchPipelineError)
+          ),
         ]);
       }
     } else {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -112,8 +112,8 @@ export function SourceData(props: SourceDataProps) {
                 <h3>Import sample data</h3>
               </EuiText>
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              {docsPopulated ? (
+            {docsPopulated && (
+              <EuiFlexItem grow={false}>
                 <EuiSmallButtonEmpty
                   onClick={() => setIsEditModalOpen(true)}
                   data-testid="editSourceDataButton"
@@ -122,19 +122,8 @@ export function SourceData(props: SourceDataProps) {
                 >
                   Edit
                 </EuiSmallButtonEmpty>
-              ) : (
-                <EuiSmallButton
-                  fill={false}
-                  style={{ width: '75px' }}
-                  onClick={() => setIsEditModalOpen(true)}
-                  data-testid="selectDataToImportButton"
-                  iconType="plus"
-                  iconSide="left"
-                >
-                  {`Import`}
-                </EuiSmallButton>
-              )}
-            </EuiFlexItem>
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
         </EuiFlexItem>
         {props.lastIngested !== undefined && (
@@ -208,6 +197,17 @@ export function SourceData(props: SourceDataProps) {
                 <EuiText size="s">
                   Import a data sample to start configuring your ingest flow.
                 </EuiText>
+                <EuiSpacer size="m" />
+                <EuiSmallButton
+                  fill={true}
+                  style={{ width: '130px' }}
+                  onClick={() => setIsEditModalOpen(true)}
+                  data-testid="selectDataToImportButton"
+                  iconType="plus"
+                  iconSide="left"
+                >
+                  {`Import data`}
+                </EuiSmallButton>
               </>
             }
           />

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -147,7 +147,7 @@ export function ModelField(props: ModelFieldProps) {
               isInvalid={isInvalid}
               error={props.showError && getIn(errors, `${field.name}.id`)}
             >
-              <EuiFlexGroup direction="row" gutterSize="none">
+              <EuiFlexGroup direction="row" gutterSize="xs">
                 <EuiFlexItem grow={true}>
                   <EuiCompressedSuperSelect
                     data-testid="selectDeployedModel"

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -15,7 +15,6 @@ import {
   EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
-  EuiSmallButton,
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -25,7 +24,6 @@ import {
   WorkflowFormValues,
   ModelFormValue,
   ML_CHOOSE_MODEL_LINK,
-  ML_REMOTE_MODEL_LINK,
   FETCH_ALL_QUERY_LARGE,
 } from '../../../../../common';
 import { AppState, searchModels, useAppDispatch } from '../../../../store';
@@ -101,31 +99,6 @@ export function ModelField(props: ModelFieldProps) {
             <EuiSpacer size="s" />
           </>
         )}
-      {isEmpty(deployedModels) && (
-        <>
-          <EuiCallOut
-            size="s"
-            title="No deployed models found"
-            iconType={'alert'}
-            color="warning"
-          >
-            <EuiText size="s">
-              To create and deploy models and make them accessible in
-              OpenSearch, see documentation.
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EuiSmallButton
-              target="_blank"
-              href={ML_REMOTE_MODEL_LINK}
-              iconSide="right"
-              iconType={'popout'}
-            >
-              Documentation
-            </EuiSmallButton>
-          </EuiCallOut>
-          <EuiSpacer size="s" />
-        </>
-      )}
       <Field name={props.fieldPath}>
         {({ field, form }: FieldProps) => {
           const isInvalid =

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -31,6 +31,7 @@ import {
   OutputMapArrayFormValue,
   EMPTY_OUTPUT_MAP_ENTRY,
   ML_REMOTE_MODEL_LINK,
+  FETCH_ALL_QUERY_LARGE,
 } from '../../../../../../common';
 import { ModelField } from '../../input_fields';
 import {
@@ -39,9 +40,10 @@ import {
 } from '../../../../../../common';
 import { OverrideQueryModal } from './modals';
 import { ModelInputs } from './model_inputs';
-import { AppState } from '../../../../../store';
+import { AppState, searchModels, useAppDispatch } from '../../../../../store';
 import {
   formikToPartialPipeline,
+  getDataSourceId,
   parseModelInputs,
   parseModelOutputs,
 } from '../../../../../utils';
@@ -62,6 +64,8 @@ interface MLProcessorInputsProps {
  * output map configuration forms, respectively.
  */
 export function MLProcessorInputs(props: MLProcessorInputsProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
   const { models } = useSelector((state: AppState) => state.ml);
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
@@ -191,11 +195,30 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
           color="primary"
           size="s"
           title={
-            <EuiText size="s">
-              You have no models registered in your cluster.{' '}
-              <EuiLink href={ML_REMOTE_MODEL_LINK}>Learn more</EuiLink> about
-              integrating ML models.
-            </EuiText>
+            <>
+              <EuiText size="s">
+                You have no models registered in your cluster.{' '}
+                <EuiLink href={ML_REMOTE_MODEL_LINK} target="_blank">
+                  Learn more
+                </EuiLink>{' '}
+                about integrating ML models.
+              </EuiText>
+              <EuiSpacer size="s" />
+              <EuiSmallButton
+                iconType={'refresh'}
+                iconSide="left"
+                onClick={() => {
+                  dispatch(
+                    searchModels({
+                      apiBody: FETCH_ALL_QUERY_LARGE,
+                      dataSourceId,
+                    })
+                  );
+                }}
+              >
+                Refresh
+              </EuiSmallButton>
+            </>
           }
         />
       ) : (

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/edit_query_modal.tsx
@@ -23,6 +23,7 @@ import {
   EuiText,
   EuiEmptyPrompt,
   EuiCallOut,
+  EuiSpacer,
 } from '@elastic/eui';
 import { JsonField } from '../input_fields';
 import {
@@ -85,7 +86,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false);
 
   // optional search panel state. allows searching within the modal
-  const [searchPanelOpen, setSearchPanelOpen] = useState<boolean>(false);
+  const [searchPanelOpen, setSearchPanelOpen] = useState<boolean>(true);
 
   // results state
   const [queryResponse, setQueryResponse] = useState<
@@ -225,7 +226,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                                 data-testid="showOrHideSearchPanelButton"
                                 fill={false}
                                 iconType={
-                                  searchPanelOpen ? 'menuLeft' : 'menuRight'
+                                  searchPanelOpen ? 'menuRight' : 'menuLeft'
                                 }
                                 iconSide="right"
                                 onClick={() => {
@@ -260,42 +261,6 @@ export function EditQueryModal(props: EditQueryModalProps) {
                           <EuiFlexItem grow={false}>
                             <EuiText size="m">Test query</EuiText>
                           </EuiFlexItem>
-                          <EuiFlexItem grow={false}>
-                            <EuiSmallButton
-                              fill={false}
-                              isLoading={loading}
-                              disabled={containsEmptyValues(queryParams)}
-                              onClick={() => {
-                                dispatch(
-                                  searchIndex({
-                                    apiBody: {
-                                      index: values?.search?.index?.name,
-                                      body: injectParameters(
-                                        queryParams,
-                                        tempRequest
-                                      ),
-                                      // Run the query independent of the pipeline inside this modal
-                                      searchPipeline: '_none',
-                                    },
-                                    dataSourceId,
-                                  })
-                                )
-                                  .unwrap()
-                                  .then(async (resp: SearchResponse) => {
-                                    setQueryResponse(resp);
-                                    setTempResultsError('');
-                                  })
-                                  .catch((error: any) => {
-                                    setQueryResponse(undefined);
-                                    const errorMsg = `Error running query: ${error}`;
-                                    setTempResultsError(errorMsg);
-                                    console.error(errorMsg);
-                                  });
-                              }}
-                            >
-                              Search
-                            </EuiSmallButton>
-                          </EuiFlexItem>
                         </EuiFlexGroup>
                       </EuiFlexItem>
                       {/**
@@ -319,6 +284,41 @@ export function EditQueryModal(props: EditQueryModalProps) {
                                   <EuiText size="s">
                                     Run a search to view results.
                                   </EuiText>
+                                  <EuiSpacer size="m" />
+                                  <EuiSmallButton
+                                    fill={false}
+                                    isLoading={loading}
+                                    disabled={containsEmptyValues(queryParams)}
+                                    onClick={() => {
+                                      dispatch(
+                                        searchIndex({
+                                          apiBody: {
+                                            index: values?.search?.index?.name,
+                                            body: injectParameters(
+                                              queryParams,
+                                              tempRequest
+                                            ),
+                                            // Run the query independent of the pipeline inside this modal
+                                            searchPipeline: '_none',
+                                          },
+                                          dataSourceId,
+                                        })
+                                      )
+                                        .unwrap()
+                                        .then(async (resp: SearchResponse) => {
+                                          setQueryResponse(resp);
+                                          setTempResultsError('');
+                                        })
+                                        .catch((error: any) => {
+                                          setQueryResponse(undefined);
+                                          const errorMsg = `Error running query: ${error}`;
+                                          setTempResultsError(errorMsg);
+                                          console.error(errorMsg);
+                                        });
+                                    }}
+                                  >
+                                    Search
+                                  </EuiSmallButton>
                                 </>
                               }
                             />

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -60,6 +60,7 @@ const filterPresetsByVersion = async (
     WORKFLOW_TYPE.SEMANTIC_SEARCH,
     WORKFLOW_TYPE.MULTIMODAL_SEARCH,
     WORKFLOW_TYPE.HYBRID_SEARCH,
+    WORKFLOW_TYPE.CUSTOM,
   ];
 
   const version = await getEffectiveVersion(dataSourceId);

--- a/public/pages/workflows/workflow_list/workflow_list.test.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.test.tsx
@@ -61,7 +61,6 @@ describe('WorkflowList', () => {
   });
   test('renders the page', () => {
     const { getAllByText } = renderWithRouter();
-    expect(getAllByText('Manage existing workflows').length).toBeGreaterThan(0);
     expect(getAllByText('Name').length).toBeGreaterThan(0);
     expect(getAllByText('Type').length).toBeGreaterThan(0);
     expect(getAllByText('Last saved').length).toBeGreaterThan(0);

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -20,6 +20,7 @@ import {
   EuiText,
   EuiFlyoutBody,
   EuiEmptyPrompt,
+  EuiSpacer,
 } from '@elastic/eui';
 import { AppState } from '../../../store';
 import {
@@ -180,14 +181,7 @@ export function WorkflowList(props: WorkflowListProps) {
         </EuiFlyout>
       )}
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiFlexGroup
-            direction="row"
-            style={{ marginLeft: '0px', paddingTop: '10px' }}
-          >
-            <EuiText color="subdued">{`Manage existing workflows`}</EuiText>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+        <EuiSpacer size="m" />
         <EuiFlexItem>
           <EuiFlexGroup direction="row" gutterSize="m">
             <EuiFlexItem grow={true}>

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { debounce } from 'lodash';
+import semver from 'semver';
 import {
   EuiInMemoryTable,
   Direction,
@@ -24,8 +25,10 @@ import { AppState } from '../../../store';
 import {
   EMPTY_FIELD_STRING,
   MAX_WORKFLOW_NAME_TO_DISPLAY,
+  MINIMUM_FULL_SUPPORTED_VERSION,
   UIState,
   WORKFLOW_TYPE,
+  WORKFLOW_TYPE_LEGACY,
   Workflow,
   getCharacterLimitedString,
 } from '../../../../common';
@@ -38,6 +41,7 @@ import { isValidUiWorkflow } from '../../../utils';
 
 interface WorkflowListProps {
   setSelectedTabId: (tabId: WORKFLOWS_TAB) => void;
+  dataSourceVersion?: string;
 }
 
 const sorting = {
@@ -47,14 +51,6 @@ const sorting = {
   },
 };
 
-const filterOptions = Object.values(WORKFLOW_TYPE).map((type) => {
-  // @ts-ignore
-  return {
-    name: type,
-    checked: 'on',
-  } as EuiFilterSelectItem;
-});
-
 /**
  * The searchable list of created workflows.
  */
@@ -62,6 +58,19 @@ export function WorkflowList(props: WorkflowListProps) {
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
+
+  // table filters. the list of filters depends on the datasource version, if applicable.
+  const isPreV219 =
+    props.dataSourceVersion !== undefined &&
+    semver.lt(props.dataSourceVersion, MINIMUM_FULL_SUPPORTED_VERSION);
+  const filterType = isPreV219 ? WORKFLOW_TYPE_LEGACY : WORKFLOW_TYPE;
+  const filterOptions = Object.values(filterType).map((type) => {
+    // @ts-ignore
+    return {
+      name: type,
+      checked: 'on',
+    } as EuiFilterSelectItem;
+  });
 
   // actions state
   const [selectedWorkflow, setSelectedWorkflow] = useState<

--- a/public/pages/workflows/workflows.test.tsx
+++ b/public/pages/workflows/workflows.test.tsx
@@ -69,7 +69,6 @@ describe('Workflows', () => {
         queryByText('Select or drag and drop a file')
       ).not.toBeInTheDocument();
     });
-    expect(getAllByText('Manage existing workflows').length).toBeGreaterThan(0);
 
     // When the "Create Workflow" button is clicked, the "New workflow" tab opens
     // Create Workflow Testing

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -38,6 +38,7 @@ import { DataSourceSelectableConfig } from '../../../../../src/plugins/data_sour
 import {
   dataSourceFilterFn,
   getDataSourceFromURL,
+  getEffectiveVersion,
   isDataSourceReady,
 } from '../../utils/utils';
 import {
@@ -90,6 +91,17 @@ export function Workflows(props: WorkflowsProps) {
   const [dataSourceId, setDataSourceId] = useState<string | undefined>(
     queryParams.dataSourceId
   );
+  const [dataSourceVersion, setDataSourceVersion] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    async function getVersion() {
+      if (dataSourceId !== undefined) {
+        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
+      }
+    }
+    getVersion();
+  }, [dataSourceId]);
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
@@ -382,7 +394,10 @@ export function Workflows(props: WorkflowsProps) {
                   bottomBorder={false}
                 />
                 {selectedTabId === WORKFLOWS_TAB.MANAGE ? (
-                  <WorkflowList setSelectedTabId={setSelectedTabId} />
+                  <WorkflowList
+                    setSelectedTabId={setSelectedTabId}
+                    dataSourceVersion={dataSourceVersion}
+                  />
                 ) : (
                   <>
                     <EuiSpacer size="s" />

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -226,14 +226,18 @@ export function Workflows(props: WorkflowsProps) {
   ingest and search flows, test different configurations, and deploy them to your environment.`;
 
   const pageTitleAndDescription = USE_NEW_HOME_PAGE ? (
-    <HeaderControl
-      controls={[
-        {
-          description: DESCRIPTION,
-        },
-      ]}
-      setMountPoint={setAppDescriptionControls}
-    />
+    <>
+      <HeaderControl
+        controls={[
+          {
+            description: DESCRIPTION,
+          },
+        ]}
+        setMountPoint={setAppDescriptionControls}
+      />
+      <GetStartedAccordion />
+      <EuiSpacer size="s" />
+    </>
   ) : (
     <EuiFlexGroup direction="column" style={{ margin: '0px' }}>
       <EuiFlexGroup direction="row" gutterSize="s">
@@ -246,6 +250,7 @@ export function Workflows(props: WorkflowsProps) {
       <EuiText color="subdued">{DESCRIPTION}</EuiText>
       <EuiSpacer size="l" />
       <GetStartedAccordion />
+      <EuiSpacer size="s" />
     </EuiFlexGroup>
   );
 
@@ -265,7 +270,7 @@ export function Workflows(props: WorkflowsProps) {
             pageTitle={pageTitleAndDescription}
             bottomBorder={false}
           />
-          {dataSourceEnabled && (dataSourceId === undefined) ? (
+          {dataSourceEnabled && dataSourceId === undefined ? (
             <EuiPageContent grow={true}>
               <EuiEmptyPrompt
                 title={<h2>Incompatible data source</h2>}

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -7,6 +7,7 @@ import React, { ReactNode } from 'react';
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
 import { capitalize, escape, findKey, get, isEmpty, set, unset } from 'lodash';
+import { EuiText } from '@elastic/eui';
 import semver from 'semver';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
@@ -66,7 +67,6 @@ import {
 import * as pluginManifest from '../../opensearch_dashboards.json';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 import { SavedObject } from '../../../../src/core/public';
-import { EuiText } from '@elastic/eui';
 
 // Generate a random ID. Optionally add a prefix. Optionally
 // override the default # characters to generate.
@@ -231,6 +231,7 @@ export function getIngestPipelineErrors(
   return ingestPipelineErrors;
 }
 
+// Extract any processor-level errors from a verbose search API call
 export function getSearchPipelineErrors(
   searchResponseVerbose: SearchResponseVerbose
 ): SearchPipelineErrors {
@@ -246,6 +247,7 @@ export function getSearchPipelineErrors(
   return searchPipelineErrors;
 }
 
+// Generate a more UI-friendly layout of a processor error
 export function formatProcessorError(processorError: {
   processorType: string;
   errorMsg: string;

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React, { ReactNode } from 'react';
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
-import { escape, findKey, get, isEmpty, set, unset } from 'lodash';
+import { capitalize, escape, findKey, get, isEmpty, set, unset } from 'lodash';
 import semver from 'semver';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
@@ -65,6 +66,7 @@ import {
 import * as pluginManifest from '../../opensearch_dashboards.json';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 import { SavedObject } from '../../../../src/core/public';
+import { EuiText } from '@elastic/eui';
 
 // Generate a random ID. Optionally add a prefix. Optionally
 // override the default # characters to generate.
@@ -221,7 +223,7 @@ export function getIngestPipelineErrors(
       if (processorResult.error?.reason !== undefined) {
         ingestPipelineErrors[idx] = {
           processorType: processorResult.processor_type,
-          errorMsg: `Type: ${processorResult.processor_type}. Error: ${processorResult.error.reason}`,
+          errorMsg: processorResult.error.reason,
         };
       }
     });
@@ -237,11 +239,27 @@ export function getSearchPipelineErrors(
     if (processorResult?.error !== undefined) {
       searchPipelineErrors[idx] = {
         processorType: processorResult.processor_name,
-        errorMsg: `Type: ${processorResult.processor_name}. Error: ${processorResult.error}`,
+        errorMsg: processorResult.error,
       };
     }
   });
   return searchPipelineErrors;
+}
+
+export function formatProcessorError(processorError: {
+  processorType: string;
+  errorMsg: string;
+}): ReactNode {
+  return (
+    <>
+      <EuiText size="s">
+        {`Processor type:`} <b>{capitalize(processorError.processorType)}</b>
+      </EuiText>
+      <EuiText size="s">
+        {`Error:`} <b>{processorError.errorMsg}</b>
+      </EuiText>
+    </>
+  );
 }
 
 // ML inference processors will use standard dot notation or JSONPath depending on the input.
@@ -770,9 +788,9 @@ export function getEmbeddingField(
       }
     }
   } else if (embedding !== undefined) {
-    embeddingField = embedding
+    embeddingField = embedding;
   } else if (fieldMap !== undefined) {
-    embeddingField = get(fieldMap, '0.value', embeddingField)
+    embeddingField = get(fieldMap, '0.value', embeddingField);
   }
   return embeddingField;
 }


### PR DESCRIPTION
### Description

Continuation of #613. Contains various enhancements & bug fixes.

- Fixes bug of `Get started` accordion not visible when the global `useNewHomePage=true`.
- Only show relevant workflow types for BWC 2.17 datasources
- Reformat processor errors, support rendering arbitrary components in Errors tab for specialized error rendering
- Remove redundant description text in workflow list
- Add back custom/empty workflow template for BWC 2.17 datasources
- Move import data button (empty state)
- Move search button in query editor modal
- Add refresh button in ModelField to fetch updated models
- Add refresh button in "no models found" callout in ML processor form component

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
