### PR TITLE
Update plugin name and rearrange Try AI Search Flows card

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenSearch Flow Framework Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "2.17.0.0",
+    "plugin_version": "2.19.0.0",
     "plugin_name": "flowFrameworkDashboards",
     "plugin_zip_name": "dashboards-flow-framework"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "OpenSearch Flow Framework Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "2.19.0.0",
     "plugin_name": "flowFrameworkDashboards",
     "plugin_zip_name": "dashboards-flow-framework"
   },
@@ -14,7 +13,7 @@
     "opensearch": "../../scripts/use_node ../../scripts/opensearch",
     "lint:es": "../../scripts/use_node ../../scripts/eslint -c eslintrc.json",
     "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip"
+    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_version.zip"
   },
   "repository": {
     "type": "git",

--- a/public/general_components/service_card/plugin_card.tsx
+++ b/public/general_components/service_card/plugin_card.tsx
@@ -37,7 +37,7 @@ export const registerPluginCard = (
           }}
         >
           {i18n.translate('flowFrameworkDashboards.opensearchFlowCard.footer', {
-            defaultMessage: 'Try AI Search Flows',
+            defaultMessage: `Try ${PLUGIN_NAME}`,
           })}
         </EuiSmallButton>
       </EuiFlexItem>

--- a/public/general_components/service_card/plugin_card.tsx
+++ b/public/general_components/service_card/plugin_card.tsx
@@ -37,7 +37,7 @@ export const registerPluginCard = (
           }}
         >
           {i18n.translate('flowFrameworkDashboards.opensearchFlowCard.footer', {
-            defaultMessage: 'Try OpenSearch Flow',
+            defaultMessage: 'Try AI Search Flows',
           })}
         </EuiSmallButton>
       </EuiFlexItem>
@@ -49,7 +49,7 @@ export const registerPluginCard = (
     getContent: () => ({
       id: 'opensearch_flow',
       kind: 'card',
-      order: 20,
+      order: 10,
       getTitle: () => {
         return (
           <EuiFlexGroup direction="row" gutterSize="xs">


### PR DESCRIPTION
### Description

- Update plugin card in Search Overview Page and rearrange "Try AI Search Flows card". 
- **Please recheck when backporting. `Removed "plugin_version": "2.19.0.0" in package.json`. Fixed yarn build script accordingly.** If needed will raise separate PR for main. 

- Relavant PR in OSD https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9500

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).




