### PR TITLE
Update model options and callout

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -259,6 +259,8 @@ export const SEARCH_PIPELINE_DOCS_LINK =
   'https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/';
 export const ML_RESPONSE_PROCESSOR_EXAMPLE_DOCS_LINK =
   'https://opensearch.org/docs/latest/search-plugins/search-pipelines/ml-inference-search-response/#example-externally-hosted-text-embedding-model';
+export const UPDATE_MODEL_DOCS_LINK =
+  'https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/update-model/';
 
 /**
  * Text chunking algorithm constants

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -18,6 +18,7 @@ import {
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHealth,
 } from '@elastic/eui';
 import {
   MODEL_STATE,
@@ -25,6 +26,7 @@ import {
   ModelFormValue,
   ML_CHOOSE_MODEL_LINK,
   FETCH_ALL_QUERY_LARGE,
+  UPDATE_MODEL_DOCS_LINK,
 } from '../../../../../common';
 import { AppState, searchModels, useAppDispatch } from '../../../../store';
 import { getDataSourceId } from '../../../../utils';
@@ -92,8 +94,15 @@ export function ModelField(props: ModelFieldProps) {
           <>
             <EuiCallOut
               size="s"
-              title="The selected model does not have a model interface. Cannot automatically determine model inputs and outputs."
-              iconType={'alert'}
+              title={
+                <EuiText size="s">
+                  This model has no interface set up yet.{' '}
+                  <EuiLink href={UPDATE_MODEL_DOCS_LINK} target="_blank">
+                    Learn more
+                  </EuiLink>{' '}
+                  about updating a model. Refresh the list when you finish.
+                </EuiText>
+              }
               color="warning"
             />
             <EuiSpacer size="s" />
@@ -137,12 +146,19 @@ export function ModelField(props: ModelFieldProps) {
                           ),
                           dropdownDisplay: (
                             <>
-                              <EuiText size="s">{option.name}</EuiText>
+                              <EuiHealth
+                                color={
+                                  isEmpty(option.interface)
+                                    ? 'warning'
+                                    : 'success'
+                                }
+                              >
+                                <EuiText size="s">{option.name}</EuiText>
+                              </EuiHealth>
                               <EuiText size="xs" color="subdued">
-                                Deployed
-                              </EuiText>
-                              <EuiText size="xs" color="subdued">
-                                {option.algorithm}
+                                {isEmpty(option.interface)
+                                  ? 'Not ready - no model interface'
+                                  : 'Deployed'}
                               </EuiText>
                             </>
                           ),

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -224,7 +224,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
       ) : (
         <ModelField
           fieldPath={modelFieldPath}
-          hasModelInterface={modelInterface !== undefined}
+          hasModelInterface={!isEmpty(modelInterface)}
           onModelChange={onModelChange}
         />
       )}


### PR DESCRIPTION
### Description
Updates the model options to include `EuiHealth` component, setting as warning color if missing model interface. Tunes the missing interface callout text and adds a link to the update model API.

<img width="370" alt="Screenshot 2025-02-17 at 11 28 43 AM" src="https://github.com/user-attachments/assets/2b42d5fb-04c8-4db6-bca6-02944c810f87" />

<img width="751" alt="Screenshot 2025-02-17 at 11 39 09 AM" src="https://github.com/user-attachments/assets/5a5e71c1-f680-4b2a-a596-ae2c7fddbb44" />

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
