### PR TITLE
Implicitly update input maps defined on non-expanded queries (common cases)

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -301,6 +301,96 @@ export const VECTOR_TEMPLATE_PLACEHOLDER = `\$\{${VECTOR}\}`;
 export const DEFAULT_K = 10;
 export const DEFAULT_FETCH_SIZE = 10;
 
+// term-level queries
+export const TERM_QUERY_TEXT = {
+  query: {
+    term: {
+      [TEXT_FIELD_PATTERN]: {
+        value: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const EXISTS_QUERY_TEXT = {
+  query: {
+    exists: {
+      field: TEXT_FIELD_PATTERN,
+    },
+  },
+};
+export const FUZZY_QUERY_TEXT = {
+  query: {
+    fuzzy: {
+      [TEXT_FIELD_PATTERN]: {
+        value: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const WILDCARD_QUERY_TEXT = {
+  query: {
+    wildcard: {
+      [TEXT_FIELD_PATTERN]: {
+        wildcard: QUERY_TEXT_PATTERN,
+        case_insensitive: false,
+      },
+    },
+  },
+};
+export const PREFIX_QUERY_TEXT = {
+  query: {
+    prefix: {
+      [TEXT_FIELD_PATTERN]: {
+        value: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+// full-text queries
+export const MATCH_QUERY_TEXT = {
+  query: {
+    match: {
+      [TEXT_FIELD_PATTERN]: {
+        query: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const MATCH_BOOLEAN_QUERY_TEXT = {
+  query: {
+    match_bool_prefix: {
+      [TEXT_FIELD_PATTERN]: {
+        query: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const MATCH_PHRASE_QUERY_TEXT = {
+  query: {
+    match_phrase: {
+      [TEXT_FIELD_PATTERN]: {
+        query: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const MATCH_PHRASE_PREFIX_QUERY_TEXT = {
+  query: {
+    match_phrase_prefix: {
+      [TEXT_FIELD_PATTERN]: {
+        query: QUERY_TEXT_PATTERN,
+      },
+    },
+  },
+};
+export const QUERY_STRING_QUERY_TEXT = {
+  query: {
+    query_string: {
+      query: QUERY_TEXT_PATTERN,
+    },
+  },
+};
+// misc / other queries
 export const FETCH_ALL_QUERY = {
   query: {
     match_all: {},
@@ -312,15 +402,6 @@ export const FETCH_ALL_QUERY_LARGE = {
     match_all: {},
   },
   size: 1000,
-};
-export const TERM_QUERY_TEXT = {
-  query: {
-    term: {
-      [TEXT_FIELD_PATTERN]: {
-        value: QUERY_TEXT_PATTERN,
-      },
-    },
-  },
 };
 export const KNN_QUERY = {
   _source: {
@@ -470,6 +551,42 @@ export const QUERY_PRESETS = [
   {
     name: 'Term',
     query: customStringify(TERM_QUERY_TEXT),
+  },
+  {
+    name: 'Match',
+    query: customStringify(MATCH_QUERY_TEXT),
+  },
+  {
+    name: 'Exists',
+    query: customStringify(EXISTS_QUERY_TEXT),
+  },
+  {
+    name: 'Fuzzy',
+    query: customStringify(FUZZY_QUERY_TEXT),
+  },
+  {
+    name: 'Wildcard',
+    query: customStringify(WILDCARD_QUERY_TEXT),
+  },
+  {
+    name: 'Prefix',
+    query: customStringify(PREFIX_QUERY_TEXT),
+  },
+  {
+    name: 'Match boolean',
+    query: customStringify(MATCH_BOOLEAN_QUERY_TEXT),
+  },
+  {
+    name: 'Match phrase',
+    query: customStringify(MATCH_PHRASE_QUERY_TEXT),
+  },
+  {
+    name: 'Match phrase prefix',
+    query: customStringify(MATCH_PHRASE_PREFIX_QUERY_TEXT),
+  },
+  {
+    name: 'Query string',
+    query: customStringify(QUERY_STRING_QUERY_TEXT),
   },
   {
     name: 'Basic k-NN',

--- a/public/utils/config_to_template_utils.test.tsx
+++ b/public/utils/config_to_template_utils.test.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import '@testing-library/jest-dom';
+import { updatePathForExpandedQuery } from './config_to_template_utils';
+
+describe('config_to_template_utils', () => {
+  beforeEach(() => {});
+  describe('updatePathForExpandedQuery', () => {
+    test('term query', () => {
+      expect(
+        updatePathForExpandedQuery('query.term.a') === 'query.term.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('query.term.a.value') ===
+          'query.term.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('$.query.term.a') === '$.query.term.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('a.b.c.d.query.term.a') ===
+          'a.b.c.d.query.term.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('query.bool.must[0].term.a') ===
+          'query.bool.must[0].term.a.value'
+      );
+    });
+    test('prefix query', () => {
+      expect(
+        updatePathForExpandedQuery('query.prefix.a') === 'query.prefix.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('query.prefix.a.value') ===
+          'query.prefix.a.value'
+      );
+    });
+    test('fuzzy query', () => {
+      expect(
+        updatePathForExpandedQuery('query.fuzzy.a') === 'query.fuzzy.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('query.fuzzy.a.value') ===
+          'query.fuzzy.a.value'
+      );
+    });
+    test('wildcard query', () => {
+      expect(
+        updatePathForExpandedQuery('query.wildcard.a') ===
+          'query.wildcard.a.wildcard'
+      );
+      expect(
+        updatePathForExpandedQuery('query.wildcard.a.wildcard') ===
+          'query.wildcard.a.wildcard'
+      );
+    });
+    test('regexp query', () => {
+      expect(
+        updatePathForExpandedQuery('query.regexp.a') === 'query.regexp.a.value'
+      );
+      expect(
+        updatePathForExpandedQuery('query.regexp.a.value') ===
+          'query.regexp.a.value'
+      );
+    });
+    test('match query', () => {
+      expect(
+        updatePathForExpandedQuery('query.match.a') === 'query.match.a.query'
+      );
+      expect(
+        updatePathForExpandedQuery('query.match.a.query') ===
+          'query.match.a.query'
+      );
+    });
+    test('match bool prefix query', () => {
+      expect(
+        updatePathForExpandedQuery('query.match_bool_prefix.a') ===
+          'query.match_bool_prefix.a.query'
+      );
+      expect(
+        updatePathForExpandedQuery('query.match_bool_prefix.a.query') ===
+          'query.match_bool_prefix.a.query'
+      );
+    });
+    test('match phrase query', () => {
+      expect(
+        updatePathForExpandedQuery('query.match_phrase.a') ===
+          'query.match_phrase.a.query'
+      );
+      expect(
+        updatePathForExpandedQuery('query.match_phrase.a.query') ===
+          'query.match_phrase.a.query'
+      );
+    });
+    test('match phrase prefix query', () => {
+      expect(
+        updatePathForExpandedQuery('query.match_phrase_prefix.a') ===
+          'query.match_phrase_prefix.a.query'
+      );
+      expect(
+        updatePathForExpandedQuery('query.match_phrase_prefix.a.query') ===
+          'query.match_phrase_prefix.a.query'
+      );
+    });
+    test('aggs query', () => {
+      expect(
+        updatePathForExpandedQuery('aggs.avg_a.avg.field') ===
+          'aggregations.avg_a.avg.field'
+      );
+      expect(
+        updatePathForExpandedQuery('aggs.b.c.d.aggs.avg_a.avg.field') ===
+          'aggregations.b.c.d.aggregations.avg_a.avg.field'
+      );
+    });
+  });
+});

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -679,12 +679,22 @@ function optionallyAddToFinalForm(
 function updatePathForExpandedQuery(path: string): string {
   let updatedPath = path;
 
-  // ensure term query has "value" suffix
+  // Several query types in expanded form nest the search value under a sub-field like "value" or "query".
+  // Update the path accordingly if it is defined on the non-expanded form of a query.
   updatedPath = addSuffixToPath(updatedPath, 'term', 'value');
-  // ensure prefix query has "value" suffix
   updatedPath = addSuffixToPath(updatedPath, 'prefix', 'value');
+  updatedPath = addSuffixToPath(updatedPath, 'fuzzy', 'value');
+  updatedPath = addSuffixToPath(updatedPath, 'wildcard', 'wildcard');
+  updatedPath = addSuffixToPath(updatedPath, 'regexp', 'value');
+  updatedPath = addSuffixToPath(updatedPath, 'match', 'query');
+  updatedPath = addSuffixToPath(updatedPath, 'match_bool_prefix', 'query');
+  updatedPath = addSuffixToPath(updatedPath, 'match_phrase', 'query');
+  updatedPath = addSuffixToPath(updatedPath, 'match_phrase_prefix', 'query');
 
-  console.log('updated path: ', updatedPath);
+  // TODO handle aggs
+  // TODO handle range query
+  // TODO handle geo / xy queries
+  // TODO handle "fields" when returning subset of fields in the source response
 
   return updatedPath;
 }

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -575,9 +575,6 @@ function processModelInputs(
           ? updatePathForExpandedQuery(mapEntry.value.value as string)
           : (mapEntry.value.value as string);
 
-      console.log('input value: ', inputValue);
-      console.log('context: ', context);
-
       inputMap = {
         ...inputMap,
         [sanitizeJSONPath(mapEntry.key)]: sanitizeJSONPath(inputValue),
@@ -697,6 +694,7 @@ function updatePathForExpandedQuery(path: string): string {
   // TODO handle range query
   // TODO handle geo / xy queries
   // TODO handle "fields" when returning subset of fields in the source response
+  // ^ all tracked in https://github.com/opensearch-project/dashboards-flow-framework/issues/574
 
   return updatedPath;
 }
@@ -708,7 +706,7 @@ function updatePathForExpandedQuery(path: string): string {
 function addSuffixToPath(path: string, prefix: string, suffix: string): string {
   function generateRegex(prefix: string, suffix: string): RegExp {
     // match the specified prefix, followed by some value in dot or bracket notation
-    const notationPattern = `${prefix}(\\.\\w+|\\[\\w+\\])`;
+    const notationPattern = `\\b${prefix}\\b(\\.\\w+|\\[\\w+\\])`;
     // ensure the suffix (in dot or bracket notation) is not present
     const suffixPattern = `(?!(\\.${suffix}|\\[${suffix}\\]))`;
     return new RegExp(notationPattern + suffixPattern, 'g');

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -679,7 +679,19 @@ function optionallyAddToFinalForm(
 function updatePathForExpandedQuery(path: string): string {
   let updatedPath = path;
 
-  // TODO: do the regex checking & replacement
+  const termPattern = /term(\.\w+|\[\w+\])(?!(\.value|\[value\]))/g;
+  const matchPattern = /match(\.\w+|\[\w+\])(?!(\.query|\[query\]))/g;
+
+  updatedPath = updatedPath.replace(
+    termPattern,
+    (match, p1) => `term${p1}.value`
+  );
+  updatedPath = updatedPath.replace(
+    matchPattern,
+    (match, p1) => `match${p1}.query`
+  );
+
+  console.log('updated path here: ', updatedPath);
 
   return updatedPath;
 }

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -673,7 +673,7 @@ function optionallyAddToFinalForm(
 // Try to catch and update paths when they are defined on a non-expanded version of a query.
 // For more details & examples, see
 // https://github.com/opensearch-project/dashboards-flow-framework/issues/574
-function updatePathForExpandedQuery(path: string): string {
+export function updatePathForExpandedQuery(path: string): string {
   let updatedPath = path;
 
   // Several query types in expanded form nest the search value under a sub-field like "value" or "query".

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -691,7 +691,9 @@ function updatePathForExpandedQuery(path: string): string {
   updatedPath = addSuffixToPath(updatedPath, 'match_phrase', 'query');
   updatedPath = addSuffixToPath(updatedPath, 'match_phrase_prefix', 'query');
 
-  // TODO handle aggs
+  // "aggs" expands to "aggregations"
+  updatedPath = updateAggsPath(updatedPath);
+
   // TODO handle range query
   // TODO handle geo / xy queries
   // TODO handle "fields" when returning subset of fields in the source response
@@ -717,4 +719,8 @@ function addSuffixToPath(path: string, prefix: string, suffix: string): string {
   return path.replace(regexPattern, (_, subStr) => {
     return `${prefix}${subStr}.${suffix}`;
   });
+}
+
+function updateAggsPath(path: string): string {
+  return path.replace(/\baggs\b/g, 'aggregations');
 }


### PR DESCRIPTION
### Description

#574 defines common short-form versions of queries that can lead to runtime failures if ML search request processors are defined/dependent on them. This PR implicitly updates any paths defined on the short-form, and makes them compatible with the long-form, for all relevant term-level and full-text queries, + aggregations.

There are some remaining edge cases that can be done in follow-up PRs, they are listed in https://github.com/opensearch-project/dashboards-flow-framework/issues/574#issuecomment-2669563040

Also added several more preset queries for convenience. By default, they are in long/extended form where applicable.

#### Testing
Added UT.
Also manually ensured for each added query (and aggregation query) that it:
1. Compiles in default (long/extended-form where applicable)
2. Compiles in short-form
3. Mappings against long-form works in ML processor
4. Mappings against short-form works in ML processor
5. Searches are successful in short-form
6. Searches are successful in long-form
7. Successful in the context of compound queries (like `bool`)

### Issues Resolved

Makes progress on #574 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
