### PR TITLE
Add functional buttons in form headers; fix query parse bug

### DIFF
--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -36,10 +36,10 @@ import {
   containsEmptyValues,
   containsSameValues,
   getDataSourceId,
-  getEffectiveVersion,
   getPlaceholdersFromQuery,
   getSearchPipelineErrors,
   injectParameters,
+  useDataSourceVersion,
 } from '../../../../utils';
 import { QueryParamsList, Results } from '../../../../general_components';
 
@@ -65,17 +65,7 @@ const SEARCH_OPTIONS = [
 export function Query(props: QueryProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
-  const [dataSourceVersion, setDataSourceVersion] = useState<
-    string | undefined
-  >(undefined);
-  useEffect(() => {
-    async function getVersion() {
-      if (dataSourceId !== undefined) {
-        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
-      }
-    }
-    getVersion();
-  }, [dataSourceId]);
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
 
   const { loading } = useSelector((state: AppState) => state.opensearch);
 

--- a/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
@@ -14,7 +14,6 @@ import {
   EuiTitle,
   EuiText,
   EuiEmptyPrompt,
-  EuiLoadingSpinner,
   EuiHealth,
   EuiSpacer,
 } from '@elastic/eui';
@@ -24,7 +23,6 @@ interface ResourceFlyoutProps {
   resource: WorkflowResource;
   resourceDetails: string;
   onClose: () => void;
-  loading: boolean;
   errorMessage?: string;
 }
 
@@ -70,7 +68,7 @@ export function ResourceFlyout(props: ResourceFlyoutProps) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
-            {!props.errorMessage && !props.loading ? (
+            {!props.errorMessage ? (
               <EuiCodeBlock
                 language="json"
                 fontSize="m"
@@ -79,11 +77,6 @@ export function ResourceFlyout(props: ResourceFlyoutProps) {
               >
                 {props.resourceDetails}
               </EuiCodeBlock>
-            ) : props.loading ? (
-              <EuiEmptyPrompt
-                icon={<EuiLoadingSpinner size="xl" />}
-                title={<h2>Loading</h2>}
-              />
             ) : (
               <EuiEmptyPrompt
                 iconType="alert"

--- a/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
@@ -18,6 +18,10 @@ interface ResourceFlyoutProps {
   resourceDetails: string;
   onClose: () => void;
   errorMessage?: string;
+  indexName?: string;
+  searchPipelineName?: string;
+  ingestPipelineName?: string;
+  searchQuery?: string;
 }
 
 /**
@@ -36,6 +40,10 @@ export function ResourceFlyout(props: ResourceFlyoutProps) {
           resource={props.resource}
           resourceDetails={props.resourceDetails}
           errorMessage={props.errorMessage}
+          indexName={props.indexName}
+          ingestPipelineName={props.ingestPipelineName}
+          searchPipelineName={props.searchPipelineName}
+          searchQuery={props.searchQuery}
         />
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiText,
+  EuiEmptyPrompt,
+  EuiLoadingSpinner,
+} from '@elastic/eui';
+
+interface ResourceFlyoutProps {
+  resourceName: string;
+  resourceDetails: string;
+  onClose: () => void;
+  loading: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * The searchable list of resources for a particular workflow.
+ */
+export function ResourceFlyout(props: ResourceFlyoutProps) {
+  return (
+    <EuiFlyout onClose={props.onClose}>
+      <EuiFlyoutHeader>
+        <EuiTitle>
+          <h2>Resource details</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFlexGroup direction="column" gutterSize="xs">
+          <EuiFlexItem grow={true}>
+            <EuiText size="m">
+              <h4>Resource details</h4>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={true}>
+            {!props.errorMessage && !props.loading ? (
+              <EuiCodeBlock
+                language="json"
+                fontSize="m"
+                isCopyable={true}
+                overflowHeight={600}
+              >
+                {props.resourceDetails}
+              </EuiCodeBlock>
+            ) : props.loading ? (
+              <EuiEmptyPrompt
+                icon={<EuiLoadingSpinner size="xl" />}
+                title={<h2>Loading</h2>}
+              />
+            ) : (
+              <EuiEmptyPrompt
+                iconType="alert"
+                iconColor="danger"
+                title={<h2>Error loading resource details</h2>}
+                body={<p>{props.errorMessage}</p>}
+              />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+}

--- a/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
@@ -5,19 +5,13 @@
 
 import React from 'react';
 import {
-  EuiCodeBlock,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiTitle,
-  EuiText,
-  EuiEmptyPrompt,
-  EuiHealth,
-  EuiSpacer,
 } from '@elastic/eui';
-import { WORKFLOW_STEP_TYPE, WorkflowResource } from '../../../../../common';
+import { WorkflowResource } from '../../../../../common';
+import { ResourceFlyoutContent } from './resource_flyout_content';
 
 interface ResourceFlyoutProps {
   resource: WorkflowResource;
@@ -27,7 +21,7 @@ interface ResourceFlyoutProps {
 }
 
 /**
- * The searchable list of resources for a particular workflow.
+ * A simple flyout to display details for a particular workflow resource.
  */
 export function ResourceFlyout(props: ResourceFlyoutProps) {
   return (
@@ -38,55 +32,11 @@ export function ResourceFlyout(props: ResourceFlyoutProps) {
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiFlexGroup direction="column" gutterSize="xs">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h4>Name</h4>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText>{props.resource?.id || ''}</EuiText>
-          </EuiFlexItem>
-          <EuiSpacer size="s" />
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h4>Status</h4>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiHealth color="success">Active</EuiHealth>
-          </EuiFlexItem>
-          <EuiSpacer size="s" />
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h4>
-                {props.resource?.stepType ===
-                WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE
-                  ? 'Configuration'
-                  : 'Pipeline configuration'}
-              </h4>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={true}>
-            {!props.errorMessage ? (
-              <EuiCodeBlock
-                language="json"
-                fontSize="m"
-                isCopyable={true}
-                overflowHeight={600}
-              >
-                {props.resourceDetails}
-              </EuiCodeBlock>
-            ) : (
-              <EuiEmptyPrompt
-                iconType="alert"
-                iconColor="danger"
-                title={<h2>Error loading resource details</h2>}
-                body={<p>{props.errorMessage}</p>}
-              />
-            )}
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <ResourceFlyoutContent
+          resource={props.resource}
+          resourceDetails={props.resourceDetails}
+          errorMessage={props.errorMessage}
+        />
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout.tsx
@@ -15,10 +15,13 @@ import {
   EuiText,
   EuiEmptyPrompt,
   EuiLoadingSpinner,
+  EuiHealth,
+  EuiSpacer,
 } from '@elastic/eui';
+import { WORKFLOW_STEP_TYPE, WorkflowResource } from '../../../../../common';
 
 interface ResourceFlyoutProps {
-  resourceName: string;
+  resource: WorkflowResource;
   resourceDetails: string;
   onClose: () => void;
   loading: boolean;
@@ -38,10 +41,33 @@ export function ResourceFlyout(props: ResourceFlyoutProps) {
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiFlexGroup direction="column" gutterSize="xs">
-          <EuiFlexItem grow={true}>
-            <EuiText size="m">
-              <h4>Resource details</h4>
-            </EuiText>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h4>Name</h4>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText>{props.resource?.id || ''}</EuiText>
+          </EuiFlexItem>
+          <EuiSpacer size="s" />
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h4>Status</h4>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiHealth color="success">Active</EuiHealth>
+          </EuiFlexItem>
+          <EuiSpacer size="s" />
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h4>
+                {props.resource?.stepType ===
+                WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE
+                  ? 'Configuration'
+                  : 'Pipeline configuration'}
+              </h4>
+            </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
             {!props.errorMessage && !props.loading ? (

--- a/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
@@ -36,7 +36,6 @@ interface ResourceFlyoutContentProps {
  * The static flyout content for a particular workflow resource.
  */
 export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
-  console.log('props.searchquery: ', props.searchQuery);
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
       <EuiFlexItem grow={false}>

--- a/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
@@ -36,6 +36,7 @@ interface ResourceFlyoutContentProps {
  * The static flyout content for a particular workflow resource.
  */
 export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
+  console.log('props.searchquery: ', props.searchQuery);
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
       <EuiFlexItem grow={false}>
@@ -129,7 +130,11 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
           <EuiCodeBlock fontSize="m" isCopyable={true}>
             {`GET /${props.indexName || 'my_index'}/_search?search_pipeline=${
               props.searchPipelineName || 'my_pipeline'
-            }
+            }` +
+              `${
+                props.searchQuery
+                  ? `\n${props.searchQuery}`
+                  : `
 {
   "query": {
     "term": {
@@ -138,7 +143,8 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
       }
     }
   }
-}`}
+}`
+              }`}
           </EuiCodeBlock>
         </EuiFlexItem>
       ) : (

--- a/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
@@ -16,6 +16,7 @@ import {
   EuiLink,
 } from '@elastic/eui';
 import {
+  BULK_API_DOCS_LINK,
   SEARCH_PIPELINE_DOCS_LINK,
   WORKFLOW_STEP_TYPE,
   WorkflowResource,
@@ -25,6 +26,10 @@ interface ResourceFlyoutContentProps {
   resource: WorkflowResource;
   resourceDetails: string;
   errorMessage?: string;
+  indexName?: string;
+  searchPipelineName?: string;
+  ingestPipelineName?: string;
+  searchQuery?: string;
 }
 
 /**
@@ -95,7 +100,7 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
         </EuiTitle>
       </EuiFlexItem>
       {props.resource?.stepType ===
-        WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE && (
+      WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE ? (
         <EuiFlexItem grow={false}>
           <EuiText size="s">
             <p>
@@ -106,10 +111,25 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
             </p>
           </EuiText>
         </EuiFlexItem>
+      ) : (
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <p>
+              You can ingest a larger amount of data using the Bulk API.{' '}
+              <EuiLink href={BULK_API_DOCS_LINK} target="_blank">
+                Learn more
+              </EuiLink>
+            </p>
+          </EuiText>
+        </EuiFlexItem>
       )}
-      <EuiFlexItem grow={false}>
-        <EuiCodeBlock fontSize="m" isCopyable={true}>
-          {`GET /my_index/_search?search_pipeline=my_pipeline
+      {props.resource?.stepType ===
+      WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE ? (
+        <EuiFlexItem grow={false}>
+          <EuiCodeBlock fontSize="m" isCopyable={true}>
+            {`GET /${props.indexName || 'my_index'}/_search?search_pipeline=${
+              props.searchPipelineName || 'my_pipeline'
+            }
 {
   "query": {
     "term": {
@@ -119,8 +139,17 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
     }
   }
 }`}
-        </EuiCodeBlock>
-      </EuiFlexItem>
+          </EuiCodeBlock>
+        </EuiFlexItem>
+      ) : (
+        <EuiFlexItem grow={false}>
+          <EuiCodeBlock fontSize="m" isCopyable={true}>
+            {`POST _bulk
+{ "index": { "_index": "${props.indexName || 'my_index'}", "_id": "abc123" } }
+{ "my_field_1": "my_field_value_1", "my_field_2": "my_field_value_2" }`}
+          </EuiCodeBlock>
+        </EuiFlexItem>
+      )}
     </EuiFlexGroup>
   );
 }

--- a/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiText,
+  EuiEmptyPrompt,
+  EuiHealth,
+  EuiSpacer,
+} from '@elastic/eui';
+import { WORKFLOW_STEP_TYPE, WorkflowResource } from '../../../../../common';
+
+interface ResourceFlyoutContentProps {
+  resource: WorkflowResource;
+  resourceDetails: string;
+  errorMessage?: string;
+}
+
+/**
+ * The static flyout content for a particular workflow resource.
+ */
+export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h4>Name</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText>{props.resource?.id || ''}</EuiText>
+      </EuiFlexItem>
+      <EuiSpacer size="s" />
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h4>Status</h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiHealth color="success">Active</EuiHealth>
+      </EuiFlexItem>
+      <EuiSpacer size="s" />
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h4>
+            {props.resource?.stepType ===
+            WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE
+              ? 'Configuration'
+              : 'Pipeline configuration'}
+          </h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={true}>
+        {!props.errorMessage ? (
+          <EuiCodeBlock
+            language="json"
+            fontSize="m"
+            isCopyable={true}
+            overflowHeight={600}
+          >
+            {props.resourceDetails}
+          </EuiCodeBlock>
+        ) : (
+          <EuiEmptyPrompt
+            iconType="alert"
+            iconColor="danger"
+            title={<h2>Error loading resource details</h2>}
+            body={<p>{props.errorMessage}</p>}
+          />
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_flyout_content.tsx
@@ -13,8 +13,13 @@ import {
   EuiEmptyPrompt,
   EuiHealth,
   EuiSpacer,
+  EuiLink,
 } from '@elastic/eui';
-import { WORKFLOW_STEP_TYPE, WorkflowResource } from '../../../../../common';
+import {
+  SEARCH_PIPELINE_DOCS_LINK,
+  WORKFLOW_STEP_TYPE,
+  WorkflowResource,
+} from '../../../../../common';
 
 interface ResourceFlyoutContentProps {
   resource: WorkflowResource;
@@ -74,6 +79,47 @@ export function ResourceFlyoutContent(props: ResourceFlyoutContentProps) {
             body={<p>{props.errorMessage}</p>}
           />
         )}
+      </EuiFlexItem>
+      <EuiSpacer size="s" />
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h4>
+            {props.resource?.stepType ===
+            WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE
+              ? 'Ingest additional data using the bulk API'
+              : props.resource?.stepType ===
+                WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE
+              ? 'Ingest additional data using the bulk API'
+              : 'Apply a search pipeline to your applications'}
+          </h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      {props.resource?.stepType ===
+        WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE && (
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <p>
+              You can invoke the search pipeline API in your applications.{' '}
+              <EuiLink href={SEARCH_PIPELINE_DOCS_LINK} target="_blank">
+                Learn more
+              </EuiLink>
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem grow={false}>
+        <EuiCodeBlock fontSize="m" isCopyable={true}>
+          {`GET /my_index/_search?search_pipeline=my_pipeline
+{
+  "query": {
+    "term": {
+      "item_text": {
+        "value": "{{query_text}}"
+      }
+    }
+  }
+}`}
+        </EuiCodeBlock>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -50,7 +50,6 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
     undefined
   );
   const {
-    loading,
     getIndexErrorMessage,
     getIngestPipelineErrorMessage,
     getSearchPipelineErrorMessage,
@@ -176,7 +175,6 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
             resource={selectedRowData}
             resourceDetails={resourceDetails}
             onClose={closeFlyout}
-            loading={loading}
             errorMessage={rowErrorMessage || undefined}
           />
         )}

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { getIn, useFormikContext } from 'formik';
 import {
   Direction,
   EuiFlexGroup,
@@ -14,6 +15,7 @@ import {
 } from '@elastic/eui';
 import {
   Workflow,
+  WorkflowFormValues,
   WorkflowResource,
   customStringify,
 } from '../../../../../common';
@@ -41,8 +43,9 @@ interface ResourceListFlyoutProps {
  * action to view more details within a flyout.
  */
 export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
-  const [allResources, setAllResources] = useState<WorkflowResource[]>([]);
   const dispatch = useAppDispatch();
+  const { values } = useFormikContext<WorkflowFormValues>();
+  const [allResources, setAllResources] = useState<WorkflowResource[]>([]);
   const dataSourceId = getDataSourceId();
   const [resourceDetails, setResourceDetails] = useState<string | undefined>(
     undefined
@@ -176,7 +179,11 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
             resource={selectedRowData}
             resourceDetails={resourceDetails}
             onClose={closeFlyout}
-            errorMessage={rowErrorMessage || undefined}
+            errorMessage={rowErrorMessage}
+            indexName={getIn(values, 'ingest.index.name')}
+            ingestPipelineName={getIn(values, 'ingest.pipelineName')}
+            searchPipelineName={getIn(values, 'search.pipelineName')}
+            searchQuery={getIn(values, 'search.request')}
           />
         )}
     </>

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -43,8 +43,12 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
   const [allResources, setAllResources] = useState<WorkflowResource[]>([]);
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
-  const [resourceDetails, setResourceDetails] = useState<string | null>(null);
-  const [rowErrorMessage, setRowErrorMessage] = useState<string | null>(null);
+  const [resourceDetails, setResourceDetails] = useState<string | undefined>(
+    undefined
+  );
+  const [rowErrorMessage, setRowErrorMessage] = useState<string | undefined>(
+    undefined
+  );
   const {
     loading,
     getIndexErrorMessage,
@@ -105,7 +109,7 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
     },
   };
 
-  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState<boolean>(false);
   const [selectedRowData, setSelectedRowData] = useState<
     WorkflowResource | undefined
   >(undefined);
@@ -133,7 +137,7 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
   const closeFlyout = () => {
     setIsFlyoutVisible(false);
     setSelectedRowData(undefined);
-    setResourceDetails(null);
+    setResourceDetails(undefined);
   };
 
   return (
@@ -165,15 +169,17 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {isFlyoutVisible && (
-        <ResourceFlyout
-          resourceName={selectedRowData?.id || ''}
-          resourceDetails={resourceDetails || ''}
-          onClose={closeFlyout}
-          loading={loading}
-          errorMessage={rowErrorMessage || undefined}
-        />
-      )}
+      {isFlyoutVisible &&
+        selectedRowData !== undefined &&
+        resourceDetails !== undefined && (
+          <ResourceFlyout
+            resource={selectedRowData}
+            resourceDetails={resourceDetails}
+            onClose={closeFlyout}
+            loading={loading}
+            errorMessage={rowErrorMessage || undefined}
+          />
+        )}
     </>
   );
 }

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -37,7 +37,8 @@ interface ResourceListFlyoutProps {
 }
 
 /**
- * The searchable list of resources for a particular workflow.
+ * The searchable list of resources for a particular workflow. Each resource has an "inspect"
+ * action to view more details within a flyout.
  */
 export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
   const [allResources, setAllResources] = useState<WorkflowResource[]>([]);

--- a/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resource_list_with_flyout.tsx
@@ -7,18 +7,10 @@ import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Direction,
-  EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFlyout,
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
   EuiInMemoryTable,
-  EuiTitle,
   EuiIcon,
-  EuiText,
-  EuiEmptyPrompt,
-  EuiLoadingSpinner,
 } from '@elastic/eui';
 import {
   Workflow,
@@ -38,6 +30,7 @@ import {
   getErrorMessageForStepType,
 } from '../../../../utils';
 import { columns } from './columns';
+import { ResourceFlyout } from './resource_flyout';
 
 interface ResourceListFlyoutProps {
   workflow?: Workflow;
@@ -173,46 +166,13 @@ export function ResourceListWithFlyout(props: ResourceListFlyoutProps) {
         </EuiFlexItem>
       </EuiFlexGroup>
       {isFlyoutVisible && (
-        <EuiFlyout onClose={closeFlyout}>
-          <EuiFlyoutHeader>
-            <EuiTitle>
-              <h2>{selectedRowData?.id}</h2>
-            </EuiTitle>
-          </EuiFlyoutHeader>
-          <EuiFlyoutBody>
-            <EuiFlexGroup direction="column" gutterSize="xs">
-              <EuiFlexItem grow={true}>
-                <EuiText size="m">
-                  <h4>Resource details</h4>
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={true}>
-                {!rowErrorMessage && !loading ? (
-                  <EuiCodeBlock
-                    language="json"
-                    fontSize="m"
-                    isCopyable={true}
-                    overflowHeight={600}
-                  >
-                    {resourceDetails}
-                  </EuiCodeBlock>
-                ) : loading ? (
-                  <EuiEmptyPrompt
-                    icon={<EuiLoadingSpinner size="xl" />}
-                    title={<h2>Loading</h2>}
-                  />
-                ) : (
-                  <EuiEmptyPrompt
-                    iconType="alert"
-                    iconColor="danger"
-                    title={<h2>Error loading resource details</h2>}
-                    body={<p>{rowErrorMessage}</p>}
-                  />
-                )}
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlyoutBody>
-        </EuiFlyout>
+        <ResourceFlyout
+          resourceName={selectedRowData?.id || ''}
+          resourceDetails={resourceDetails || ''}
+          onClose={closeFlyout}
+          loading={loading}
+          errorMessage={rowErrorMessage || undefined}
+        />
       )}
     </>
   );

--- a/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiTab,
+  EuiTabs,
+  EuiTitle,
+} from '@elastic/eui';
+import {
+  WORKFLOW_RESOURCE_TYPE,
+  WorkflowResource,
+} from '../../../../../common';
+import { ResourceFlyoutContent } from './resource_flyout_content';
+import { get } from 'lodash';
+
+interface ResourcesFlyoutProps {
+  resources: WorkflowResource[];
+  resourceDetails: string[];
+  onClose: () => void;
+  errorMessage?: string;
+}
+
+/**
+ * A simple flyout to display details for multiple workflow resources nested
+ * under tabs.
+ */
+export function ResourcesFlyout(props: ResourcesFlyoutProps) {
+  const [selectedResourceIdx, setSelectedResourceIdx] = useState<number>(0);
+  const [selectedTabId, setSelectedTabId] = useState<string>(
+    get(props, `resources.${selectedResourceIdx}.id`)
+  );
+  const selectedResource = get(
+    props,
+    `resources.${selectedResourceIdx}`,
+    undefined
+  ) as WorkflowResource | undefined;
+  const selectedResourceDetails = get(
+    props,
+    `resourceDetails.${selectedResourceIdx}`,
+    undefined
+  ) as string | undefined;
+
+  return (
+    <EuiFlyout onClose={props.onClose}>
+      <EuiFlyoutHeader>
+        <EuiTitle>
+          <h2>Resource details</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFlexItem grow={false}>
+          <EuiTabs size="s" expand={false}>
+            {props.resources?.map((tab, idx) => {
+              return (
+                <EuiTab
+                  onClick={() => {
+                    setSelectedTabId(tab.id);
+                    setSelectedResourceIdx(idx);
+                  }}
+                  isSelected={tab.id === selectedTabId}
+                  disabled={false}
+                  key={idx}
+                >
+                  {tab?.type === WORKFLOW_RESOURCE_TYPE.INDEX_NAME
+                    ? 'Index'
+                    : 'Pipeline'}
+                </EuiTab>
+              );
+            })}
+          </EuiTabs>
+        </EuiFlexItem>
+        {selectedResource !== undefined &&
+          selectedResourceDetails !== undefined && (
+            <ResourceFlyoutContent
+              resource={selectedResource}
+              resourceDetails={selectedResourceDetails}
+              errorMessage={props.errorMessage}
+            />
+          )}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+}

--- a/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
@@ -3,49 +3,140 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { get } from 'lodash';
 import {
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiSpacer,
   EuiTab,
   EuiTabs,
   EuiTitle,
 } from '@elastic/eui';
 import {
+  CONFIG_STEP,
+  customStringify,
   WORKFLOW_RESOURCE_TYPE,
+  WORKFLOW_STEP_TYPE,
   WorkflowResource,
 } from '../../../../../common';
 import { ResourceFlyoutContent } from './resource_flyout_content';
-import { get } from 'lodash';
+import { extractIdsByStepType, getDataSourceId } from '../../../../utils';
+import {
+  AppState,
+  getIndex,
+  getIngestPipeline,
+  getSearchPipeline,
+  useAppDispatch,
+} from '../../../../store';
 
 interface ResourcesFlyoutProps {
   resources: WorkflowResource[];
-  resourceDetails: string[];
+  selectedStep: CONFIG_STEP;
   onClose: () => void;
-  errorMessage?: string;
 }
 
 /**
- * A simple flyout to display details for multiple workflow resources nested
- * under tabs.
+ * Flyout to display details for multiple workflow resources, depending on the context (ingest or search).
+ * Dynamically render data nested under tabs if there are multiple - e.g., an index and ingest pipeline under the ingest context.
  */
 export function ResourcesFlyout(props: ResourcesFlyoutProps) {
+  const dispatch = useAppDispatch();
+  const dataSourceId = getDataSourceId();
+
+  const {
+    getIndexErrorMessage,
+    getIngestPipelineErrorMessage,
+    getSearchPipelineErrorMessage,
+    indexDetails,
+    ingestPipelineDetails,
+    searchPipelineDetails,
+  } = useSelector((state: AppState) => state.opensearch);
+
+  // Fetch the filtered resource(s) based on ingest or search context
+  const [allResources, setAllResources] = useState<WorkflowResource[]>([]);
+  useEffect(() => {
+    if (props.resources) {
+      const resourcesMap = {} as { [id: string]: WorkflowResource };
+      props.resources.forEach((resource) => {
+        if (
+          (props.selectedStep === CONFIG_STEP.INGEST &&
+            (resource.stepType === WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE ||
+              resource.stepType ===
+                WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE)) ||
+          (props.selectedStep === CONFIG_STEP.SEARCH &&
+            resource.stepType ===
+              WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE)
+        ) {
+          resourcesMap[resource.id] = resource;
+        }
+      });
+      setAllResources(Object.values(resourcesMap || {}));
+    }
+  }, [props.resources]);
+
+  // fetch details for each resource type
+  useEffect(() => {
+    const {
+      indexIds,
+      ingestPipelineIds,
+      searchPipelineIds,
+    } = extractIdsByStepType(allResources);
+    if (indexIds) {
+      try {
+        dispatch(getIndex({ index: indexIds, dataSourceId }));
+      } catch {}
+    }
+    if (ingestPipelineIds) {
+      try {
+        dispatch(
+          getIngestPipeline({ pipelineId: ingestPipelineIds, dataSourceId })
+        );
+      } catch {}
+    }
+    if (searchPipelineIds) {
+      try {
+        dispatch(
+          getSearchPipeline({ pipelineId: searchPipelineIds, dataSourceId })
+        );
+      } catch {}
+    }
+  }, [allResources]);
+
+  // keep state for the resource index, and the selected tab ID (if applicable)
   const [selectedResourceIdx, setSelectedResourceIdx] = useState<number>(0);
-  const [selectedTabId, setSelectedTabId] = useState<string>(
-    get(props, `resources.${selectedResourceIdx}.id`)
-  );
-  const selectedResource = get(
-    props,
-    `resources.${selectedResourceIdx}`,
-    undefined
-  ) as WorkflowResource | undefined;
-  const selectedResourceDetails = get(
-    props,
-    `resourceDetails.${selectedResourceIdx}`,
-    undefined
-  ) as string | undefined;
+  const [selectedTabId, setSelectedTabId] = useState<string>('');
+  useEffect(() => {
+    if (allResources) {
+      setSelectedTabId(get(allResources, `0.id`));
+    }
+  }, [allResources]);
+
+  // get the resource details, and any error message, based on the selected resource index
+  const selectedResource = get(allResources, selectedResourceIdx, undefined) as
+    | WorkflowResource
+    | undefined;
+  const selectedResourceDetailsObj =
+    indexDetails[selectedResource?.id || ''] ??
+    ingestPipelineDetails[selectedResource?.id || ''] ??
+    searchPipelineDetails[selectedResource?.id || ''] ??
+    '';
+  const selectedResourceDetails = customStringify({
+    [selectedResource?.id || '']: selectedResourceDetailsObj,
+  });
+  const selectedResourceErrorMessage =
+    selectedResource?.stepType === WORKFLOW_STEP_TYPE.CREATE_INDEX_STEP_TYPE
+      ? getIndexErrorMessage
+      : selectedResource?.stepType ===
+        WORKFLOW_STEP_TYPE.CREATE_INGEST_PIPELINE_STEP_TYPE
+      ? getIngestPipelineErrorMessage
+      : selectedResource?.stepType ===
+        WORKFLOW_STEP_TYPE.CREATE_SEARCH_PIPELINE_STEP_TYPE
+      ? getSearchPipelineErrorMessage
+      : (undefined as string | undefined);
 
   return (
     <EuiFlyout onClose={props.onClose}>
@@ -55,33 +146,36 @@ export function ResourcesFlyout(props: ResourcesFlyoutProps) {
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiFlexItem grow={false}>
-          <EuiTabs size="s" expand={false}>
-            {props.resources?.map((tab, idx) => {
-              return (
-                <EuiTab
-                  onClick={() => {
-                    setSelectedTabId(tab.id);
-                    setSelectedResourceIdx(idx);
-                  }}
-                  isSelected={tab.id === selectedTabId}
-                  disabled={false}
-                  key={idx}
-                >
-                  {tab?.type === WORKFLOW_RESOURCE_TYPE.INDEX_NAME
-                    ? 'Index'
-                    : 'Pipeline'}
-                </EuiTab>
-              );
-            })}
-          </EuiTabs>
-        </EuiFlexItem>
+        {allResources.length > 1 && (
+          <EuiFlexItem grow={false}>
+            <EuiTabs size="s" expand={false}>
+              {allResources?.map((tab, idx) => {
+                return (
+                  <EuiTab
+                    onClick={() => {
+                      setSelectedTabId(tab.id);
+                      setSelectedResourceIdx(idx);
+                    }}
+                    isSelected={tab.id === selectedTabId}
+                    disabled={false}
+                    key={idx}
+                  >
+                    {tab?.type === WORKFLOW_RESOURCE_TYPE.INDEX_NAME
+                      ? 'Index'
+                      : 'Pipeline'}
+                  </EuiTab>
+                );
+              })}
+            </EuiTabs>
+            <EuiSpacer size="m" />
+          </EuiFlexItem>
+        )}
         {selectedResource !== undefined &&
           selectedResourceDetails !== undefined && (
             <ResourceFlyoutContent
               resource={selectedResource}
               resourceDetails={selectedResourceDetails}
-              errorMessage={props.errorMessage}
+              errorMessage={selectedResourceErrorMessage}
             />
           )}
       </EuiFlyoutBody>

--- a/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
+++ b/public/pages/workflow_detail/tools/resources/resources_flyout.tsx
@@ -37,6 +37,10 @@ interface ResourcesFlyoutProps {
   resources: WorkflowResource[];
   selectedStep: CONFIG_STEP;
   onClose: () => void;
+  indexName?: string;
+  searchPipelineName?: string;
+  ingestPipelineName?: string;
+  searchQuery?: string;
 }
 
 /**
@@ -176,6 +180,10 @@ export function ResourcesFlyout(props: ResourcesFlyoutProps) {
               resource={selectedResource}
               resourceDetails={selectedResourceDetails}
               errorMessage={selectedResourceErrorMessage}
+              indexName={props.indexName}
+              ingestPipelineName={props.ingestPipelineName}
+              searchPipelineName={props.searchPipelineName}
+              searchQuery={props.searchQuery}
             />
           )}
       </EuiFlyoutBody>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -703,26 +703,43 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                   <h2>{onIngest ? 'Ingest flow' : 'Search flow'}</h2>
                 </EuiText>
               </EuiFlexItem>
-              {onIngestAndUnprovisioned && (
-                <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
-                  <BooleanField
-                    fieldPath="ingest.enabled"
-                    label="Enable ingest flow"
-                    type="Switch"
-                  />
-                </EuiFlexItem>
-              )}
-              {(ingestProvisioned || searchProvisioned) && (
-                <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
-                  <EuiButtonEmpty
-                    iconSide="left"
-                    iconType="play"
-                    onClick={() => props.displaySearchPanel()}
-                  >
-                    Test flow
-                  </EuiButtonEmpty>
-                </EuiFlexItem>
-              )}
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup direction="row" gutterSize="s">
+                  {onIngestAndUnprovisioned && (
+                    <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
+                      <BooleanField
+                        fieldPath="ingest.enabled"
+                        label="Enable ingest flow"
+                        type="Switch"
+                      />
+                    </EuiFlexItem>
+                  )}
+                  {(ingestProvisioned || searchProvisioned) && (
+                    <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
+                      <EuiButtonEmpty
+                        iconSide="left"
+                        iconType="play"
+                        onClick={() => props.displaySearchPanel()}
+                      >
+                        Test flow
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )}
+                  {onIngest && ingestProvisioned && (
+                    <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
+                      <EuiButtonEmpty
+                        iconSide="left"
+                        iconType="inspect"
+                        onClick={() => {
+                          console.log('clicking details...');
+                        }}
+                      >
+                        Details
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
+              </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -6,7 +6,6 @@
 import React, { useEffect, useState } from 'react';
 import { getIn, useFormikContext } from 'formik';
 import { isEmpty, isEqual } from 'lodash';
-import semver from 'semver';
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -25,7 +24,6 @@ import {
 import {
   CONFIG_STEP,
   CachedFormikState,
-  MINIMUM_FULL_SUPPORTED_VERSION,
   SimulateIngestPipelineResponseVerbose,
   TemplateNode,
   WORKFLOW_STEP_TYPE,
@@ -59,8 +57,9 @@ import {
   getDataSourceId,
   prepareDocsForSimulate,
   getIngestPipelineErrors,
-  getEffectiveVersion,
   sleep,
+  useDataSourceVersion,
+  getIsPreV219,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -102,21 +101,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   } = useFormikContext<WorkflowFormValues>();
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
-  const [dataSourceVersion, setDataSourceVersion] = useState<
-    string | undefined
-  >(undefined);
-  useEffect(() => {
-    async function getVersion() {
-      if (dataSourceId !== undefined) {
-        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
-      }
-    }
-    getVersion();
-  }, [dataSourceId]);
-  const isPreV219 =
-    dataSourceVersion !== undefined
-      ? semver.lt(dataSourceVersion, MINIMUM_FULL_SUPPORTED_VERSION)
-      : false;
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
+  const isPreV219 = getIsPreV219(dataSourceVersion);
 
   // transient running states
   const [isUpdatingSearchPipeline, setIsUpdatingSearchPipeline] = useState<

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -63,6 +63,7 @@ import {
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
+import { ResourcesFlyout } from '../tools/resources/resources_flyout';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;
@@ -116,6 +117,11 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   // last ingested state
   const [lastIngested, setLastIngested] = useState<number | undefined>(
     undefined
+  );
+
+  // resource details state
+  const [resourcesFlyoutOpen, setResourcesFlyoutOpen] = useState<boolean>(
+    false
   );
 
   // maintain global states
@@ -684,6 +690,13 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
       className="workspace-panel"
       borderRadius="l"
     >
+      {resourcesFlyoutOpen && (
+        <ResourcesFlyout
+          resources={props.workflow?.resourcesCreated || []}
+          selectedStep={props.selectedStep}
+          onClose={() => setResourcesFlyoutOpen(false)}
+        />
+      )}
       {props.uiConfig === undefined ? (
         <EuiLoadingSpinner size="xl" />
       ) : (
@@ -725,19 +738,19 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       </EuiButtonEmpty>
                     </EuiFlexItem>
                   )}
-                  {onIngest && ingestProvisioned && (
-                    <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
-                      <EuiButtonEmpty
-                        iconSide="left"
-                        iconType="inspect"
-                        onClick={() => {
-                          console.log('clicking details...');
-                        }}
-                      >
-                        Details
-                      </EuiButtonEmpty>
-                    </EuiFlexItem>
-                  )}
+                  {((onIngest && ingestProvisioned) ||
+                    (onSearch && searchProvisioned)) &&
+                    props.workflow?.resourcesCreated !== undefined && (
+                      <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
+                        <EuiButtonEmpty
+                          iconSide="left"
+                          iconType="inspect"
+                          onClick={() => setResourcesFlyoutOpen(true)}
+                        >
+                          Details
+                        </EuiButtonEmpty>
+                      </EuiFlexItem>
+                    )}
                 </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -695,6 +695,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           resources={props.workflow?.resourcesCreated || []}
           selectedStep={props.selectedStep}
           onClose={() => setResourcesFlyoutOpen(false)}
+          indexName={getIn(values, 'ingest.index.name')}
+          ingestPipelineName={getIn(values, 'ingest.pipelineName')}
+          searchPipelineName={getIn(values, 'search.pipelineName')}
+          searchQuery={getIn(values, 'search.request')}
         />
       )}
       {props.uiConfig === undefined ? (

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -20,6 +20,7 @@ import {
   EuiBottomBar,
   EuiIconTip,
   EuiSmallButtonIcon,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import {
   CONFIG_STEP,
@@ -723,6 +724,17 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     label="Enable ingest flow"
                     type="Switch"
                   />
+                </EuiFlexItem>
+              )}
+              {(ingestProvisioned || searchProvisioned) && (
+                <EuiFlexItem grow={false} style={{ marginTop: '20px' }}>
+                  <EuiButtonEmpty
+                    iconSide="left"
+                    iconType="play"
+                    onClick={() => props.displaySearchPanel()}
+                  >
+                    Test flow
+                  </EuiButtonEmpty>
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -38,8 +38,8 @@ import { DataSourceSelectableConfig } from '../../../../../src/plugins/data_sour
 import {
   dataSourceFilterFn,
   getDataSourceFromURL,
-  getEffectiveVersion,
   isDataSourceReady,
+  useDataSourceVersion,
 } from '../../utils/utils';
 import {
   getDataSourceManagementPlugin,
@@ -91,17 +91,7 @@ export function Workflows(props: WorkflowsProps) {
   const [dataSourceId, setDataSourceId] = useState<string | undefined>(
     queryParams.dataSourceId
   );
-  const [dataSourceVersion, setDataSourceVersion] = useState<
-    string | undefined
-  >(undefined);
-  useEffect(() => {
-    async function getVersion() {
-      if (dataSourceId !== undefined) {
-        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
-      }
-    }
-    getVersion();
-  }, [dataSourceId]);
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );

--- a/public/utils/config_to_template_utils.test.tsx
+++ b/public/utils/config_to_template_utils.test.tsx
@@ -10,110 +10,141 @@ describe('config_to_template_utils', () => {
   beforeEach(() => {});
   describe('updatePathForExpandedQuery', () => {
     test('term query', () => {
-      expect(
-        updatePathForExpandedQuery('query.term.a') === 'query.term.a.value'
+      expect(updatePathForExpandedQuery('query.term.a')).toEqual(
+        'query.term.a.value'
+      );
+      expect(updatePathForExpandedQuery('query.term.a.value')).toEqual(
+        'query.term.a.value'
+      );
+      expect(updatePathForExpandedQuery('query.term.abc')).toEqual(
+        'query.term.abc.value'
+      );
+      expect(updatePathForExpandedQuery('query.term.abc.value')).toEqual(
+        'query.term.abc.value'
+      );
+      expect(updatePathForExpandedQuery('$.query.term.abc.value')).toEqual(
+        '$.query.term.abc.value'
+      );
+      expect(updatePathForExpandedQuery('query.bool.must[0].term.abc')).toEqual(
+        'query.bool.must[0].term.abc.value'
       );
       expect(
-        updatePathForExpandedQuery('query.term.a.value') ===
-          'query.term.a.value'
-      );
-      expect(
-        updatePathForExpandedQuery('$.query.term.a') === '$.query.term.a.value'
-      );
-      expect(
-        updatePathForExpandedQuery('a.b.c.d.query.term.a') ===
-          'a.b.c.d.query.term.a.value'
-      );
-      expect(
-        updatePathForExpandedQuery('query.bool.must[0].term.a') ===
-          'query.bool.must[0].term.a.value'
-      );
+        updatePathForExpandedQuery('query.bool.must[0].term.ab_c')
+      ).toEqual('query.bool.must[0].term.ab_c.value');
     });
     test('prefix query', () => {
-      expect(
-        updatePathForExpandedQuery('query.prefix.a') === 'query.prefix.a.value'
+      expect(updatePathForExpandedQuery('query.prefix.a')).toEqual(
+        'query.prefix.a.value'
       );
-      expect(
-        updatePathForExpandedQuery('query.prefix.a.value') ===
-          'query.prefix.a.value'
+      expect(updatePathForExpandedQuery('query.prefix.a.value')).toEqual(
+        'query.prefix.a.value'
+      );
+      expect(updatePathForExpandedQuery('query.prefix.abc')).toEqual(
+        'query.prefix.abc.value'
+      );
+      expect(updatePathForExpandedQuery('query.prefix.abc.value')).toEqual(
+        'query.prefix.abc.value'
       );
     });
     test('fuzzy query', () => {
-      expect(
-        updatePathForExpandedQuery('query.fuzzy.a') === 'query.fuzzy.a.value'
+      expect(updatePathForExpandedQuery('query.fuzzy.a')).toEqual(
+        'query.fuzzy.a.value'
       );
-      expect(
-        updatePathForExpandedQuery('query.fuzzy.a.value') ===
-          'query.fuzzy.a.value'
+      expect(updatePathForExpandedQuery('query.fuzzy.a.value')).toEqual(
+        'query.fuzzy.a.value'
+      );
+      expect(updatePathForExpandedQuery('query.fuzzy.abc')).toEqual(
+        'query.fuzzy.abc.value'
+      );
+      expect(updatePathForExpandedQuery('query.fuzzy.abc.value')).toEqual(
+        'query.fuzzy.abc.value'
       );
     });
     test('wildcard query', () => {
-      expect(
-        updatePathForExpandedQuery('query.wildcard.a') ===
-          'query.wildcard.a.wildcard'
+      expect(updatePathForExpandedQuery('query.wildcard.a')).toEqual(
+        'query.wildcard.a.wildcard'
       );
-      expect(
-        updatePathForExpandedQuery('query.wildcard.a.wildcard') ===
-          'query.wildcard.a.wildcard'
+      expect(updatePathForExpandedQuery('query.wildcard.a.wildcard')).toEqual(
+        'query.wildcard.a.wildcard'
+      );
+      expect(updatePathForExpandedQuery('query.wildcard.abc')).toEqual(
+        'query.wildcard.abc.wildcard'
+      );
+      expect(updatePathForExpandedQuery('query.wildcard.abc.wildcard')).toEqual(
+        'query.wildcard.abc.wildcard'
       );
     });
     test('regexp query', () => {
-      expect(
-        updatePathForExpandedQuery('query.regexp.a') === 'query.regexp.a.value'
+      expect(updatePathForExpandedQuery('query.regexp.a')).toEqual(
+        'query.regexp.a.value'
       );
-      expect(
-        updatePathForExpandedQuery('query.regexp.a.value') ===
-          'query.regexp.a.value'
+      expect(updatePathForExpandedQuery('query.regexp.a.value')).toEqual(
+        'query.regexp.a.value'
+      );
+      expect(updatePathForExpandedQuery('query.regexp.abc')).toEqual(
+        'query.regexp.abc.value'
+      );
+      expect(updatePathForExpandedQuery('query.regexp.abc.value')).toEqual(
+        'query.regexp.abc.value'
       );
     });
     test('match query', () => {
-      expect(
-        updatePathForExpandedQuery('query.match.a') === 'query.match.a.query'
+      expect(updatePathForExpandedQuery('query.match.a')).toEqual(
+        'query.match.a.query'
       );
-      expect(
-        updatePathForExpandedQuery('query.match.a.query') ===
-          'query.match.a.query'
+      expect(updatePathForExpandedQuery('query.match.a.query')).toEqual(
+        'query.match.a.query'
+      );
+      expect(updatePathForExpandedQuery('query.match.item_text')).toEqual(
+        'query.match.item_text.query'
+      );
+      expect(updatePathForExpandedQuery('query.match.item_text.query')).toEqual(
+        'query.match.item_text.query'
       );
     });
     test('match bool prefix query', () => {
       expect(
-        updatePathForExpandedQuery('query.match_bool_prefix.a') ===
-          'query.match_bool_prefix.a.query'
-      );
+        updatePathForExpandedQuery('query.match_bool_prefix.a.query')
+      ).toEqual('query.match_bool_prefix.a.query');
       expect(
-        updatePathForExpandedQuery('query.match_bool_prefix.a.query') ===
-          'query.match_bool_prefix.a.query'
-      );
+        updatePathForExpandedQuery('query.match_bool_prefix.item_text')
+      ).toEqual('query.match_bool_prefix.item_text.query');
+      expect(
+        updatePathForExpandedQuery('query.match_bool_prefix.item_text.query')
+      ).toEqual('query.match_bool_prefix.item_text.query');
     });
     test('match phrase query', () => {
-      expect(
-        updatePathForExpandedQuery('query.match_phrase.a') ===
-          'query.match_phrase.a.query'
+      expect(updatePathForExpandedQuery('query.match_phrase.a.query')).toEqual(
+        'query.match_phrase.a.query'
       );
       expect(
-        updatePathForExpandedQuery('query.match_phrase.a.query') ===
-          'query.match_phrase.a.query'
-      );
+        updatePathForExpandedQuery('query.match_phrase.item_text')
+      ).toEqual('query.match_phrase.item_text.query');
+      expect(
+        updatePathForExpandedQuery('query.match_phrase.item_text.query')
+      ).toEqual('query.match_phrase.item_text.query');
     });
     test('match phrase prefix query', () => {
       expect(
-        updatePathForExpandedQuery('query.match_phrase_prefix.a') ===
-          'query.match_phrase_prefix.a.query'
-      );
+        updatePathForExpandedQuery('query.match_phrase_prefix.a.query')
+      ).toEqual('query.match_phrase_prefix.a.query');
       expect(
-        updatePathForExpandedQuery('query.match_phrase_prefix.a.query') ===
-          'query.match_phrase_prefix.a.query'
-      );
+        updatePathForExpandedQuery('query.match_phrase_prefix.item_text')
+      ).toEqual('query.match_phrase_prefix.item_text.query');
+      expect(
+        updatePathForExpandedQuery('query.match_phrase_prefix.item_text.query')
+      ).toEqual('query.match_phrase_prefix.item_text.query');
     });
     test('aggs query', () => {
-      expect(
-        updatePathForExpandedQuery('aggs.avg_a.avg.field') ===
-          'aggregations.avg_a.avg.field'
+      expect(updatePathForExpandedQuery('aggs.avg_a.avg.field')).toEqual(
+        'aggregations.avg_a.avg.field'
       );
       expect(
-        updatePathForExpandedQuery('aggs.b.c.d.aggs.avg_a.avg.field') ===
-          'aggregations.b.c.d.aggregations.avg_a.avg.field'
-      );
+        updatePathForExpandedQuery('aggs.b.c.d.aggs.avg_a.avg.field')
+      ).toEqual('aggregations.b.c.d.aggregations.avg_a.avg.field');
+      expect(
+        updatePathForExpandedQuery('aggs.b.c.d_e_f.aggs.avg_a.avg.field_abc')
+      ).toEqual('aggregations.b.c.d_e_f.aggregations.avg_a.avg.field_abc');
     });
   });
 });

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -705,17 +705,16 @@ export function updatePathForExpandedQuery(path: string): string {
 // If the path already has the suffix present, do nothing.
 function addSuffixToPath(path: string, prefix: string, suffix: string): string {
   function generateRegex(prefix: string, suffix: string): RegExp {
-    // match the specified prefix, followed by some value in dot or bracket notation
-    const notationPattern = `\\b${prefix}\\b(\\.\\w+|\\[\\w+\\])`;
-    // ensure the suffix (in dot or bracket notation) is not present
-    const suffixPattern = `(?!(\\.${suffix}|\\[${suffix}\\]))`;
-    return new RegExp(notationPattern + suffixPattern, 'g');
+    // ensure the suffix (in dot or bracket notation) is not present, and match
+    // on the prefix, followed by some value in dot notation
+    const finalPattern = `(?!.*(\\.\\b${suffix}\\b|\\[\\b${suffix}\\b\\])).*\\b${prefix}\\b\\.(.+)`;
+    return new RegExp(finalPattern, 'g');
   }
 
   // if the pattern matches, append the appropriate suffix via dot notation
   const regexPattern = generateRegex(prefix, suffix);
-  return path.replace(regexPattern, (_, subStr) => {
-    return `${prefix}${subStr}.${suffix}`;
+  return path.replace(regexPattern, (pattern) => {
+    return `${pattern}.${suffix}`;
   });
 }
 

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import yaml from 'js-yaml';
 import jsonpath from 'jsonpath';
 import { capitalize, escape, findKey, get, isEmpty, set, unset } from 'lodash';
@@ -43,6 +43,7 @@ import {
   MODEL_ID_PATTERN,
   WORKFLOW_TYPE,
   MIN_SUPPORTED_VERSION,
+  MINIMUM_FULL_SUPPORTED_VERSION,
 } from '../../common';
 import {
   getCore,
@@ -527,6 +528,29 @@ export const getDataSourceId = () => {
   const mdsQueryParams = getDataSourceFromURL(location);
   return mdsQueryParams.dataSourceId;
 };
+
+export function useDataSourceVersion(
+  dataSourceId: string | undefined
+): string | undefined {
+  const [dataSourceVersion, setDataSourceVersion] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    async function getVersion() {
+      if (dataSourceId !== undefined) {
+        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
+      }
+    }
+    getVersion();
+  }, [dataSourceId]);
+  return dataSourceVersion;
+}
+
+export function getIsPreV219(dataSourceVersion: string | undefined): boolean {
+  return dataSourceVersion !== undefined
+    ? semver.lt(dataSourceVersion, MINIMUM_FULL_SUPPORTED_VERSION)
+    : false;
+}
 
 export const isDataSourceReady = (dataSourceId?: string) => {
   const dataSourceEnabled = getDataSourceEnabled().enabled;


### PR DESCRIPTION
### Description

This PR adds several new buttons in the form headers for performing different actions:
- "Test flow" button which automatically opens and navigates to the "Test flow" tab in the inspector
- "Details" button which automatically opens a flyout for the relevant resources (if created) for a particular context. On ingest, at most show the index and ingest pipeline (nest them under tabs if both found). On ingest, at most show the search pipeline
- Update the newly-added flyouts and existing flyouts to show usage examples leveraging runtime data if found - for example, use the configured index name, ingest pipeline name, search pipeline name, and/or search query, if found.

Also:
- moves data source version checks into a reusable custom hook
- fixes query parsing bug which caused failures on matching strings > 1 character

Demo video, showing the updated flyouts and buttons in the form headers:

[screen-capture (29).webm](https://github.com/user-attachments/assets/717817be-8a2d-46a6-adc0-d9aab095c9d8)

### Issues Resolved

Closes #656 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
