### PR TITLE
disable choosing index in search pipeline if index is ingested in ingest pipeline

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -26,6 +26,7 @@ interface ConfigFieldListProps {
   configId: string;
   configFields: IConfigField[];
   baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
+  disableIndexSelection?: boolean;
 }
 
 const CONFIG_FIELD_SPACER_SIZE = 'm';
@@ -35,6 +36,9 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
     <EuiFlexItem grow={false}>
       {props.configFields.map((field, idx) => {
         const fieldPath = `${props.baseConfigPath}.${props.configId}.${field.id}`;
+        const isIndexField = field.id === 'index';
+        const isDisabled = isIndexField && props.disableIndexSelection;
+
         let el;
         switch (field.type) {
           case 'string': {
@@ -44,6 +48,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={fieldPath}
                   showError={true}
+                  disabled={isDisabled}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
@@ -58,6 +63,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   fieldPath={fieldPath}
                   showError={true}
                   textArea={true}
+                  disabled={isDisabled}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
@@ -67,7 +73,11 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
           case 'select': {
             el = (
               <EuiFlexItem key={idx}>
-                <SelectField field={field} fieldPath={fieldPath} />
+                <SelectField
+                  field={field}
+                  fieldPath={fieldPath}
+                  disabled={isDisabled}
+                />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
             );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -19,6 +19,7 @@ interface SelectFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onSelectChange?: (option: string) => void;
   showInvalid?: boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -66,6 +67,7 @@ export function SelectField(props: SelectFieldProps) {
                 }
               }}
               isInvalid={isInvalid}
+              disabled={props.disabled}
             />
           </EuiCompressedFormRow>
         );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -25,7 +25,11 @@ interface TextFieldProps {
   showInvalid?: boolean;
   fullWidth?: boolean;
   textArea?: boolean;
+<<<<<<< HEAD
   inputRef?: React.RefObject<HTMLInputElement>;
+=======
+  disabled?: boolean;
+>>>>>>> 0abce6b (disable choosing index in search pipeline if ingest pipeline already have an index)
 }
 
 /**
@@ -69,6 +73,7 @@ export function TextField(props: TextFieldProps) {
                   form.setFieldValue(props.fieldPath, e.target.value);
                 }}
                 isInvalid={isInvalid}
+                disabled={props.disabled}
               />
             ) : (
               <EuiCompressedFieldText
@@ -80,7 +85,11 @@ export function TextField(props: TextFieldProps) {
                   form.setFieldValue(props.fieldPath, e.target.value?.trim());
                 }}
                 isInvalid={isInvalid}
+<<<<<<< HEAD
                 inputRef={props.inputRef}
+=======
+                disabled={props.disabled}
+>>>>>>> 0abce6b (disable choosing index in search pipeline if ingest pipeline already have an index)
               />
             )}
           </EuiCompressedFormRow>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -26,6 +26,7 @@ interface ProcessorInputsProps {
   config: IProcessorConfig;
   baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
   context: PROCESSOR_CONTEXT;
+  disableIndexSelection?: boolean;
 }
 
 // Component to dynamically render the processor inputs based on the processor types.
@@ -87,6 +88,7 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
                     configId={props.config.id}
                     configFields={props.config.fields}
                     baseConfigPath={props.baseConfigPath}
+                    disableIndexSelection={props.disableIndexSelection}
                   />
                   {!isEmpty(props.config.optionalFields) && (
                     <EuiAccordion
@@ -100,6 +102,7 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
                           configId={props.config.id}
                           configFields={props.config.optionalFields || []}
                           baseConfigPath={props.baseConfigPath}
+                          disableIndexSelection={props.disableIndexSelection}
                         />
                       </EuiFlexItem>
                     </EuiAccordion>

--- a/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processors_list.tsx
@@ -94,6 +94,11 @@ export function ProcessorsList(props: ProcessorsListProps) {
     [processorId: string]: boolean;
   }>({});
 
+  // check if an index has already been indexed in the ingest pipeline
+  const hasIngestedIndex =
+    props.uiConfig?.ingest?.index?.name?.value !== undefined &&
+    props.uiConfig?.ingest?.index?.name?.value !== '';
+
   function clearProcessorErrors(): void {
     if (props.context === PROCESSOR_CONTEXT.INGEST) {
       dispatch(setIngestPipelineErrors({ errors: {} }));
@@ -580,6 +585,10 @@ export function ProcessorsList(props: ProcessorsListProps) {
                     config={processor}
                     baseConfigPath={baseConfigPath}
                     context={props.context}
+                    disableIndexSelection={
+                      props.context !== PROCESSOR_CONTEXT.INGEST &&
+                      hasIngestedIndex
+                    }
                   />
                 </EuiFlexItem>
               </EuiAccordion>


### PR DESCRIPTION

### Description
If the user has already ingested an index in the ingest pipeline, in the search pipeline, should disable the index drop down list so that user can use the index in the ingest pipeline.

### Issues Resolved

NA

### Demo


### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
