### PR TITLE
Persist state across Inspector tab switches; add presets dropdown

### DIFF
--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -20,7 +20,6 @@ import {
 import {
   CONFIG_STEP,
   customStringify,
-  FETCH_ALL_QUERY,
   QueryParam,
   SearchResponse,
   SearchResponseVerbose,
@@ -47,6 +46,12 @@ interface QueryProps {
   hasSearchPipeline: boolean;
   hasIngestResources: boolean;
   selectedStep: CONFIG_STEP;
+  queryRequest: string;
+  setQueryRequest: (queryRequest: string) => void;
+  queryResponse: SearchResponse | undefined;
+  setQueryResponse: (queryResponse: SearchResponse | undefined) => void;
+  queryParams: QueryParam[];
+  setQueryParams: (queryParams: QueryParam[]) => void;
 }
 
 const SEARCH_OPTIONS = [
@@ -66,28 +71,8 @@ export function Query(props: QueryProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
   const dataSourceVersion = useDataSourceVersion(dataSourceId);
-
   const { loading } = useSelector((state: AppState) => state.opensearch);
-
-  // Form state
   const { values } = useFormikContext<WorkflowFormValues>();
-
-  // query response state
-  const [queryResponse, setQueryResponse] = useState<
-    SearchResponse | undefined
-  >(undefined);
-
-  // Standalone / sandboxed search request state. Users can test things out
-  // without updating the base form / persisted value.
-  // Update if the parent form values are changed, or if a newly-created search pipeline is detected.
-  const [tempRequest, setTempRequest] = useState<string>('');
-  useEffect(() => {
-    if (!isEmpty(values?.search?.request)) {
-      setTempRequest(values?.search?.request);
-    } else {
-      setTempRequest(customStringify(FETCH_ALL_QUERY));
-    }
-  }, [values?.search?.request]);
 
   // state for if to execute search w/ or w/o any configured search pipeline.
   // default based on if there is an available search pipeline or not.
@@ -96,22 +81,16 @@ export function Query(props: QueryProps) {
     setIncludePipeline(props.hasSearchPipeline);
   }, [props.hasSearchPipeline]);
 
-  // query params state
-  const [queryParams, setQueryParams] = useState<QueryParam[]>([]);
-
-  // Do a few things when the request is changed:
-  // 1. Check if there is a new set of query parameters, and if so,
-  //    reset the form.
-  // 2. Clear any stale results
+  // Check if there is a new set of query parameters, and if so, reset the form
   useEffect(() => {
-    const placeholders = getPlaceholdersFromQuery(tempRequest);
+    const placeholders = getPlaceholdersFromQuery(props.queryRequest);
     if (
       !containsSameValues(
         placeholders,
-        queryParams.map((queryParam) => queryParam.name)
+        props.queryParams.map((queryParam) => queryParam.name)
       )
     ) {
-      setQueryParams(
+      props.setQueryParams(
         placeholders.map((placeholder) => ({
           name: placeholder,
           type: 'Text',
@@ -119,8 +98,7 @@ export function Query(props: QueryProps) {
         }))
       );
     }
-    setQueryResponse(undefined);
-  }, [tempRequest]);
+  }, [props.queryRequest]);
 
   // empty states
   const noSearchIndex = isEmpty(values?.search?.index?.name);
@@ -192,7 +170,7 @@ export function Query(props: QueryProps) {
                       fill={true}
                       isLoading={loading}
                       disabled={
-                        containsEmptyValues(queryParams) ||
+                        containsEmptyValues(props.queryParams) ||
                         isEmpty(indexToSearch)
                       }
                       onClick={() => {
@@ -200,7 +178,10 @@ export function Query(props: QueryProps) {
                           searchIndex({
                             apiBody: {
                               index: indexToSearch,
-                              body: injectParameters(queryParams, tempRequest),
+                              body: injectParameters(
+                                props.queryParams,
+                                props.queryRequest
+                              ),
                               searchPipeline: includePipeline
                                 ? values?.search?.pipelineName
                                 : '_none',
@@ -230,11 +211,11 @@ export function Query(props: QueryProps) {
                                 setSearchPipelineErrors({ errors: {} });
                               }
 
-                              setQueryResponse(resp);
+                              props.setQueryResponse(resp);
                             }
                           )
                           .catch((error: any) => {
-                            setQueryResponse(undefined);
+                            props.setQueryResponse(undefined);
                             setSearchPipelineErrors({ errors: {} });
                             console.error('Error running query: ', error);
                           });
@@ -252,12 +233,12 @@ export function Query(props: QueryProps) {
                   </EuiFlexItem>
                   {props.selectedStep === CONFIG_STEP.SEARCH &&
                     !isEmpty(values?.search?.request) &&
-                    values?.search?.request !== tempRequest && (
+                    values?.search?.request !== props.queryRequest && (
                       <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>
                         <EuiSmallButtonEmpty
                           disabled={false}
                           onClick={() => {
-                            setTempRequest(values?.search?.request);
+                            props.setQueryRequest(values?.search?.request);
                           }}
                         >
                           Revert to original query
@@ -272,13 +253,16 @@ export function Query(props: QueryProps) {
                   theme="textmate"
                   width="100%"
                   height={'100%'}
-                  value={tempRequest}
+                  value={props.queryRequest}
                   onChange={(input) => {
-                    setTempRequest(input);
+                    props.setQueryRequest(input);
                   }}
+                  // format the JSON on blur
                   onBlur={() => {
                     try {
-                      setTempRequest(customStringify(JSON.parse(tempRequest)));
+                      props.setQueryRequest(
+                        customStringify(JSON.parse(props.queryRequest))
+                      );
                     } catch (error) {}
                   }}
                   readOnly={false}
@@ -299,8 +283,8 @@ export function Query(props: QueryProps) {
                  * This may return nothing if the list of params are empty
                  */}
                 <QueryParamsList
-                  queryParams={queryParams}
-                  setQueryParams={setQueryParams}
+                  queryParams={props.queryParams}
+                  setQueryParams={props.setQueryParams}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -311,7 +295,8 @@ export function Query(props: QueryProps) {
                 <EuiText size="m">Results</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
-                {queryResponse === undefined || isEmpty(queryResponse) ? (
+                {props.queryResponse === undefined ||
+                isEmpty(props.queryResponse) ? (
                   <EuiEmptyPrompt
                     title={<h2>No results</h2>}
                     titleSize="s"
@@ -324,7 +309,7 @@ export function Query(props: QueryProps) {
                     }
                   />
                 ) : (
-                  <Results response={queryResponse} />
+                  <Results response={props.queryResponse} />
                 )}
               </EuiFlexItem>
             </EuiFlexGroup>


### PR DESCRIPTION
### Description

Currently, a lot of the search-related state is localized to the tab component, and as a consequence gets reset across tab switches and re-renderings. This PR moves the following state params to the parent `Tools` component to prevent lost data:
- query request
- query params
- query response

Also, adds a query preset dropdown consistent with the other locations it is available (in the edit query modal and override query modals).

Demo video showing the persisted state:

[screen-capture (27).webm](https://github.com/user-attachments/assets/4da836d8-9e37-47fb-b4c3-0509a5d8fc00)

Screenshot showing the query preset in the panel:
<img width="410" alt="presets-dropdown" src="https://github.com/user-attachments/assets/0c8d6b38-7a43-46d1-89c6-a080bcc6b533" />


### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
