### PR TITLE
adding icons to reorder processors up and down

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -353,8 +353,6 @@ export function ProcessorsList(props: ProcessorsListProps) {
   }
 
   function moveProcessorUp(processorIndex: number): void {
-    if (processorIndex <= 0) return;
-
     clearProcessorErrors();
     const existingConfig = cloneDeep(props.uiConfig as WorkflowConfig);
     let newConfig = formikToUiConfig(values, existingConfig);
@@ -411,8 +409,6 @@ export function ProcessorsList(props: ProcessorsListProps) {
         currentProcessors = newConfig.search.enrichResponse.processors;
         break;
     }
-
-    if (processorIndex >= currentProcessors.length - 1) return;
 
     [
       currentProcessors[processorIndex],

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -352,6 +352,91 @@ export function ProcessorsList(props: ProcessorsListProps) {
     props.setUiConfig(newConfig);
   }
 
+  function moveProcessorUp(processorIndex: number): void {
+    if (processorIndex <= 0) return;
+
+    clearProcessorErrors();
+    const existingConfig = cloneDeep(props.uiConfig as WorkflowConfig);
+    let newConfig = formikToUiConfig(values, existingConfig);
+    let currentProcessors: IProcessorConfig[] = [];
+    switch (props.context) {
+      case PROCESSOR_CONTEXT.INGEST:
+        currentProcessors = newConfig.ingest.enrich.processors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_REQUEST:
+        currentProcessors = newConfig.search.enrichRequest.processors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_RESPONSE:
+        currentProcessors = newConfig.search.enrichResponse.processors;
+        break;
+    }
+
+    [
+      currentProcessors[processorIndex],
+      currentProcessors[processorIndex - 1],
+    ] = [
+      currentProcessors[processorIndex - 1],
+      currentProcessors[processorIndex],
+    ];
+
+    switch (props.context) {
+      case PROCESSOR_CONTEXT.INGEST:
+        newConfig.ingest.enrich.processors = currentProcessors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_REQUEST:
+        newConfig.search.enrichRequest.processors = currentProcessors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_RESPONSE:
+        newConfig.search.enrichResponse.processors = currentProcessors;
+        break;
+    }
+
+    props.setUiConfig(newConfig);
+  }
+
+  function moveProcessorDown(processorIndex: number): void {
+    clearProcessorErrors();
+    const existingConfig = cloneDeep(props.uiConfig as WorkflowConfig);
+    let newConfig = formikToUiConfig(values, existingConfig);
+
+    let currentProcessors: IProcessorConfig[] = [];
+    switch (props.context) {
+      case PROCESSOR_CONTEXT.INGEST:
+        currentProcessors = newConfig.ingest.enrich.processors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_REQUEST:
+        currentProcessors = newConfig.search.enrichRequest.processors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_RESPONSE:
+        currentProcessors = newConfig.search.enrichResponse.processors;
+        break;
+    }
+
+    if (processorIndex >= currentProcessors.length - 1) return;
+
+    [
+      currentProcessors[processorIndex],
+      currentProcessors[processorIndex + 1],
+    ] = [
+      currentProcessors[processorIndex + 1],
+      currentProcessors[processorIndex],
+    ];
+
+    switch (props.context) {
+      case PROCESSOR_CONTEXT.INGEST:
+        newConfig.ingest.enrich.processors = currentProcessors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_REQUEST:
+        newConfig.search.enrichRequest.processors = currentProcessors;
+        break;
+      case PROCESSOR_CONTEXT.SEARCH_RESPONSE:
+        newConfig.search.enrichResponse.processors = currentProcessors;
+        break;
+    }
+
+    props.setUiConfig(newConfig);
+  }
+
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
       {processors.map((processor: IProcessorConfig, processorIndex) => {
@@ -447,14 +532,34 @@ export function ProcessorsList(props: ProcessorsListProps) {
                   </EuiFlexGroup>
                 }
                 extraAction={
-                  <EuiSmallButtonIcon
-                    iconType={'trash'}
-                    color="danger"
-                    aria-label="Delete"
-                    onClick={() => {
-                      deleteProcessor(processor.id);
-                    }}
-                  />
+                  <EuiFlexGroup gutterSize="s" alignItems="center">
+                    <EuiFlexItem grow={false}>
+                      <EuiSmallButtonIcon
+                        iconType="sortUp"
+                        aria-label="Move processor up"
+                        onClick={() => moveProcessorUp(processorIndex)}
+                        isDisabled={processorIndex === 0}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiSmallButtonIcon
+                        iconType="sortDown"
+                        aria-label="Move processor down"
+                        onClick={() => moveProcessorDown(processorIndex)}
+                        isDisabled={processorIndex === processors.length - 1}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiSmallButtonIcon
+                        iconType="trash"
+                        color="danger"
+                        aria-label="Delete"
+                        onClick={() => {
+                          deleteProcessor(processor.id);
+                        }}
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 }
               >
                 <EuiSpacer size="s" />


### PR DESCRIPTION
### Description

Add icons so that users can use the icons to move the processors up and down for one step once a time.

### Mock ups

![Xnip2025-03-31_13-47-00](https://github.com/user-attachments/assets/93dd4ffc-1ad8-421c-8b15-d44855d3a2e5)

### Video demo

https://github.com/user-attachments/assets/400071d2-67a1-4808-bbe7-87cc0c3d364a




### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
