### PR TITLE
Change ingestion input to JSON lines format

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -30,6 +30,7 @@ export type ConfigFieldType =
   | 'json'
   | 'jsonArray'
   | 'jsonString'
+  | 'jsonLines'
   | 'select'
   | 'model'
   | 'map'

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -40,6 +40,10 @@ export function customStringify(jsonObj: {} | []): string {
   return JSON.stringify(jsonObj, undefined, 2);
 }
 
+export function customStringifySingleLine(jsonObj: {}): string {
+  return JSON.stringify(jsonObj, undefined, 0);
+}
+
 export function isVectorSearchUseCase(workflow: Workflow | undefined): boolean {
   return (
     workflow?.ui_metadata?.type !== undefined &&

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -44,7 +44,8 @@ export function SourceData(props: SourceDataProps) {
   // empty/populated docs state
   let docs = [];
   try {
-    docs = JSON.parse(getIn(values, 'ingest.docs', []));
+    const lines = getIn(values, 'ingest.docs', '').split('\n') as string[];
+    lines.forEach((line) => docs.push(JSON.parse(line)));
   } catch {}
   const docsPopulated = docs.length > 0;
 

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -22,9 +22,10 @@ import {
   EuiButtonGroup,
   EuiCompressedComboBox,
 } from '@elastic/eui';
-import { JsonField } from '../input_fields';
+import { JsonLinesField } from '../input_fields';
 import {
   customStringify,
+  customStringifySingleLine,
   FETCH_ALL_QUERY_LARGE,
   IConfigField,
   IndexMappings,
@@ -177,8 +178,14 @@ export function SourceDataModal(props: SourceDataProps) {
               .then((resp) => {
                 const docObjs = resp?.hits?.hits
                   ?.slice(0, MAX_DOCS_TO_IMPORT)
-                  ?.map((hit: SearchHit) => hit?._source);
-                formikProps.setFieldValue('docs', customStringify(docObjs));
+                  ?.map((hit: SearchHit) => hit?._source) as {}[];
+                let jsonLinesStr = '';
+                try {
+                  docObjs.forEach((docObj) => {
+                    jsonLinesStr += customStringifySingleLine(docObj) + '\n';
+                  });
+                } catch {}
+                formikProps.setFieldValue('docs', jsonLinesStr);
               });
           }
         }, [selectedIndex]);
@@ -287,14 +294,13 @@ export function SourceDataModal(props: SourceDataProps) {
                     <EuiSpacer size="xs" />
                   </>
                 )}
-                <JsonField
+                <JsonLinesField
                   label="Documents to be imported"
                   fieldPath={'docs'}
                   helpText="Documents must be in JSON lines format."
                   editorHeight="40vh"
                   readOnly={false}
                   validate={true}
-                  validateInline={true}
                 />
               </>
             </EuiModalBody>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -72,11 +72,11 @@ export function SourceDataModal(props: SourceDataProps) {
 
   // sub-form values/schema
   const docsFormValues = {
-    docs: getInitialValue('jsonArray'),
+    docs: getInitialValue('jsonLines'),
   } as IngestDocsFormValues;
   const docsFormSchema = yup.object({
     docs: getFieldSchema({
-      type: 'jsonArray',
+      type: 'jsonLines',
     } as IConfigField),
   }) as yup.Schema;
 
@@ -234,7 +234,7 @@ export function SourceDataModal(props: SourceDataProps) {
                 {props.selectedOption === SOURCE_OPTIONS.UPLOAD && (
                   <>
                     <EuiCompressedFilePicker
-                      accept="application/json"
+                      accept=".jsonl"
                       multiple={false}
                       initialPromptText="Upload file"
                       onChange={(files) => {
@@ -247,6 +247,7 @@ export function SourceDataModal(props: SourceDataProps) {
                                 'docs',
                                 e.target.result as string
                               );
+                              formikProps.setFieldTouched('docs');
                             }
                           };
                           fileReader.readAsText(files[0]);
@@ -289,9 +290,11 @@ export function SourceDataModal(props: SourceDataProps) {
                 <JsonField
                   label="Documents to be imported"
                   fieldPath={'docs'}
-                  helpText="Documents must be in a JSON array format."
+                  helpText="Documents must be in JSON lines format."
                   editorHeight="40vh"
                   readOnly={false}
+                  validate={true}
+                  validateInline={true}
                 />
               </>
             </EuiModalBody>

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/index.ts
@@ -5,6 +5,7 @@
 
 export { TextField } from './text_field';
 export { JsonField } from './json_field';
+export { JsonLinesField } from './json_lines_field';
 export { ModelField } from './model_field';
 export { MapField } from './map_field';
 export { MapArrayField } from './map_array_field';

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/json_field.tsx
@@ -11,12 +11,13 @@ import {
   EuiLink,
   EuiText,
 } from '@elastic/eui';
-import { WorkflowFormValues, customStringify } from '../../../../../common';
+import { WorkflowFormValues } from '../../../../../common';
 import { camelCaseToTitleString } from '../../../../utils';
 
 interface JsonFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   validate?: boolean;
+  validateInline?: boolean;
   label?: string;
   helpLink?: string;
   helpText?: string;
@@ -29,7 +30,8 @@ interface JsonFieldProps {
  * in some custom JSON
  */
 export function JsonField(props: JsonFieldProps) {
-  const validate = props.validate !== undefined ? props.validate : true;
+  const validate = props.validate ?? true;
+  const validateInline = props.validateInline ?? true;
 
   const { errors, touched, values } = useFormikContext<WorkflowFormValues>();
 
@@ -82,21 +84,25 @@ export function JsonField(props: JsonFieldProps) {
                 form.setFieldValue(field.name, input);
               }}
               onBlur={() => {
-                try {
-                  form.setFieldValue(
-                    field.name,
-                    customStringify(JSON.parse(jsonStr))
-                  );
-                } catch (error) {
-                  form.setFieldValue(field.name, jsonStr);
-                } finally {
-                  form.setFieldTouched(field.name);
-                }
+                form.setFieldValue(field.name, jsonStr);
+                form.setFieldTouched(field.name);
+
+                // TODO: format under regular scenario, leave alone if JSONLines scenario
+                // try {
+                //   form.setFieldValue(
+                //     field.name,
+                //     customStringify(JSON.parse(jsonStr))
+                //   );
+                // } catch (error) {
+                //   form.setFieldValue(field.name, jsonStr);
+                // } finally {
+                //   form.setFieldTouched(field.name);
+                // }
               }}
               readOnly={props.readOnly || false}
               setOptions={{
                 fontSize: '14px',
-                useWorker: validate,
+                useWorker: validateInline,
                 highlightActiveLine: !props.readOnly,
                 highlightSelectedWord: !props.readOnly,
                 highlightGutterLine: !props.readOnly,
@@ -104,6 +110,18 @@ export function JsonField(props: JsonFieldProps) {
               }}
               aria-label="Code Editor"
               tabSize={2}
+              // onValidate={(props) => {
+              //   console.log('validate props: ', props);
+              //   return [];
+              // }}
+              // annotations={[
+              //   {
+              //     column: 0,
+              //     row: 1,
+              //     text: 'Invalid JSON',
+              //     type: 'error',
+              //   },
+              // ]}
             />
           </EuiCompressedFormRow>
         );

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -123,7 +123,8 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
   const docs = getIn(values, 'ingest.docs');
   let docObjs = [] as {}[] | undefined;
   try {
-    docObjs = JSON.parse(docs);
+    const lines = docs?.split('\n') as string[];
+    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
   } catch {}
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -466,9 +466,13 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                                       });
                                   } else {
                                     try {
-                                      const docObjs = JSON.parse(
-                                        values.ingest.docs
-                                      ) as {}[];
+                                      const docObjs = [] as {}[];
+                                      const lines = values?.ingest?.docs?.split(
+                                        '\n'
+                                      ) as string[];
+                                      lines.forEach((line) =>
+                                        docObjs?.push(JSON.parse(line))
+                                      );
                                       if (docObjs.length > 0) {
                                         setSourceInput(
                                           customStringify(docObjs[0])

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -129,7 +129,8 @@ export function ConfigureMultiExpressionModal(
   const docs = getIn(values, 'ingest.docs');
   let docObjs = [] as {}[] | undefined;
   try {
-    docObjs = JSON.parse(docs);
+    const lines = docs?.split('\n') as string[];
+    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
   } catch {}
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -149,7 +149,8 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
   const docs = getIn(values, 'ingest.docs');
   let docObjs = [] as {}[] | undefined;
   try {
-    docObjs = JSON.parse(docs);
+    const lines = docs?.split('\n') as string[];
+    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
   } catch {}
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -275,8 +275,9 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   useEffect(() => {
     let parsedDocsObjs = [] as {}[];
     try {
-      parsedDocsObjs = JSON.parse(props.ingestDocs);
-    } catch (e) {}
+      const lines = props.ingestDocs?.split('\n') as string[];
+      lines.forEach((line) => parsedDocsObjs.push(JSON.parse(line)));
+    } catch {}
     setDocsPopulated(parsedDocsObjs.length > 0 && !isEmpty(parsedDocsObjs[0]));
   }, [props.ingestDocs]);
 
@@ -607,7 +608,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     try {
       let ingestDocsObjs = [] as {}[];
       try {
-        ingestDocsObjs = JSON.parse(props.ingestDocs);
+        const lines = props.ingestDocs?.split('\n') as string[];
+        lines.forEach((line) => ingestDocsObjs.push(JSON.parse(line)));
       } catch (e) {}
       if (ingestDocsObjs.length > 0 && !isEmpty(ingestDocsObjs[0])) {
         success = await validateAndUpdateWorkflow(false, true, false);

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -46,7 +46,7 @@ function ingestConfigToFormik(
     ingestFormikValues['pipelineName'] =
       ingestConfig.pipelineName.value ||
       getInitialValue(ingestConfig.pipelineName.type);
-    ingestFormikValues['docs'] = ingestDocs || getInitialValue('jsonArray');
+    ingestFormikValues['docs'] = ingestDocs || getInitialValue('jsonLines');
     ingestFormikValues['enrich'] = processorsConfigToFormik(
       ingestConfig.enrich
     );
@@ -124,10 +124,9 @@ function searchIndexConfigToFormik(
 // Helper fn to get an initial value based on the field type
 export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
   switch (fieldType) {
-    case 'string': {
-      return '';
-    }
-    case 'select': {
+    case 'string':
+    case 'select':
+    case 'jsonLines': {
       return '';
     }
     case 'model': {

--- a/public/utils/form_to_pipeline_utils.ts
+++ b/public/utils/form_to_pipeline_utils.ts
@@ -44,7 +44,8 @@ export function formikToPartialPipeline(
         return !isEmpty(precedingProcessors)
           ? ({
               processors: processorConfigsToTemplateProcessors(
-                precedingProcessors
+                precedingProcessors,
+                context
               ),
             } as IngestPipelineConfig)
           : undefined;
@@ -60,7 +61,8 @@ export function formikToPartialPipeline(
         return !isEmpty(precedingProcessors)
           ? ({
               request_processors: processorConfigsToTemplateProcessors(
-                precedingProcessors
+                precedingProcessors,
+                context
               ),
             } as SearchPipelineConfig)
           : undefined;
@@ -78,10 +80,12 @@ export function formikToPartialPipeline(
         return !isEmpty(precedingProcessors) || !isEmpty(requestProcessors)
           ? ({
               request_processors: processorConfigsToTemplateProcessors(
-                requestProcessors
+                requestProcessors,
+                context
               ),
               response_processors: processorConfigsToTemplateProcessors(
-                precedingProcessors
+                precedingProcessors,
+                context
               ),
             } as SearchPipelineConfig)
           : undefined;

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -176,6 +176,8 @@ export function prepareDocsForSimulate(
   let docObjs = [] as {}[];
   try {
     docObjs = JSON.parse(docs) as {}[];
+    const lines = docs?.split('\n') as string[];
+    lines.forEach((line) => docObjs.push(JSON.parse(line)));
   } catch {}
   docObjs.forEach((doc) => {
     preparedDocs.push({

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -175,17 +175,18 @@ export function prepareDocsForSimulate(
   const preparedDocs = [] as SimulateIngestPipelineDoc[];
   let docObjs = [] as {}[];
   try {
-    docObjs = JSON.parse(docs) as {}[];
     const lines = docs?.split('\n') as string[];
     lines.forEach((line) => docObjs.push(JSON.parse(line)));
   } catch {}
-  docObjs.forEach((doc) => {
+  docObjs?.forEach((doc) => {
     preparedDocs.push({
       _index: indexName,
       _id: generateId(),
       _source: doc,
     });
   });
+  console.log('docobs: ', docObjs);
+  console.log('prepared docs: ', preparedDocs);
   return preparedDocs;
 }
 


### PR DESCRIPTION
### Description

This PR updates the ingestion input format to JSON lines format: https://jsonlines.org/. This is a more standard data file format for persisting JSON data, and makes it easier for importing.

More details:
- adds new `JsonLinesField` component, which is similar to `JsonField` but has specific logic around error handling and formatting to be specific to JSON lines.
- changes file upload type extension to be `*.jsonl` instead of JSON inputs
- adds new JSON lines config field type and corresponding schema/value presets
- updates all instances of the ingest docs parsing to handle a JSON lines string instead of a JSON array string
- bug fix: missing parameters on `processorConfigsToTemplateProcessors`. Externally, this has no impact.

Demo video:
TODO


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
