### PR TITLE
Block simulate API calls if datasource version is missing

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -53,6 +53,8 @@ import {
   injectParameters,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
+  useDataSourceVersion,
+  useMissingDataSourceVersion,
 } from '../../../../../../utils';
 import { TextField } from '../../../input_fields';
 import {
@@ -94,6 +96,11 @@ const MAX_INPUT_DOCS = 10;
 export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
+  const missingDataSourceVersion = useMissingDataSourceVersion(
+    dataSourceId,
+    dataSourceVersion
+  );
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
   >();
@@ -407,6 +414,8 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                             style={{ width: '100px' }}
                             isLoading={isFetching}
                             disabled={
+                              (props.context === PROCESSOR_CONTEXT.INGEST &&
+                                missingDataSourceVersion) ||
                               onIngestAndNoDocs ||
                               onSearchAndNoQuery ||
                               !props.isDataFetchingAvailable ||

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -51,6 +51,8 @@ import {
   injectParameters,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
+  useDataSourceVersion,
+  useMissingDataSourceVersion,
 } from '../../../../../../utils';
 import { TextField } from '../../../input_fields';
 import {
@@ -91,6 +93,11 @@ export function ConfigureMultiExpressionModal(
 ) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
+  const missingDataSourceVersion = useMissingDataSourceVersion(
+    dataSourceId,
+    dataSourceVersion
+  );
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
   >();
@@ -433,6 +440,8 @@ export function ConfigureMultiExpressionModal(
                             style={{ width: '100px' }}
                             isLoading={isFetching}
                             disabled={
+                              (props.context === PROCESSOR_CONTEXT.INGEST &&
+                                missingDataSourceVersion) ||
                               onIngestAndNoDocs ||
                               onSearchAndNoQuery ||
                               !props.isDataFetchingAvailable ||

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -57,6 +57,8 @@ import {
   injectParameters,
   prepareDocsForSimulate,
   unwrapTransformedDocs,
+  useDataSourceVersion,
+  useMissingDataSourceVersion,
 } from '../../../../../../utils';
 import { TextField } from '../../../input_fields';
 import {
@@ -102,6 +104,11 @@ const PROMPT_EDITOR_ID = 'promptEditor';
 export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
+  const missingDataSourceVersion = useMissingDataSourceVersion(
+    dataSourceId,
+    dataSourceVersion
+  );
   const { values, setFieldValue, setFieldTouched } = useFormikContext<
     WorkflowFormValues
   >();
@@ -638,6 +645,8 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                             style={{ width: '100px' }}
                             isLoading={isFetching}
                             disabled={
+                              (props.context === PROCESSOR_CONTEXT.INGEST &&
+                                missingDataSourceVersion) ||
                               onIngestAndNoDocs ||
                               onSearchAndNoQuery ||
                               !props.isDataFetchingAvailable ||

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -122,7 +122,7 @@ export function ProcessorsList(props: ProcessorsListProps) {
     if (dataSourceId !== undefined) {
       getEffectiveVersion(dataSourceId)
         .then((ver) => {
-          setVersion(ver);
+          setVersion(ver || MIN_SUPPORTED_VERSION);
         })
         .catch(console.error);
     }

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -32,7 +32,7 @@ import {
 import {
   formikToUiConfig,
   getDataSourceFromURL,
-  getEffectiveVersion,
+  getDataSourceVersion,
 } from '../../../utils';
 import {
   CollapseProcessor,
@@ -120,7 +120,7 @@ export function ProcessorsList(props: ProcessorsListProps) {
     }
 
     if (dataSourceId !== undefined) {
-      getEffectiveVersion(dataSourceId)
+      getDataSourceVersion(dataSourceId)
         .then((ver) => {
           setVersion(ver || MIN_SUPPORTED_VERSION);
         })

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -11,6 +11,7 @@ import { EnrichSearchRequest } from './enrich_search_request';
 import { EnrichSearchResponse } from './enrich_search_response';
 import {
   CachedFormikState,
+  MIN_SUPPORTED_VERSION,
   OMIT_SYSTEM_INDEX_PATTERN,
   WorkflowConfig,
 } from '../../../../../common';
@@ -42,10 +43,11 @@ export function SearchInputs(props: SearchInputsProps) {
     const checkVersion = async () => {
       try {
         if (dataSourceId !== undefined) {
-          const version = await getEffectiveVersion(dataSourceId);
+          const version =
+            (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
           setShowTransformQuery(semver.gte(version, '2.19.0'));
         } else {
-          setShowTransformQuery(true); 
+          setShowTransformQuery(true);
         }
       } catch (error) {
         console.error('Error checking version:', error);

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/search_inputs.tsx
@@ -16,7 +16,7 @@ import {
   WorkflowConfig,
 } from '../../../../../common';
 import { catIndices, useAppDispatch } from '../../../../store';
-import { getDataSourceId, getEffectiveVersion } from '../../../../utils';
+import { getDataSourceId, getDataSourceVersion } from '../../../../utils';
 
 interface SearchInputsProps {
   uiConfig: WorkflowConfig;
@@ -44,7 +44,7 @@ export function SearchInputs(props: SearchInputsProps) {
       try {
         if (dataSourceId !== undefined) {
           const version =
-            (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
+            (await getDataSourceVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
           setShowTransformQuery(semver.gte(version, '2.19.0'));
         } else {
           setShowTransformQuery(true);

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -60,6 +60,7 @@ import {
   sleep,
   useDataSourceVersion,
   getIsPreV219,
+  useMissingDataSourceVersion,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -104,6 +105,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   const dataSourceId = getDataSourceId();
   const dataSourceVersion = useDataSourceVersion(dataSourceId);
   const isPreV219 = getIsPreV219(dataSourceVersion);
+  const missingDataSourceVersion = useMissingDataSourceVersion(
+    dataSourceId,
+    dataSourceVersion
+  );
 
   // transient running states
   const [isUpdatingSearchPipeline, setIsUpdatingSearchPipeline] = useState<
@@ -610,7 +615,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
           if (
             !isEmpty(values?.ingest?.enrich) &&
             values?.ingest?.pipelineName !== undefined &&
-            values?.ingest?.pipelineName !== ''
+            values?.ingest?.pipelineName !== '' &&
+            // if the data source version is missing/undefined, we cannot
+            // guarantee that the simulate API will be available
+            !missingDataSourceVersion
           ) {
             const curDocs = prepareDocsForSimulate(
               values?.ingest?.docs,

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -44,7 +44,11 @@ import {
   WORKFLOW_NAME_RESTRICTIONS,
 } from '../../../../common';
 import { WORKFLOWS_TAB } from '../workflows';
-import { getDataSourceId, getEffectiveVersion, formatDisplayVersion } from '../../../utils/utils';
+import {
+  getDataSourceId,
+  formatDisplayVersion,
+  useDataSourceVersion,
+} from '../../../utils/utils';
 
 interface ImportWorkflowModalProps {
   isImportModalOpen: boolean;
@@ -62,17 +66,7 @@ interface ImportWorkflowModalProps {
 export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
-  const [dataSourceVersion, setDataSourceVersion] = useState<
-    string | undefined
-  >(undefined);
-  useEffect(() => {
-    async function getVersion() {
-      if (dataSourceId !== undefined) {
-        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
-      }
-    }
-    getVersion();
-  }, [dataSourceId]);
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
   const { workflows } = useSelector((state: AppState) => state.workflows);
 
   // workflow name state
@@ -171,7 +165,9 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
             <>
               <EuiFlexItem>
                 <EuiCallOut
-                  title={`The uploaded file is not compatible with the current data source version ${formatDisplayVersion(dataSourceVersion)}. Upload a compatible file or switch to another data source.`}
+                  title={`The uploaded file is not compatible with the current data source version ${formatDisplayVersion(
+                    dataSourceVersion
+                  )}. Upload a compatible file or switch to another data source.`}
                   iconType={'alert'}
                   color="danger"
                 />

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -64,7 +64,8 @@ const filterPresetsByVersion = async (
     WORKFLOW_TYPE.CUSTOM,
   ];
 
-  const version = await getEffectiveVersion(dataSourceId);
+  const version =
+    (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
 
   if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
     return [];
@@ -159,7 +160,8 @@ export function NewWorkflow(props: NewWorkflowProps) {
         return;
       }
 
-      const version = await getEffectiveVersion(dataSourceId);
+      const version =
+        (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
 
       const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
         enrichPresetWorkflowWithUiMetadata(presetWorkflow, version)

--- a/public/pages/workflows/new_workflow/new_workflow.tsx
+++ b/public/pages/workflows/new_workflow/new_workflow.tsx
@@ -30,7 +30,7 @@ import { enrichPresetWorkflowWithUiMetadata } from './utils';
 import {
   getDataSourceId,
   isDataSourceReady,
-  getEffectiveVersion,
+  getDataSourceVersion,
 } from '../../../utils';
 import { getDataSourceEnabled } from '../../../services';
 import semver from 'semver';
@@ -65,7 +65,7 @@ const filterPresetsByVersion = async (
   ];
 
   const version =
-    (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
+    (await getDataSourceVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
 
   if (semver.lt(version, MIN_SUPPORTED_VERSION)) {
     return [];
@@ -161,7 +161,7 @@ export function NewWorkflow(props: NewWorkflowProps) {
       }
 
       const version =
-        (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
+        (await getDataSourceVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
 
       const enrichedWorkflows = presetWorkflows.map((presetWorkflow) =>
         enrichPresetWorkflowWithUiMetadata(presetWorkflow, version)

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -260,7 +260,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
               <EuiFlexGroup direction="column" gutterSize="s">
                 <EuiFlexItem>
                   <TextField
-                    label="Name - required"
+                    label="Name"
                     fullWidth={true}
                     fieldPath={`name`}
                     showError={true}
@@ -308,7 +308,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                         modelCategory={MODEL_CATEGORY.LLM}
                         fieldPath="llm"
                         showMissingInterfaceCallout={false}
-                        label="Large language model - required"
+                        label="Large language model"
                         helpText="The large language model to generate user-friendly responses."
                         fullWidth={true}
                         showError={true}
@@ -340,7 +340,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                           modelCategory={MODEL_CATEGORY.EMBEDDING}
                           fieldPath="embeddingModel"
                           showMissingInterfaceCallout={false}
-                          label="Embedding model - required"
+                          label="Embedding model"
                           helpText="The model to generate embeddings."
                           fullWidth={true}
                           showError={true}

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -175,7 +175,7 @@ export async function isCompatibleWorkflow(
   }
 
   const dataSourceVersion =
-    (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
+    (await getDataSourceVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
   const [
     effectiveMajorVersion,
     effectiveMinorVersion,
@@ -573,7 +573,7 @@ export function useDataSourceVersion(
   useEffect(() => {
     async function getVersion() {
       if (dataSourceId !== undefined) {
-        setDataSourceVersion(await getEffectiveVersion(dataSourceId));
+        setDataSourceVersion(await getDataSourceVersion(dataSourceId));
       }
     }
     getVersion();
@@ -946,7 +946,7 @@ export function getFieldValue(jsonObj: {}, fieldName: string): any | undefined {
 }
 
 // Get the version from the selected data source, if found
-export const getEffectiveVersion = async (
+export const getDataSourceVersion = async (
   dataSourceId: string | undefined
 ): Promise<string | undefined> => {
   try {

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -174,7 +174,8 @@ export async function isCompatibleWorkflow(
     return true;
   }
 
-  const dataSourceVersion = await getEffectiveVersion(dataSourceId);
+  const dataSourceVersion =
+    (await getEffectiveVersion(dataSourceId)) || MIN_SUPPORTED_VERSION;
   const [
     effectiveMajorVersion,
     effectiveMinorVersion,

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -160,26 +160,37 @@ export function isValidWorkflow(workflowObj: any): boolean {
 
 // Determines if a file used for import workflow is compatible with the current data source version.
 export async function isCompatibleWorkflow(
-  workflowObj: any, 
+  workflowObj: any,
   dataSourceId?: string | undefined
 ): Promise<boolean> {
   const compatibility = workflowObj?.version?.compatibility;
 
   // Default to true when compatibility cannot be assessed (empty/invalid compatibility array or MDS disabled.)
-  if (!Array.isArray(compatibility) || compatibility.length === 0 || dataSourceId === undefined) {
+  if (
+    !Array.isArray(compatibility) ||
+    compatibility.length === 0 ||
+    dataSourceId === undefined
+  ) {
     return true;
   }
 
-  const dataSourceVersion = await getEffectiveVersion(dataSourceId);  
-  const [effectiveMajorVersion, effectiveMinorVersion] = dataSourceVersion.split('.').map(Number);
-  
+  const dataSourceVersion = await getEffectiveVersion(dataSourceId);
+  const [
+    effectiveMajorVersion,
+    effectiveMinorVersion,
+  ] = dataSourceVersion.split('.').map(Number);
+
   // Checks if any version in compatibility array matches the current dataSourceVersion (major.minor)
-  return compatibility.some(compatibleVersion => {
-    const [compatibleMajor, compatibleMinor] = compatibleVersion.split('.').map(Number);
-    return effectiveMajorVersion === compatibleMajor && effectiveMinorVersion === compatibleMinor;
+  return compatibility.some((compatibleVersion) => {
+    const [compatibleMajor, compatibleMinor] = compatibleVersion
+      .split('.')
+      .map(Number);
+    return (
+      effectiveMajorVersion === compatibleMajor &&
+      effectiveMinorVersion === compatibleMinor
+    );
   });
 }
-
 
 export function isValidUiWorkflow(workflowObj: any): boolean {
   return (
@@ -933,13 +944,13 @@ export function getFieldValue(jsonObj: {}, fieldName: string): any | undefined {
   return undefined;
 }
 
-// Get the version from the selected data source
+// Get the version from the selected data source, if found
 export const getEffectiveVersion = async (
   dataSourceId: string | undefined
-): Promise<string> => {
+): Promise<string | undefined> => {
   try {
     if (dataSourceId === undefined) {
-      throw new Error('Data source is required');
+      throw new Error();
     }
 
     if (dataSourceId === '') {
@@ -951,16 +962,26 @@ export const getEffectiveVersion = async (
       'data-source',
       dataSourceId
     );
-    const version =
-      dataSource?.attributes?.dataSourceVersion || MIN_SUPPORTED_VERSION;
-    return version;
+    return dataSource?.attributes?.dataSourceVersion;
   } catch (error) {
-    console.error('Error getting version:', error);
-    return MIN_SUPPORTED_VERSION;
+    console.error('Error getting version: ', error);
+    return undefined;
   }
 };
 
-    
+export function useMissingDataSourceVersion(
+  dataSourceId: string | undefined,
+  dataSourceVersion: string | undefined
+): boolean {
+  const [missingVersion, setMissingVersion] = useState<boolean>(false);
+  useEffect(() => {
+    setMissingVersion(
+      dataSourceId !== undefined && dataSourceVersion === undefined
+    );
+  }, [dataSourceId, dataSourceVersion]);
+  return missingVersion;
+}
+
 /**
  * Formats version string to show only major.minor numbers
  * Example: "3.0.0-alpha1" -> "3.0"
@@ -970,4 +991,3 @@ export function formatDisplayVersion(version: string): string {
   const [major, minor] = version.split('.');
   return `${major}.${minor}`;
 }
-


### PR DESCRIPTION
### Description

If there is a datasource ID, but no known version found, we cannot guarantee that the simulate API will be available. This PR adds a reusable custom hook to check for that scenario, and adds conditional checks for all places where `simulatePipeline()` is called:
- `WorkflowInputs` component
- Configure expression modal
- Configure multi-expression modal
- Configure template (prompt) modal

To make this work, `getEffectiveVersion()` was updated slightly to return `undefined` instead of defaulting to the minimum version, since this undefined/empty case now needs to be handled. Audited all places where `getEffectiveVersion` is called, where a minimum version is wanted, and updated there. Updated the name to `getDataSourceVersion()` to reflect this more clearly as well.

Also moves datasource-related logic into custom hooks for readability and reusability.

Also removes unnecessary '- required' text on quick config required fields to follow consistent pattern.


Testing
- tested for all 4 scenarios that behavior was expected, if data source version was missing or not. Used dummy data source IDs to trigger

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
