### PR TITLE
Various bug fixes & improvements

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -27,6 +27,7 @@ export type MDSQueryParams = {
 
 export type ConfigFieldType =
   | 'string'
+  | 'textArea'
   | 'json'
   | 'jsonArray'
   | 'jsonString'

--- a/public/app.tsx
+++ b/public/app.tsx
@@ -29,7 +29,6 @@ interface Props extends RouteComponentProps {
 export const FlowFrameworkDashboardsApp = (props: Props) => {
   const { setHeaderActionMenu } = props;
 
-
   // Render the application DOM.
   return (
     <EuiFlexGroup

--- a/public/configs/ingest_processors/copy_ingest_processor.ts
+++ b/public/configs/ingest_processors/copy_ingest_processor.ts
@@ -49,7 +49,7 @@ export class CopyIngestProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/ingest_processors/text_chunking_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_chunking_ingest_processor.ts
@@ -64,7 +64,7 @@ export class TextChunkingIngestProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/ingest_processors/text_embedding_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_embedding_ingest_processor.ts
@@ -21,7 +21,7 @@ export class TextEmbeddingIngestProcessor extends Processor {
     this.optionalFields = [
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/ingest_processors/text_image_embedding_ingest_processor.ts
+++ b/public/configs/ingest_processors/text_image_embedding_ingest_processor.ts
@@ -25,7 +25,7 @@ export class TextImageEmbeddingIngestProcessor extends Processor {
     this.optionalFields = [
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/ml_processor.ts
+++ b/public/configs/ml_processor.ts
@@ -60,7 +60,7 @@ export abstract class MLProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
     ];
   }

--- a/public/configs/search_response_processors/collapse_processor.ts
+++ b/public/configs/search_response_processors/collapse_processor.ts
@@ -33,7 +33,7 @@ export class CollapseProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'ignore_failure',

--- a/public/configs/search_response_processors/normalization_processor.ts
+++ b/public/configs/search_response_processors/normalization_processor.ts
@@ -21,16 +21,19 @@ export class NormalizationProcessor extends Processor {
       {
         id: 'weights',
         type: 'string',
+        value: '0.5, 0.5',
       },
       {
         id: 'normalization_technique',
         type: 'select',
         selectOptions: ['min_max', 'l2'],
+        value: 'min_max',
       },
       {
         id: 'combination_technique',
         type: 'select',
         selectOptions: ['arithmetic_mean', 'geometric_mean', 'harmonic_mean'],
+        value: 'arithmetic_mean',
       },
       {
         id: 'description',

--- a/public/configs/search_response_processors/normalization_processor.ts
+++ b/public/configs/search_response_processors/normalization_processor.ts
@@ -34,7 +34,7 @@ export class NormalizationProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/search_response_processors/rerank_processor.ts
+++ b/public/configs/search_response_processors/rerank_processor.ts
@@ -41,7 +41,7 @@ export class RerankProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'ignore_failure',

--- a/public/configs/sort_processor.ts
+++ b/public/configs/sort_processor.ts
@@ -34,7 +34,7 @@ export abstract class SortProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/configs/split_processor.ts
+++ b/public/configs/split_processor.ts
@@ -39,7 +39,7 @@ export abstract class SplitProcessor extends Processor {
       },
       {
         id: 'description',
-        type: 'string',
+        type: 'textArea',
       },
       {
         id: 'tag',

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -197,23 +197,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     props.setBlockNavigation(!saveDisabled);
   }, [saveDisabled]);
 
-  // Add warning when exiting with unsaved changes
-  function alertFn(e: BeforeUnloadEvent) {
-    e.preventDefault();
-  }
-
-  // Hook for warning of unsaved changes if a browser refresh is detected
-  useEffect(() => {
-    if (!saveDisabled) {
-      window.addEventListener('beforeunload', alertFn);
-    } else {
-      window.removeEventListener('beforeunload', alertFn);
-    }
-    return () => {
-      window.removeEventListener('beforeunload', alertFn);
-    };
-  }, [saveDisabled]);
-
   // Utility fn to update the workflow UI config only, based on the current form values.
   // A get workflow API call is subsequently run to fetch the updated state.
   async function updateWorkflowUiConfig() {

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -408,6 +408,7 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 {`Save`}
               </EuiSmallButtonEmpty>,
               <EuiSmallButtonIcon
+                data-testid="undoButton"
                 iconType="editorUndo"
                 aria-label="undo changes"
                 isDisabled={undoDisabled}

--- a/public/pages/workflow_detail/components/header.tsx
+++ b/public/pages/workflow_detail/components/header.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useEffect, useState, ReactElement } from 'react';
-import { useHistory } from 'react-router-dom';
 import {
   EuiPageHeader,
   EuiFlexGroup,
@@ -29,10 +28,10 @@ import {
 import {
   APP_PATH,
   USE_NEW_HOME_PAGE,
-  constructUrlWithParams,
   getDataSourceId,
   dataSourceFilterFn,
   formikToUiConfig,
+  constructHrefWithDataSourceId,
 } from '../../../utils';
 import { ExportModal } from './export_modal';
 import {
@@ -70,11 +69,11 @@ interface WorkflowDetailHeaderProps {
   unsavedSearchProcessors: boolean;
   setUnsavedSearchProcessors: (unsavedSearchProcessors: boolean) => void;
   setActionMenu: (menuMount?: MountPoint) => void;
+  setBlockNavigation: (blockNavigation: boolean) => void;
 }
 
 export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
   const dispatch = useAppDispatch();
-  const history = useHistory();
   const { resetForm, setTouched, values, touched, dirty } = useFormikContext<
     WorkflowFormValues
   >();
@@ -115,12 +114,6 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
       setHeaderVariant?.();
     };
   }, [setHeaderVariant, USE_NEW_HOME_PAGE]);
-
-  const onExitButtonClick = () => {
-    history.replace(
-      constructUrlWithParams(APP_PATH.WORKFLOWS, undefined, dataSourceId)
-    );
-  };
 
   // get & render the data source component, if applicable
   let DataSourceComponent: ReactElement | null = null;
@@ -199,6 +192,10 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
     props.selectedStep === CONFIG_STEP.INGEST
       ? ingestSaveButtonDisabled
       : searchSaveButtonDisabled;
+
+  useEffect(() => {
+    props.setBlockNavigation(!saveDisabled);
+  }, [saveDisabled]);
 
   // Add warning when exiting with unsaved changes
   function alertFn(e: BeforeUnloadEvent) {
@@ -319,7 +316,10 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 iconType: 'exit',
                 tooltip: 'Return to projects',
                 ariaLabel: 'Exit',
-                run: onExitButtonClick,
+                href: constructHrefWithDataSourceId(
+                  APP_PATH.WORKFLOWS,
+                  dataSourceId
+                ),
                 controlType: 'icon',
               } as TopNavMenuIconData,
               {
@@ -407,15 +407,10 @@ export function WorkflowDetailHeader(props: WorkflowDetailHeaderProps) {
                 Export
               </EuiSmallButton>,
               <EuiSmallButtonEmpty
-                onClick={() => {
-                  history.replace(
-                    constructUrlWithParams(
-                      APP_PATH.WORKFLOWS,
-                      undefined,
-                      dataSourceId
-                    )
-                  );
-                }}
+                href={constructHrefWithDataSourceId(
+                  APP_PATH.WORKFLOWS,
+                  dataSourceId
+                )}
                 data-testid="closeButton"
               >
                 Close

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -149,19 +149,6 @@ describe('WorkflowDetail Page Functionality (Custom Workflow)', () => {
       );
     });
   });
-
-  test('tests navigation to workflows list on Close button click', async () => {
-    const { getByTestId, history } = renderWithRouter(
-      workflowId,
-      workflowName,
-      WORKFLOW_TYPE.CUSTOM
-    );
-    // The WorkflowDetail Page Close button should navigate back to the workflows list
-    userEvent.click(getByTestId('closeButton'));
-    await waitFor(() => {
-      expect(history.location.pathname).toBe('/workflows');
-    });
-  });
 });
 
 describe('WorkflowDetail Page with skip ingestion option (Hybrid Search Workflow)', () => {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -118,13 +118,11 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
   // 2. Block navigation (externally-controlled buttons/links)
   // Remove listeners on component unload.
   const handleLinkClick = (e: Event) => {
-    if (blockNavigation) {
-      const confirmation = window.confirm(
-        'You have unsaved changes. Are you sure you want to leave?'
-      );
-      if (!confirmation) {
-        e.preventDefault();
-      }
+    const confirmation = window.confirm(
+      'You have unsaved changes. Are you sure you want to leave?'
+    );
+    if (!confirmation) {
+      e.preventDefault();
     }
   };
   useEffect(() => {

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -128,7 +128,10 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     }
   };
   useEffect(() => {
-    const links = document.querySelectorAll(`a[href="/app/home"]`); // this will catch the home page buttons in core OSD.
+    // try to catch as many external links as possible, particularly
+    // ones that will go to the home page, or different plugins within
+    // the side navigation.
+    const links = document.querySelectorAll(`a[href*="app/"]`);
     links.forEach((link) => {
       link.addEventListener('click', handleLinkClick);
     });

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -132,9 +132,15 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     // ones that will go to the home page, or different plugins within
     // the side navigation.
     const links = document.querySelectorAll(`a[href*="app/"]`);
-    links.forEach((link) => {
-      link.addEventListener('click', handleLinkClick);
-    });
+    if (blockNavigation) {
+      links.forEach((link) => {
+        link.addEventListener('click', handleLinkClick);
+      });
+    } else {
+      links.forEach((link) => {
+        link.removeEventListener('click', handleLinkClick);
+      });
+    }
     return () => {
       links.forEach((link) => {
         link.removeEventListener('click', handleLinkClick);

--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -50,6 +50,20 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
             );
             break;
           }
+          case 'textArea': {
+            el = (
+              <EuiFlexItem key={idx}>
+                <TextField
+                  label={camelCaseToTitleString(field.id)}
+                  fieldPath={fieldPath}
+                  showError={true}
+                  textArea={true}
+                />
+                <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
+              </EuiFlexItem>
+            );
+            break;
+          }
           case 'select': {
             el = (
               <EuiFlexItem key={idx}>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/normalization_processor_inputs.tsx
@@ -22,7 +22,8 @@ interface NormalizationProcessorInputsProps {
 }
 
 /**
- * Specialized component to render the normalization processor. Adds some helper text around weights field.
+ * Specialized component to render the normalization processor. Adds some helper text around weights field,
+ * and bubble it up as a primary field to populate (even though it is technically optional).
  * In the future, may have a more customizable / guided way for specifying the array of weights.
  * For example, could have some visual way of linking it to the underlying sub-queries in the query field,
  * enforce its length = the number of queries, etc.
@@ -38,30 +39,30 @@ export function NormalizationProcessorInputs(
   );
 
   return (
-    // We only have optional fields for this processor, so everything is nested under the accordion
-    <EuiAccordion
-      id={`advancedSettings${props.config.id}`}
-      buttonContent="Advanced settings"
-      paddingSize="none"
-    >
-      <EuiFlexItem style={{ marginLeft: '28px' }}>
+    <>
+      <TextField
+        label={'Weights'}
+        helpText={`A comma-separated array of floating-point values specifying the weight for each query. For example: '0.8, 0.2'`}
+        helpLink={NORMALIZATION_PROCESSOR_LINK}
+        fieldPath={weightsFieldPath}
+        showError={true}
+      />
+      <EuiSpacer size="s" />
+      <EuiAccordion
+        id={`advancedSettings${props.config.id}`}
+        buttonContent="Advanced settings"
+        paddingSize="none"
+        style={{ marginLeft: '-8px' }}
+      >
         <EuiSpacer size="s" />
-        <EuiFlexItem>
-          <TextField
-            label={'Weights'}
-            helpText={`A comma-separated array of floating-point values specifying the weight for each query. For example: '0.8, 0.2'`}
-            helpLink={NORMALIZATION_PROCESSOR_LINK}
-            fieldPath={weightsFieldPath}
-            showError={true}
+        <EuiFlexItem style={{ marginLeft: '28px' }}>
+          <ConfigFieldList
+            configId={props.config.id}
+            configFields={optionalFieldsWithoutWeights}
+            baseConfigPath={props.baseConfigPath}
           />
         </EuiFlexItem>
-        <EuiSpacer size="s" />
-        <ConfigFieldList
-          configId={props.config.id}
-          configFields={optionalFieldsWithoutWeights}
-          baseConfigPath={props.baseConfigPath}
-        />
-      </EuiFlexItem>
-    </EuiAccordion>
+      </EuiAccordion>
+    </>
   );
 }

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -804,6 +804,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                               disabled={
                                 !ingestEnabled
                                   ? false
+                                  : onIngestAndUnprovisioned
+                                  ? true
                                   : ingestTemplatesDifferent
                               }
                               iconSide="right"

--- a/public/pages/workflows/new_workflow/utils.ts
+++ b/public/pages/workflows/new_workflow/utils.ts
@@ -228,9 +228,7 @@ export function fetchHybridSearchMetadata(version: string): UIState {
   );
 
   baseState.config.search.enrichResponse.processors = [
-    injectDefaultWeightsInNormalizationProcessor(
-      new NormalizationProcessor().toObj()
-    ),
+    new NormalizationProcessor().toObj(),
   ];
 
   baseState.config.search.enrichRequest.processors = isPreV219
@@ -297,28 +295,6 @@ function injectQueryTemplateInProcessor(
             new RegExp(`"${VECTOR_PATTERN}"`, 'g'),
             VECTOR_TEMPLATE_PLACEHOLDER
           ),
-        };
-      }
-      return updatedField;
-    }
-  );
-  return processorConfig;
-}
-
-// set default weights for a normalization processor. assumes there is 2 queries, and equally
-// balances the weight. We don't hardcode in the configuration, since we don't want to set
-// invalid defaults for arbitrary use cases (e.g., more than 2 queries). In this case, we
-// are already setting 2 queries by default, so we can make this assumption.
-function injectDefaultWeightsInNormalizationProcessor(
-  processorConfig: IProcessorConfig
-): IProcessorConfig {
-  processorConfig.optionalFields = processorConfig.optionalFields?.map(
-    (optionalField) => {
-      let updatedField = optionalField;
-      if (optionalField.id === 'weights') {
-        updatedField = {
-          ...updatedField,
-          value: '0.5, 0.5',
         };
       }
       return updatedField;

--- a/public/utils/config_to_form_utils.ts
+++ b/public/utils/config_to_form_utils.ts
@@ -125,6 +125,7 @@ function searchIndexConfigToFormik(
 export function getInitialValue(fieldType: ConfigFieldType): ConfigFieldValue {
   switch (fieldType) {
     case 'string':
+    case 'textArea':
     case 'select':
     case 'jsonLines': {
       return '';

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -152,6 +152,7 @@ export function getFieldSchema(
 
   switch (field.type) {
     case 'string':
+    case 'textArea':
     case 'select': {
       baseSchema = defaultStringSchema;
       break;


### PR DESCRIPTION
### Description

PR with various improvements:
- changes `description` field types to textarea, instead of single text field that prevents whitespace by default. All processors that currently expose this field have been updated.
- catches 5 more scenarios of navigating away from the details page, if unsaved changes are detected. This includes the native browser back/forward buttons, the breadcrumbs links, exit buttons, home buttons, and side nav buttons. Adds a browser-native confirmation modal to confirm or deny the navigation. See screenshot below. See #469 for more details on the scenarios.
- auto-populates more of the default optional fields for the normalization processor, as well as bubbling up the 'weights' field to make it more accessible. See screenshots below
- prevent navigating to search if ingestion provisioning failed

Confirmation modal:
![modal](https://github.com/user-attachments/assets/70277b9a-5528-4192-b301-7a10cda5d477)

Normalization processor UI updates:
![normalization (collapsed)](https://github.com/user-attachments/assets/9fdc26e9-6c30-4b2e-823e-169ba0e6076e)
![normalization (expanded)](https://github.com/user-attachments/assets/2eabf4a2-6740-40b6-af50-9f99f34287da)

### Issues Resolved

Closes #627 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
