### PR TITLE
Fix missed UI autofilling after JSON Lines change

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../../../common';
 import { SourceDataModal } from './source_data_modal';
 import { BulkPopoverContent } from './bulk_popover_content';
+import { getObjsFromJSONLines } from '../../../../utils';
 
 interface SourceDataProps {
   workflow: Workflow | undefined;
@@ -42,11 +43,7 @@ export function SourceData(props: SourceDataProps) {
   const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
 
   // empty/populated docs state
-  let docs = [];
-  try {
-    const lines = getIn(values, 'ingest.docs', '').split('\n') as string[];
-    lines.forEach((line) => docs.push(JSON.parse(line)));
-  } catch {}
+  const docs = getObjsFromJSONLines(getIn(values, 'ingest.docs', ''));
   const docsPopulated = docs.length > 0;
 
   // selected option state

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_expression_modal.tsx
@@ -49,6 +49,7 @@ import {
   generateTransform,
   getDataSourceId,
   getInitialValue,
+  getObjsFromJSONLines,
   getPlaceholdersFromQuery,
   injectParameters,
   prepareDocsForSimulate,
@@ -128,11 +129,7 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
     `${props.baseConfigPath}.${props.config.id}.one_to_one`
   );
   const docs = getIn(values, 'ingest.docs');
-  let docObjs = [] as {}[] | undefined;
-  try {
-    const lines = docs?.split('\n') as string[];
-    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
-  } catch {}
+  const docObjs = getObjsFromJSONLines(docs);
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;
   try {
@@ -475,12 +472,8 @@ export function ConfigureExpressionModal(props: ConfigureExpressionModalProps) {
                                       });
                                   } else {
                                     try {
-                                      const docObjs = [] as {}[];
-                                      const lines = values?.ingest?.docs?.split(
-                                        '\n'
-                                      ) as string[];
-                                      lines.forEach((line) =>
-                                        docObjs?.push(JSON.parse(line))
+                                      const docObjs = getObjsFromJSONLines(
+                                        values?.ingest?.docs
                                       );
                                       if (docObjs.length > 0) {
                                         setSourceInput(

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_multi_expression_modal.tsx
@@ -47,6 +47,7 @@ import {
   formikToPartialPipeline,
   generateTransform,
   getDataSourceId,
+  getObjsFromJSONLines,
   getPlaceholdersFromQuery,
   injectParameters,
   prepareDocsForSimulate,
@@ -134,11 +135,7 @@ export function ConfigureMultiExpressionModal(
 
   // get some current form values
   const docs = getIn(values, 'ingest.docs');
-  let docObjs = [] as {}[] | undefined;
-  try {
-    const lines = docs?.split('\n') as string[];
-    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
-  } catch {}
+  const docObjs = getObjsFromJSONLines(docs);
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;
   try {

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/modals/configure_template_modal.tsx
@@ -53,6 +53,7 @@ import {
   generateTransform,
   getDataSourceId,
   getInitialValue,
+  getObjsFromJSONLines,
   getPlaceholdersFromQuery,
   injectParameters,
   prepareDocsForSimulate,
@@ -154,11 +155,7 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
     `${props.baseConfigPath}.${props.config.id}.one_to_one`
   );
   const docs = getIn(values, 'ingest.docs');
-  let docObjs = [] as {}[] | undefined;
-  try {
-    const lines = docs?.split('\n') as string[];
-    lines.forEach((line) => docObjs?.push(JSON.parse(line)));
-  } catch {}
+  const docObjs = getObjsFromJSONLines(docs);
   const query = getIn(values, 'search.request');
   let queryObj = {} as {} | undefined;
   try {
@@ -706,9 +703,9 @@ export function ConfigureTemplateModal(props: ConfigureTemplateModalProps) {
                                       });
                                   } else {
                                     try {
-                                      const docObjs = JSON.parse(
-                                        values.ingest.docs
-                                      ) as {}[];
+                                      const docObjs = getObjsFromJSONLines(
+                                        values?.ingest?.docs
+                                      );
                                       if (docObjs.length > 0) {
                                         setSourceInput(
                                           customStringify(docObjs[0])

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -46,6 +46,7 @@ import {
 import { AppState, getMappings, useAppDispatch } from '../../../../../store';
 import {
   getDataSourceId,
+  getObjsFromJSONLines,
   parseModelInputs,
   sanitizeJSONPath,
 } from '../../../../../utils';
@@ -126,9 +127,10 @@ export function ModelInputs(props: ModelInputsProps) {
   >([]);
   useEffect(() => {
     try {
-      const docObjKeys = Object.keys(
-        flattie((JSON.parse(values.ingest.docs) as {}[])[0])
+      const ingestDocsObjs = getObjsFromJSONLines(
+        getIn(values, 'ingest.docs', '')
       );
+      const docObjKeys = Object.keys(flattie(ingestDocsObjs[0]));
       if (docObjKeys.length > 0) {
         setDocFields(
           docObjKeys.map((key) => {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -61,6 +61,7 @@ import {
   useDataSourceVersion,
   getIsPreV219,
   useMissingDataSourceVersion,
+  getObjsFromJSONLines,
 } from '../../../utils';
 import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
@@ -271,11 +272,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
   // populated ingest docs state
   const [docsPopulated, setDocsPopulated] = useState<boolean>(false);
   useEffect(() => {
-    let parsedDocsObjs = [] as {}[];
-    try {
-      const lines = props.ingestDocs?.split('\n') as string[];
-      lines.forEach((line) => parsedDocsObjs.push(JSON.parse(line)));
-    } catch {}
+    const parsedDocsObjs = getObjsFromJSONLines(props.ingestDocs);
     setDocsPopulated(parsedDocsObjs.length > 0 && !isEmpty(parsedDocsObjs[0]));
   }, [props.ingestDocs]);
 
@@ -604,11 +601,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     props.setIsRunningIngest(true);
     let success = false;
     try {
-      let ingestDocsObjs = [] as {}[];
-      try {
-        const lines = props.ingestDocs?.split('\n') as string[];
-        lines.forEach((line) => ingestDocsObjs.push(JSON.parse(line)));
-      } catch (e) {}
+      const ingestDocsObjs = getObjsFromJSONLines(props.ingestDocs);
       if (ingestDocsObjs.length > 0 && !isEmpty(ingestDocsObjs[0])) {
         success = await validateAndUpdateWorkflow(false, true, false);
         if (success) {

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -209,11 +209,7 @@ export function prepareDocsForSimulate(
   indexName: string
 ): SimulateIngestPipelineDoc[] {
   const preparedDocs = [] as SimulateIngestPipelineDoc[];
-  let docObjs = [] as {}[];
-  try {
-    const lines = docs?.split('\n') as string[];
-    lines.forEach((line) => docObjs.push(JSON.parse(line)));
-  } catch {}
+  const docObjs = getObjsFromJSONLines(docs);
   docObjs?.forEach((doc) => {
     preparedDocs.push({
       _index: indexName,
@@ -222,6 +218,17 @@ export function prepareDocsForSimulate(
     });
   });
   return preparedDocs;
+}
+
+// Utility fn to transform a raw JSON Lines string into an arr of JSON objs
+// for easier downstream parsing
+export function getObjsFromJSONLines(jsonLines: string | undefined): {}[] {
+  let objs = [] as {}[];
+  try {
+    const lines = jsonLines?.split('\n') as string[];
+    lines.forEach((line) => objs.push(JSON.parse(line)));
+  } catch {}
+  return objs;
 }
 
 // Docs are returned in a certain format from the simulate ingest pipeline API. We want


### PR DESCRIPTION
### Description

Fixes a few missed edge cases where the doc parsing failed after the switch to JSONLines format. Also moves common logic into a helper fn.

Demo video showing the autofilling with different inputs:

[screen-capture (28).webm](https://github.com/user-attachments/assets/0db0b620-fe65-4269-8021-f49b36e47a4f)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
