### PR TITLE
Update visible plugin name to 'AI Search Flows'

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -13,7 +13,8 @@ import {
 import { customStringify } from './utils';
 
 export const PLUGIN_ID = 'opensearch-flow';
-export const PLUGIN_NAME = 'OpenSearch Flow';
+export const PLUGIN_NAME = 'AI Search Flows'; // visible plugin name in the context of OSD
+export const OPENSEARCH_FLOW = 'OpenSearch Flow'; // overall feature / name that the plugin encapsulates
 
 /**
  * BACKEND FLOW FRAMEWORK APIs

--- a/public/general_components/service_card/plugin_card.tsx
+++ b/public/general_components/service_card/plugin_card.tsx
@@ -12,14 +12,13 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { PLUGIN_ID } from '../../../common';
+import { PLUGIN_ID, PLUGIN_NAME } from '../../../common';
 import { ContentManagementPluginStart } from '../../../../../src/plugins/content_management/public';
 import { CoreStart } from '../../../../../src/core/public';
 import pluginIcon from './icon.svg';
 
 const HEADER_TEXT = 'Design and test your search solutions with ease';
-const DESCRIPTION_TEXT =
-  'OpenSearch Flow is a visual editor for creating search AI flows to power advanced search and generative AI solutions.';
+const DESCRIPTION_TEXT = `${PLUGIN_NAME} is a visual editor for creating search AI flows to power advanced search and generative AI solutions.`;
 
 export const registerPluginCard = (
   contentManagement: ContentManagementPluginStart,

--- a/public/pages/workflows/import_workflow/import_workflow_modal.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.tsx
@@ -39,6 +39,7 @@ import {
 import {
   FETCH_ALL_QUERY_LARGE,
   MAX_DESCRIPTION_LENGTH,
+  PLUGIN_NAME,
   Workflow,
   WORKFLOW_NAME_REGEXP,
   WORKFLOW_NAME_RESTRICTIONS,
@@ -179,7 +180,7 @@ export function ImportWorkflowModal(props: ImportWorkflowModalProps) {
             <>
               <EuiFlexItem>
                 <EuiCallOut
-                  title="This project is not compatible with OpenSearch Flow. You may not be able to edit or run it."
+                  title={`This project is not compatible with ${PLUGIN_NAME}. You may not be able to edit or run it.`}
                   iconType={'help'}
                   color="warning"
                 />

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -31,7 +31,11 @@ import { WorkflowList } from './workflow_list';
 import { NewWorkflow } from './new_workflow';
 import { AppState, searchWorkflows, useAppDispatch } from '../../store';
 import { EmptyListMessage } from './empty_list_message';
-import { FETCH_ALL_QUERY_LARGE, PLUGIN_NAME } from '../../../common';
+import {
+  FETCH_ALL_QUERY_LARGE,
+  OPENSEARCH_FLOW,
+  PLUGIN_NAME,
+} from '../../../common';
 import { ImportWorkflowModal } from './import_workflow';
 import { MountPoint } from '../../../../../src/core/public';
 import { DataSourceSelectableConfig } from '../../../../../src/plugins/data_source_management/public';
@@ -224,7 +228,7 @@ export function Workflows(props: WorkflowsProps) {
     }, [getSavedObjectsClient, getNotifications(), props.setActionMenu]);
   }
 
-  const DESCRIPTION = `Design, prototype, and experiment with solutions using ${PLUGIN_NAME}. Use the visual interface to build
+  const DESCRIPTION = `Design, prototype, and experiment with solutions using ${OPENSEARCH_FLOW}. Use the visual interface to build
   ingest and search flows, test different configurations, and deploy them to your environment.`;
 
   const pageTitleAndDescription = USE_NEW_HOME_PAGE ? (


### PR DESCRIPTION
### Description

Updates all instances (besides the URL and certain description texts) from "OpenSearch Flow" -> "AI Search Flows". This includes the side navigation item, the breadcrumbs, the plugin title on the home page, and other various texts.

Note the underlying plugin ID remains unchanged to prevent build/registration issues with core OSD. Only user-facing changes have been changed.

#### Testing
- all UT passes
- all IT passes
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/dashboards-flow-framework/c      02:43        6        6        -        -        - │
  │    reate_workflow_spec.js                                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        02:43        6        6        -        -        -  

✨  Done in 194.81s.
```
- manually verified and tested basic use cases work as expected, and all visible instances of "OpenSearch Flow" have been updated accordingly. Tested for both `useNewHomePage=false` and `useNewHomePage=true`. See screenshots below.

![old-1](https://github.com/user-attachments/assets/71c5a19c-fefc-4ab2-8a1d-1393c2aa2651)

![new-1](https://github.com/user-attachments/assets/000e01b1-fd73-4554-9b25-36232b8c500f)

![new-2](https://github.com/user-attachments/assets/418bbcbe-8a62-4255-8588-dd228b29a72f)

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
