### PR TITLE
add focus to the first field for the quick config modal

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -25,6 +25,7 @@ interface TextFieldProps {
   showInvalid?: boolean;
   fullWidth?: boolean;
   textArea?: boolean;
+  inputRef?: React.RefObject<HTMLInputElement>;
 }
 
 /**
@@ -79,6 +80,7 @@ export function TextField(props: TextFieldProps) {
                   form.setFieldValue(props.fieldPath, e.target.value?.trim());
                 }}
                 isInvalid={isInvalid}
+                inputRef={props.inputRef}
               />
             )}
           </EuiCompressedFormRow>

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import * as yup from 'yup';
 import { Formik, getIn } from 'formik';
@@ -88,6 +88,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const { models, connectors } = useSelector((state: AppState) => state.ml);
   const { workflows } = useSelector((state: AppState) => state.workflows);
 
+  const nameInputRef = useRef<HTMLInputElement>(null);
   // is creating state
   const [isCreating, setIsCreating] = useState<boolean>(false);
 
@@ -95,6 +96,16 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
   const [quickConfigureFields, setQuickConfigureFields] = useState<
     QuickConfigureFields
   >({});
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (nameInputRef.current) {
+        nameInputRef.current.focus();
+      }
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   // sub-form values/schema. dependent on the workflow type.
   // certain types require different subsets of models.
@@ -257,6 +268,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                     fullWidth={true}
                     fieldPath={`name`}
                     showError={true}
+                    inputRef={nameInputRef}
                   />
                 </EuiFlexItem>
                 <EuiFlexItem>


### PR DESCRIPTION
### Description

When the user creates a new workflow, a quick config modal will pop up. This PR make the first field of the modal focused.

### Issues Resolved

NA

### Modal without focus
![Xnip2025-04-03_11-59-23](https://github.com/user-attachments/assets/ef19e396-b9d0-462e-aba0-fa17283984ac)

### Modal with focus
![Xnip2025-04-03_14-38-04](https://github.com/user-attachments/assets/4b2b3208-3079-4631-ba83-b998fc142e1a)



### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
