### PR TITLE
Support optional model inputs

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -112,6 +112,7 @@ export type ExpressionVar = {
 export type Transform = {
   transformType: TRANSFORM_TYPE;
   value?: string;
+  optional?: boolean;
   // Templates may persist their own set of nested transforms
   // to be dynamically injected into the template
   nestedVars?: ExpressionVar[];
@@ -448,9 +449,11 @@ export type ModelOutput = ModelInput;
 export type ModelInputMap = { [key: string]: ModelInput };
 export type ModelOutputMap = { [key: string]: ModelOutput };
 
-// For rendering options, we extract the name (the key in the input/output obj) and combine into a single obj
+// For rendering options, we extract the name (the key in the input/output obj) and combine into a single obj.
+// Also persist an optional field to dynamically run / not run validation on the form later on
 export type ModelInputFormField = ModelInput & {
   label: string;
+  optional?: boolean;
 };
 
 export type ModelOutputFormField = ModelInputFormField;

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -124,7 +124,10 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
     const modelInputsAsForm = [
       parseModelInputs(newModelInterface).map((modelInput) => {
         return {
-          ...EMPTY_INPUT_MAP_ENTRY,
+          value: {
+            ...EMPTY_INPUT_MAP_ENTRY.value,
+            optional: modelInput.optional,
+          },
           key: modelInput.label,
         };
       }) as InputMapFormValue,

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -337,6 +337,13 @@ export function ModelInputs(props: ModelInputsProps) {
                                               values,
                                               `${inputMapFieldPath}.${idx}.key`
                                             )}
+                                            {getIn(
+                                              values,
+                                              `${inputMapFieldPath}.${idx}.value.optional`,
+                                              false
+                                            ) === true && (
+                                              <i>{` - optional`}</i>
+                                            )}
                                           </EuiText>
                                         ) : (
                                           <TextField

--- a/public/utils/config_to_schema_utils.ts
+++ b/public/utils/config_to_schema_utils.ts
@@ -285,21 +285,27 @@ export function getFieldSchema(
               transformType: defaultStringSchema.required(),
               value: yup
                 .string()
-                .when('transformType', (transformType, schema) => {
+                .when(['transformType', 'optional'], (transform, schema) => {
                   const finalType = getIn(
-                    transformType,
+                    transform,
                     '0',
                     TRANSFORM_TYPE.FIELD
                   ) as TRANSFORM_TYPE;
+                  const optional = getIn(transform, '1', false) as boolean;
+
                   // accept longer string lengths if the input is a template
                   if (finalType === TRANSFORM_TYPE.TEMPLATE) {
-                    return yup
+                    const templateSchema = yup
                       .string()
                       .min(1, 'Too short')
-                      .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long')
-                      .required();
+                      .max(MAX_TEMPLATE_STRING_LENGTH, 'Too long');
+                    return optional
+                      ? templateSchema.optional()
+                      : templateSchema.required();
                   } else {
-                    return defaultStringSchema.required();
+                    return optional
+                      ? defaultStringSchema.optional()
+                      : defaultStringSchema.required();
                   }
                 }),
               nestedVars: yup.array().of(

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -471,10 +471,12 @@ export function parseModelInputs(
   modelInterface: ModelInterface | undefined
 ): ModelInputFormField[] {
   const modelInputsObj = parseModelInputsObj(modelInterface);
+  const requiredModelInputs = parseRequiredModelInputs(modelInterface);
   return Object.keys(modelInputsObj).map(
     (inputName: string) =>
       ({
         label: inputName,
+        optional: !requiredModelInputs.includes(inputName),
         ...modelInputsObj[inputName],
       } as ModelInputFormField)
   );
@@ -491,6 +493,16 @@ export function parseModelInputsObj(
     'input.properties.parameters.properties',
     {}
   ) as ModelInputMap;
+}
+
+function parseRequiredModelInputs(
+  modelInterface: ModelInterface | undefined
+): string[] {
+  return get(
+    modelInterface,
+    'input.properties.parameters.required',
+    []
+  ) as string[];
 }
 
 // Derive the collection of model outputs from the model interface JSONSchema into a form-ready list.


### PR DESCRIPTION
### Description

Recent changes have added more guardrails, such that users cannot add/remove input mappings if a model interface is defined. However, if a field is optional, users may not want to include. This relaxes the constraints such that if an optional field is found, it is displayed on the UI, and there are no validations on the value if left empty.

Implementation details: adds an `optional` field in the model input form interface, defaulting to `false` for smooth BWC experience. Updates `config_to_schema_utils` to relax the constraints if the form field is optional. Updates `config_to_template_utils` to filter out empty optional fields and omit altogether when building the ML processor config. Also adds a helper util fn `parseRequiredModelInputs()` to fetch and filter the required vs. optional fields when building the interface based on the underlying JSON schema. This logic in particular will be expanded on in the future for deeper interface checks, such as [JSON schema boolean combinations](https://json-schema.org/understanding-json-schema/reference/combining).

Demo video, showing the loosened restrictions and UI changes for optional fields on a Titan MM model, vs. Claude model with a single required `prompt` field:

[screen-capture (29).webm](https://github.com/user-attachments/assets/0352e6a8-836c-41e6-935a-194a630996ec)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
