### PR TITLE
disable index in search pipeline if already indexed in ingest pipeline

### DIFF
--- a/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/config_field_list.tsx
@@ -26,6 +26,7 @@ interface ConfigFieldListProps {
   configId: string;
   configFields: IConfigField[];
   baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
+  disableIndexSelection?: boolean;
 }
 
 const CONFIG_FIELD_SPACER_SIZE = 'm';
@@ -35,6 +36,8 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
     <EuiFlexItem grow={false}>
       {props.configFields.map((field, idx) => {
         const fieldPath = `${props.baseConfigPath}.${props.configId}.${field.id}`;
+        const isIndexField = field.id === 'index';
+        const isDisabled = isIndexField && props.disableIndexSelection;
         let el;
         switch (field.type) {
           case 'string': {
@@ -44,6 +47,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   label={camelCaseToTitleString(field.id)}
                   fieldPath={fieldPath}
                   showError={true}
+                  disabled={isDisabled}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
@@ -58,6 +62,7 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
                   fieldPath={fieldPath}
                   showError={true}
                   textArea={true}
+                  disabled={isDisabled}
                 />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
@@ -67,7 +72,11 @@ export function ConfigFieldList(props: ConfigFieldListProps) {
           case 'select': {
             el = (
               <EuiFlexItem key={idx}>
-                <SelectField field={field} fieldPath={fieldPath} />
+                <SelectField
+                  field={field}
+                  fieldPath={fieldPath}
+                  disabled={isDisabled}
+                />
                 <EuiSpacer size={CONFIG_FIELD_SPACER_SIZE} />
               </EuiFlexItem>
             );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/select_field.tsx
@@ -19,6 +19,7 @@ interface SelectFieldProps {
   fieldPath: string; // the full path in string-form to the field (e.g., 'ingest.enrich.processors.text_embedding_processor.inputField')
   onSelectChange?: (option: string) => void;
   showInvalid?: boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -66,6 +67,7 @@ export function SelectField(props: SelectFieldProps) {
                 }
               }}
               isInvalid={isInvalid}
+              disabled={props.disabled}
             />
           </EuiCompressedFormRow>
         );

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -26,6 +26,7 @@ interface TextFieldProps {
   fullWidth?: boolean;
   textArea?: boolean;
   inputRef?: React.RefObject<HTMLInputElement>;
+  disabled?: boolean;
 }
 
 /**
@@ -69,6 +70,7 @@ export function TextField(props: TextFieldProps) {
                   form.setFieldValue(props.fieldPath, e.target.value);
                 }}
                 isInvalid={isInvalid}
+                disabled={props.disabled}
               />
             ) : (
               <EuiCompressedFieldText
@@ -81,6 +83,7 @@ export function TextField(props: TextFieldProps) {
                 }}
                 isInvalid={isInvalid}
                 inputRef={props.inputRef}
+                disabled={props.disabled}
               />
             )}
           </EuiCompressedFormRow>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/processor_inputs.tsx
@@ -26,6 +26,7 @@ interface ProcessorInputsProps {
   config: IProcessorConfig;
   baseConfigPath: string; // the base path of the nested config, if applicable. e.g., 'ingest.enrich'
   context: PROCESSOR_CONTEXT;
+  disableIndexSelection?: boolean;
 }
 
 // Component to dynamically render the processor inputs based on the processor types.
@@ -87,6 +88,7 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
                     configId={props.config.id}
                     configFields={props.config.fields}
                     baseConfigPath={props.baseConfigPath}
+                    disableIndexSelection={props.disableIndexSelection}
                   />
                   {!isEmpty(props.config.optionalFields) && (
                     <EuiAccordion
@@ -100,6 +102,7 @@ export function ProcessorInputs(props: ProcessorInputsProps) {
                           configId={props.config.id}
                           configFields={props.config.optionalFields || []}
                           baseConfigPath={props.baseConfigPath}
+                          disableIndexSelection={props.disableIndexSelection}
                         />
                       </EuiFlexItem>
                     </EuiAccordion>


### PR DESCRIPTION
### Description

If the user ingest an index in the ingest pipeline, the index should be reflected in the search pipeline

### Issues Resolved

NA

### Demo


https://github.com/user-attachments/assets/c00462b1-c538-4556-91f1-d86bb418eeeb


### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
