### PR TITLE
Update new index mappings if selecting from existing index

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -221,7 +221,7 @@ export function SourceData(props: SourceDataProps) {
 // helper fn to parse out some useful info from the ML ingest processor config, if applicable
 // takes on the assumption the first processor is an ML inference processor, and should
 // only be executed for workflows coming from preset vector search use cases.
-export function getProcessorInfo(
+function getProcessorInfo(
   uiConfig: WorkflowConfig,
   values: WorkflowFormValues
 ): {

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data_modal.tsx
@@ -123,10 +123,6 @@ export function SourceDataModal(props: SourceDataProps) {
               let existingMappingsObj = JSON.parse(
                 getIn(values, indexMappingsPath)
               );
-              // const existingEmbeddingField = findKey(
-              //   existingMappingsObj?.properties,
-              //   (field) => field.type === 'knn_vector'
-              // );
               const existingEmbeddingField = getExistingVectorField(
                 existingMappingsObj
               );

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -890,10 +890,7 @@ export function removeVectorFieldFromIndexMappings(
 ): string {
   try {
     let existingMappingsObj = JSON.parse(existingMappings);
-    const existingEmbeddingField = findKey(
-      existingMappingsObj?.properties,
-      (field) => field.type === 'knn_vector'
-    );
+    const existingEmbeddingField = getExistingVectorField(existingMappingsObj);
     if (existingEmbeddingField !== undefined) {
       unset(existingMappingsObj?.properties, existingEmbeddingField);
     }
@@ -901,6 +898,15 @@ export function removeVectorFieldFromIndexMappings(
   } catch {
     return existingMappings;
   }
+}
+
+export function getExistingVectorField(
+  existingMappings: any
+): string | undefined {
+  return findKey(
+    existingMappings?.properties,
+    (field) => field.type === 'knn_vector'
+  );
 }
 
 // Parse out any hidden errors within a 2xx ingest response


### PR DESCRIPTION
### Description

This PR updates the new index mappings to match that of the existing index, if "select from an existing index" option is selected when fetching the source data. Persists any pre-configured vector field mappings, if found. For example, suppose there is a `my_vector` field of type `knn_vector`. If source data is selected and the overall index mappings are updated, `my_vector` is still persisted. See demo video below.

Also cleans up some unnecessary logic of updating the input map based on the source data selection, which could cause bugs under certain edge cases.

Demo video:

[screen-capture (26).webm](https://github.com/user-attachments/assets/3b36f3b1-41a8-48ea-8068-4bf10c144094)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
