### PR TITLE
Cache form across ML transform types

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -126,6 +126,10 @@ export type OutputMapEntry = InputMapEntry;
 export type InputMapFormValue = InputMapEntry[];
 export type OutputMapFormValue = OutputMapEntry[];
 
+export type MapCache = {
+  [idx: number]: Transform[];
+};
+
 export type InputMapArrayFormValue = InputMapFormValue[];
 export type OutputMapArrayFormValue = OutputMapFormValue[];
 

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -346,6 +346,7 @@ export function ModelInputs(props: ModelInputsProps) {
                               <EuiFlexItem grow={TYPE_FLEX_RATIO}>
                                 <EuiFlexItem>
                                   <EuiCompressedSuperSelect
+                                    fullWidth={true}
                                     disabled={false}
                                     options={INPUT_TRANSFORM_OPTIONS.map(
                                       (option) =>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -31,6 +31,7 @@ import {
   IndexMappings,
   InputMapEntry,
   InputMapFormValue,
+  Transform,
   TRANSFORM_TYPE,
   EMPTY_INPUT_MAP_ENTRY,
   WorkflowConfig,
@@ -98,14 +99,6 @@ export function ModelInputs(props: ModelInputsProps) {
     ModelInterface | undefined
   >(undefined);
 
-  // various modal states
-  const [templateModalIdx, setTemplateModalIdx] = useState<number | undefined>(
-    undefined
-  );
-  const [expressionModalIdx, setExpressionModalIdx] = useState<
-    number | undefined
-  >(undefined);
-
   // get the model interface based on the selected ID and list of known models
   useEffect(() => {
     if (!isEmpty(models)) {
@@ -115,6 +108,79 @@ export function ModelInputs(props: ModelInputsProps) {
       }
     }
   }, [models, getIn(values, modelFieldPath)?.id]);
+
+  // various modal states
+  const [templateModalIdx, setTemplateModalIdx] = useState<number | undefined>(
+    undefined
+  );
+  const [expressionModalIdx, setExpressionModalIdx] = useState<
+    number | undefined
+  >(undefined);
+
+  const [debouncedInputMap, setDebouncedInputMap] = useState<any>();
+  useEffect(() => {
+    // Set a timeout to update debounced value after 500ms
+    const handler = setTimeout(() => {
+      setDebouncedInputMap(getIn(values, inputMapFieldPath));
+    }, 500);
+
+    // Cleanup the timeout if `query` changes before 500ms
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [getIn(values, inputMapFieldPath)]);
+
+  // TODO: this works ok, but does not allow clearing out any form value, or it resets to the last-known/cached value.
+  // need to filter out on this use case.
+
+  // Temporarily cache any configured transformations for different transform types.
+  // For example, if a user configures a prompt, swaps the transform
+  // type to "Data field", and swaps back to "Prompt", the prompt will be persisted.
+  const [inputMapCache, _] = useState<{
+    [idx: number]: Transform[];
+  }>({});
+  useEffect(() => {
+    const curFormValues = debouncedInputMap as InputMapFormValue | undefined;
+    if (curFormValues !== undefined && !isEmpty(curFormValues)) {
+      // for each form value: populate the cache with a non-empty value and/or populate the
+      // form value with its cached value, if found.
+      curFormValues.forEach((mapEntry, idx) => {
+        const curCacheForIdx = inputMapCache[idx];
+        if (curCacheForIdx === undefined || isEmpty(curCacheForIdx)) {
+          // case 1: there is no persisted state for this entry index. create a fresh arr
+          inputMapCache[idx] = [mapEntry.value];
+        } else if (
+          !curCacheForIdx.some(
+            (transform: Transform) =>
+              transform.transformType === mapEntry.value.transformType
+          )
+        ) {
+          // case 2: there is persisted state for this entry index, but not for the particular
+          // transform type. append to the arr
+          inputMapCache[idx] = [...inputMapCache[idx], mapEntry.value];
+        } else {
+          // case 3: there is persisted state for this entry index, and for the particular transform type.
+          // Either update the cache with the current form value(s) (if non-empty), or update the form
+          // with any value found in the cache
+          inputMapCache[idx] = inputMapCache[idx].map((cachedEntry) => {
+            if (cachedEntry.transformType === mapEntry.value.transformType) {
+              const formValue = mapEntry.value.value;
+              // form is non-empty. update the cache
+              if (formValue !== undefined && !isEmpty(formValue)) {
+                return mapEntry.value;
+                // form is empty. update the form with cached value(s)
+              } else {
+                setFieldValue(`${inputMapFieldPath}.${idx}.value`, cachedEntry);
+                return cachedEntry;
+              }
+            } else {
+              return cachedEntry;
+            }
+          });
+        }
+      });
+    }
+  }, [debouncedInputMap]);
 
   // persisting doc/query/index mapping fields to collect a list
   // of options to display in the dropdowns when configuring input / output maps

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -211,6 +211,7 @@ export function ModelOutputs(props: ModelOutputsProps) {
                               <EuiFlexItem grow={TYPE_FLEX_RATIO}>
                                 <EuiFlexItem>
                                   <EuiCompressedSuperSelect
+                                    fullWidth={true}
                                     disabled={false}
                                     options={OUTPUT_TRANSFORM_OPTIONS.map(
                                       (option) =>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -34,10 +34,13 @@ import {
   EMPTY_OUTPUT_MAP_ENTRY,
   ExpressionVar,
   OUTPUT_TRANSFORM_OPTIONS,
+  Transform,
+  MapCache,
 } from '../../../../../../common';
 import { TextField } from '../../input_fields';
 import { AppState } from '../../../../../store';
 import { ConfigureMultiExpressionModal } from './modals';
+import { updateCache } from './utils';
 
 interface ModelOutputsProps {
   config: IProcessorConfig;
@@ -92,6 +95,11 @@ export function ModelOutputs(props: ModelOutputsProps) {
       }
     }
   }, [models, getIn(values, modelFieldPath)?.id]);
+
+  // Temporarily cache any configured transformations for different transform types.
+  // For example, if a user configures a prompt, swaps the transform
+  // type to "Data field", and swaps back to "Prompt", the prompt will be persisted.
+  const [outputMapCache, setOutputMapCache] = useState<MapCache>({});
 
   // Adding a map entry to the end of the existing arr
   function addMapEntry(curEntries: OutputMapFormValue): void {
@@ -247,20 +255,32 @@ export function ModelOutputs(props: ModelOutputsProps) {
                                       ) || ''
                                     }
                                     onChange={(option) => {
+                                      // before updating, cache any form values
+                                      const updatedCache = updateCache(
+                                        outputMapCache,
+                                        mapEntry,
+                                        idx
+                                      );
                                       setFieldValue(
                                         `${outputMapFieldPath}.${idx}.value.transformType`,
                                         option
                                       );
-                                      // If the transform type changes, clear any set value and/or nested vars,
-                                      // as it will likely not make sense under other types/contexts.
+                                      // Pre-populate with any cached values, if found
+                                      const curCacheForOption = updatedCache[
+                                        idx
+                                      ]?.find(
+                                        (transform: Transform) =>
+                                          transform.transformType === option
+                                      );
                                       setFieldValue(
                                         `${outputMapFieldPath}.${idx}.value.value`,
-                                        ''
+                                        curCacheForOption?.value || ''
                                       );
                                       setFieldValue(
                                         `${outputMapFieldPath}.${idx}.value.nestedVars`,
-                                        []
+                                        curCacheForOption?.nestedVars || []
                                       );
+                                      setOutputMapCache(updatedCache);
                                     }}
                                   />
                                 </EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/utils.ts
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/utils.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isEmpty } from 'lodash';
+import {
+  MapCache,
+  InputMapEntry,
+  OutputMapEntry,
+  Transform,
+} from '../../../../../../common';
+
+// Update a cache of data transform values based on a given form value
+export function updateCache(
+  cache: MapCache,
+  mapEntry: InputMapEntry | OutputMapEntry,
+  idx: number // the mapEntry index
+): MapCache {
+  const updatedCache = cache;
+  const curCache = updatedCache[idx];
+  if (curCache === undefined || isEmpty(curCache)) {
+    // case 1: there is no persisted state for this entry index. create a fresh arr
+    updatedCache[idx] = [mapEntry.value];
+  } else if (
+    !curCache.some(
+      (transform: Transform) =>
+        transform.transformType === mapEntry.value.transformType
+    )
+  ) {
+    // case 2: there is persisted state for this entry index, but not for the particular
+    // transform type. append to the arr
+    updatedCache[idx] = [...updatedCache[idx], mapEntry.value];
+  } else {
+    // case 3: there is persisted state for this entry index, and for the particular transform type.
+    // Update the cache with the current form value(s)
+    updatedCache[idx] = updatedCache[idx].map((cachedEntry) => {
+      if (cachedEntry.transformType === mapEntry.value.transformType) {
+        return mapEntry.value;
+      } else {
+        return cachedEntry;
+      }
+    });
+  }
+  return updatedCache;
+}


### PR DESCRIPTION
### Description

Adds caches for the input/output forms for ML processors, such that values are cached across different transform types. The idea is users can easily toggle between types and not lose lost configuration. Note this is only cached while the component is loaded on the page; a navigation away or page refresh will lose the cached state.

Implementation-wise, this adds a util fn shared across `model_inputs` and `model_outputs` to update a cache, and pre-populate values _from_ the cache, as users change underlying transform types within the input/output maps.

Demo video:

[screen-capture (30).webm](https://github.com/user-attachments/assets/da11767b-e943-4441-b20d-6b29c2553db8)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
