### PR TITLE
add callout if knn query does not have knn index

### DIFF
--- a/public/component_types/other/search_request.tsx
+++ b/public/component_types/other/search_request.tsx
@@ -5,7 +5,7 @@
 
 import { COMPONENT_CLASS } from '../../../common';
 import { BaseComponent } from '../base_component';
-import { isKnnIndex } from '../../utils/utils';
+import { isKnnIndex, isKnnQuery } from '../../utils/utils';
 
 /**
  * A basic search request placeholder UI component.
@@ -41,7 +41,7 @@ export class SearchRequest extends BaseComponent {
     try {
       const queryString =
         typeof query === 'string' ? query : JSON.stringify(query);
-      const hasKnnQuery = this.isKnnQuery(queryString);
+      const hasKnnQuery = isKnnQuery(queryString);
 
       if (hasKnnQuery) {
         const isKnnEnabled = isKnnIndex(indexSettings);
@@ -50,7 +50,7 @@ export class SearchRequest extends BaseComponent {
           return {
             isValid: false,
             warningMessage:
-              'Warning: You are using a neural/KNN query, but the selected index does not have KNN enabled (index.knn:true). Please select a KNN-enabled index for proper vector search functionality.',
+              'Warning: The selected index does not have KNN enabled. Please selecte a KNN enabled index.',
           };
         }
       }
@@ -59,33 +59,6 @@ export class SearchRequest extends BaseComponent {
     } catch (error) {
       console.error('Error validating KNN query:', error);
       return { isValid: true };
-    }
-  }
-
-  /**
-   * Determines if a query is a KNN query
-   * @param queryString The query string to check
-   * @returns boolean indicating if it's a KNN query
-   */
-  isKnnQuery(queryString: string): boolean {
-    try {
-      const query =
-        typeof queryString === 'string' ? JSON.parse(queryString) : queryString;
-
-      const queryAsString = JSON.stringify(query);
-
-      const hasKnn = queryAsString.includes('"knn":{');
-      const hasNeural = queryAsString.includes('"neural":{');
-
-      console.log('KNN query detection:', { hasKnn, hasNeural, queryAsString });
-
-      return hasKnn || hasNeural;
-    } catch (error) {
-      console.error('Error in isKnnQuery:', error);
-      // Fallback to string-based detection
-      return (
-        queryString.includes('"knn":{') || queryString.includes('"neural":{')
-      );
     }
   }
 }

--- a/public/component_types/other/search_request.tsx
+++ b/public/component_types/other/search_request.tsx
@@ -5,6 +5,7 @@
 
 import { COMPONENT_CLASS } from '../../../common';
 import { BaseComponent } from '../base_component';
+import { isKnnIndex } from '../../utils/utils';
 
 /**
  * A basic search request placeholder UI component.
@@ -22,5 +23,69 @@ export class SearchRequest extends BaseComponent {
         label: '',
       },
     ];
+  }
+
+  /**
+   * Validates if the index supports Knn if it is Knn query
+   * @param query The current search query
+   * @param indexSettings The settings of the selected index
+   * @returns Object containing validation result and warning message if needed
+   */
+  validateKnnQueryToHaveValidKnnIndex(
+    query: string,
+    indexSettings: string
+  ): {
+    isValid: boolean;
+    warningMessage?: string;
+  } {
+    try {
+      const queryString =
+        typeof query === 'string' ? query : JSON.stringify(query);
+      const hasKnnQuery = this.isKnnQuery(queryString);
+
+      if (hasKnnQuery) {
+        const isKnnEnabled = isKnnIndex(indexSettings);
+
+        if (!isKnnEnabled) {
+          return {
+            isValid: false,
+            warningMessage:
+              'Warning: You are using a neural/KNN query, but the selected index does not have KNN enabled (index.knn:true). Please select a KNN-enabled index for proper vector search functionality.',
+          };
+        }
+      }
+
+      return { isValid: true };
+    } catch (error) {
+      console.error('Error validating KNN query:', error);
+      return { isValid: true };
+    }
+  }
+
+  /**
+   * Determines if a query is a KNN query
+   * @param queryString The query string to check
+   * @returns boolean indicating if it's a KNN query
+   */
+  isKnnQuery(queryString: string): boolean {
+    try {
+      const query =
+        typeof queryString === 'string' ? JSON.parse(queryString) : queryString;
+
+      const queryAsString = JSON.stringify(query);
+
+      const hasKnn = queryAsString.includes('"knn":{');
+      const hasNeural = queryAsString.includes('"neural":{');
+
+      console.log('KNN query detection:', { hasKnn, hasNeural, queryAsString });
+
+      return hasKnn || hasNeural;
+    } catch (error) {
+      console.error('Error in isKnnQuery:', error);
+      // Fallback to string-based detection
+      return (
+        queryString.includes('"knn":{') || queryString.includes('"neural":{')
+      );
+    }
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/search_inputs/configure_search_request.tsx
@@ -155,7 +155,7 @@ export function ConfigureSearchRequest(props: ConfigureSearchRequestProps) {
         {!validationResult.isValid && validationResult.warningMessage && (
           <EuiFlexItem>
             <EuiCallOut
-              title="KNN Query Warning"
+              title="Vector search might not be working"
               color="warning"
               iconType="alert"
               size="s"

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -782,6 +782,25 @@ export function isKnnIndex(existingSettings: string): boolean {
     return false;
   }
 }
+// Check if a query is knn query
+
+export function isKnnQuery(queryString: string): boolean {
+  try {
+    const query =
+      typeof queryString === 'string' ? JSON.parse(queryString) : queryString;
+
+    const hasKnn = getFieldValue(query, 'knn') !== undefined;
+    const hasNeural = getFieldValue(query, 'neural') !== undefined;
+
+    return hasKnn || hasNeural;
+  } catch (error) {
+    console.error('Error in isKnnQuery:', error);
+    // Fallback to string-based detection
+    return (
+      queryString.includes('"knn":{') || queryString.includes('"neural":{')
+    );
+  }
+}
 
 // Update the index settings based on parameters passed.
 // Currently just used for updating the `knn` flag.


### PR DESCRIPTION
### Description
In the search flow, if the query is Knn query and the source index file is not knn, should pop up a callout box.

### Issues Resolved

[682](https://github.com/opensearch-project/dashboards-flow-framework/issues/682)

### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
