### PR TITLE
Fixed yarn build script to use right plugin version and rearranged "Try OpenSearch Flow" card in Search Overview Page (Backport Main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "OpenSearch Flow Framework Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "3.0.0.0-alpha1",
     "plugin_name": "flowFrameworkDashboards",
     "plugin_zip_name": "dashboards-flow-framework"
   },
@@ -14,7 +13,7 @@
     "opensearch": "../../scripts/use_node ../../scripts/opensearch",
     "lint:es": "../../scripts/use_node ../../scripts/eslint -c eslintrc.json",
     "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip"
+    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_version.zip"
   },
   "repository": {
     "type": "git",

--- a/public/general_components/service_card/plugin_card.tsx
+++ b/public/general_components/service_card/plugin_card.tsx
@@ -37,7 +37,7 @@ export const registerPluginCard = (
           }}
         >
           {i18n.translate('flowFrameworkDashboards.opensearchFlowCard.footer', {
-            defaultMessage: 'Try OpenSearch Flow',
+            defaultMessage: `Try ${PLUGIN_NAME}`,
           })}
         </EuiSmallButton>
       </EuiFlexItem>
@@ -49,7 +49,7 @@ export const registerPluginCard = (
     getContent: () => ({
       id: 'opensearch_flow',
       kind: 'card',
-      order: 20,
+      order: 10,
       getTitle: () => {
         return (
           <EuiFlexGroup direction="row" gutterSize="xs">


### PR DESCRIPTION
### Description

- Fixed yarn build script to use right plugin version and rearranged "Try OpenSearch Flow" card in Search Overview Page
- Backporting to main #664 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
