### PR TITLE
Simplify ML processor form when interface is defined

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/model_field.tsx
@@ -124,13 +124,15 @@ export function ModelField(props: ModelFieldProps) {
               labelAppend={
                 props.modelCategory ? (
                   <ModelInfoPopover modelCategory={props.modelCategory} />
-                ) : <EuiText size="xs">
-                  <EuiLink href={ML_CHOOSE_MODEL_LINK} target="_blank">
-                    Learn more
-                  </EuiLink>
-                </EuiText>
+                ) : (
+                  <EuiText size="xs">
+                    <EuiLink href={ML_CHOOSE_MODEL_LINK} target="_blank">
+                      Learn more
+                    </EuiLink>
+                  </EuiText>
+                )
               }
-              helpText={props.helpText || 'The model ID.'}
+              helpText={props.helpText}
               isInvalid={isInvalid}
               error={props.showError && getIn(errors, `${field.name}.id`)}
             >
@@ -142,33 +144,33 @@ export function ModelField(props: ModelFieldProps) {
                     disabled={isEmpty(deployedModels)}
                     options={deployedModels.map(
                       (option) =>
-                      ({
-                        value: option.id,
-                        inputDisplay: (
-                          <>
-                            <EuiText size="s">{option.name}</EuiText>
-                          </>
-                        ),
-                        dropdownDisplay: (
-                          <>
-                            <EuiHealth
-                              color={
-                                isEmpty(option.interface)
-                                  ? 'warning'
-                                  : 'success'
-                              }
-                            >
+                        ({
+                          value: option.id,
+                          inputDisplay: (
+                            <>
                               <EuiText size="s">{option.name}</EuiText>
-                            </EuiHealth>
-                            <EuiText size="xs" color="subdued">
-                              {isEmpty(option.interface)
-                                ? 'Not ready - no model interface'
-                                : 'Deployed'}
-                            </EuiText>
-                          </>
-                        ),
-                        disabled: false,
-                      } as EuiSuperSelectOption<string>)
+                            </>
+                          ),
+                          dropdownDisplay: (
+                            <>
+                              <EuiHealth
+                                color={
+                                  isEmpty(option.interface)
+                                    ? 'warning'
+                                    : 'success'
+                                }
+                              >
+                                <EuiText size="s">{option.name}</EuiText>
+                              </EuiHealth>
+                              <EuiText size="xs" color="subdued">
+                                {isEmpty(option.interface)
+                                  ? 'Not ready - no model interface'
+                                  : 'Deployed'}
+                              </EuiText>
+                            </>
+                          ),
+                          disabled: false,
+                        } as EuiSuperSelectOption<string>)
                     )}
                     valueOfSelected={field.value?.id || ''}
                     onChange={(option: string) => {


### PR DESCRIPTION
### Description

Simplifies the controls & form components for ML processors when the underlying model has a defined interface. Make the inputs & outputs readonly, and prevent adding/deleting entries. The main idea, is that if a model has a defined interface, add more guardrails to prevent user confusion from creating invalid/unnecessary mappings.

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
