### PR TITLE
Support whitespace for string constant; support ext toggling on ML resp processors

### DIFF
--- a/public/configs/search_response_processors/ml_search_response_processor.ts
+++ b/public/configs/search_response_processors/ml_search_response_processor.ts
@@ -23,6 +23,12 @@ export class MLSearchResponseProcessor extends MLProcessor {
         id: 'override',
         type: 'boolean',
       },
+      // ext_output is not a field stored in the processor. We expose it as if it is,
+      // to let users easily toggle saving the output under "ext.ml_inference" or not
+      {
+        id: 'ext_output',
+        type: 'boolean',
+      },
     ];
   }
 }

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/boolean_field.tsx
@@ -20,6 +20,7 @@ interface BooleanFieldProps {
   type: ComponentType;
   inverse?: boolean; // We may label something as the inverse of how the field is persisted, regarding "on/off" or "true/false"
   helpText?: string;
+  disabled?: boolean;
 }
 
 type ComponentType = 'Checkbox' | 'Switch';
@@ -36,6 +37,7 @@ export function BooleanField(props: BooleanFieldProps) {
           <EuiCompressedCheckbox
             data-testid={`checkbox-${field.name}`}
             id={`checkbox-${field.name}`}
+            disabled={props.disabled ?? false}
             label={
               <>
                 <EuiFlexGroup direction="row">
@@ -63,6 +65,7 @@ export function BooleanField(props: BooleanFieldProps) {
           <EuiSwitch
             data-testid={`switch-${field.name}`}
             id={`switch-${field.name}`}
+            disabled={props.disabled ?? false}
             label={
               <>
                 <EuiFlexGroup direction="row">

--- a/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/input_fields/text_field.tsx
@@ -25,6 +25,7 @@ interface TextFieldProps {
   showInvalid?: boolean;
   fullWidth?: boolean;
   textArea?: boolean;
+  preventWhitespace?: boolean;
 }
 
 /**
@@ -76,7 +77,12 @@ export function TextField(props: TextFieldProps) {
                 placeholder={props.placeholder || ''}
                 value={field.value || getInitialValue('string')}
                 onChange={(e) => {
-                  form.setFieldValue(props.fieldPath, e.target.value?.trim());
+                  form.setFieldValue(
+                    props.fieldPath,
+                    props.preventWhitespace
+                      ? e.target.value?.trim()
+                      : e.target.value
+                  );
                 }}
                 isInvalid={isInvalid}
               />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -330,8 +330,14 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
               <ConfigFieldList
                 configId={props.config.id}
                 configFields={(props.config.optionalFields || []).filter(
-                  // we specially render the one_to_one field in <ModelInputs/>, hence we discard it here to prevent confusion.
-                  (optionalField) => optionalField.id !== 'one_to_one'
+                  (optionalField) => {
+                    // we specially render the one_to_one field in <ModelInputs/>, hence we discard it here to prevent confusion.
+                    return (
+                      optionalField.id !== 'one_to_one' &&
+                      // we specially render the ext_output field in <ModelOutputs/>, hence we discard it here to prevent confusion.
+                      optionalField.id !== 'ext_output'
+                    );
+                  }
                 )}
                 baseConfigPath={props.baseConfigPath}
               />

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/ml_processor_inputs.tsx
@@ -86,8 +86,7 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
   const oneToOnePath = `${props.baseConfigPath}.${props.config.id}.one_to_one`;
   const extOutputPath = `${props.baseConfigPath}.${props.config.id}.ext_output`;
 
-  // Automatically update "ext_output" field based on changes to "one_to_one".
-  // Handles BWC automatically by populating the form value with defaults, even if it is undefined.
+  // Automatically update "ext_output" field based on changes to "one_to_one"
   useEffect(() => {
     const oneToOneVal = getIn(values, oneToOnePath);
     const extOutputVal = getIn(values, extOutputPath);
@@ -95,16 +94,10 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
       props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE &&
       oneToOneVal !== undefined
     ) {
-      if (
-        oneToOneVal === true &&
-        (extOutputVal === true || extOutputVal === undefined)
-      ) {
+      if (oneToOneVal === true && extOutputVal === true) {
         setFieldValue(extOutputPath, false);
         setFieldTouched(extOutputPath, true);
-      } else if (
-        oneToOneVal === false &&
-        (extOutputVal === false || extOutputVal === undefined)
-      ) {
+      } else if (oneToOneVal === false && extOutputVal === false) {
         setFieldValue(extOutputPath, true);
         setFieldTouched(extOutputPath, true);
       }
@@ -369,16 +362,17 @@ export function MLProcessorInputs(props: MLProcessorInputsProps) {
                 )}
                 baseConfigPath={props.baseConfigPath}
               />
-              {props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE && (
-                <EuiFlexItem>
-                  <BooleanField
-                    label={'Separate outputs from search hits'}
-                    fieldPath={extOutputPath}
-                    type="Checkbox"
-                    disabled={getIn(values, oneToOnePath, false) === true}
-                  />
-                </EuiFlexItem>
-              )}
+              {props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE &&
+                getIn(values, extOutputPath) !== undefined && (
+                  <EuiFlexItem>
+                    <BooleanField
+                      label={'Separate outputs from search hits'}
+                      fieldPath={extOutputPath}
+                      type="Checkbox"
+                      disabled={getIn(values, oneToOnePath, false) === true}
+                    />
+                  </EuiFlexItem>
+                )}
             </EuiFlexItem>
           </EuiAccordion>
         </>

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_inputs.tsx
@@ -590,6 +590,12 @@ export function ModelInputs(props: ModelInputsProps) {
                                             fieldPath={`${inputMapFieldPath}.${idx}.value.value`}
                                             placeholder={`Value`}
                                             showError={false}
+                                            preventWhitespace={
+                                              !(
+                                                transformType ===
+                                                TRANSFORM_TYPE.STRING
+                                              )
+                                            }
                                           />
                                         ) : (
                                           <SelectWithCustomOptions

--- a/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/processor_inputs/ml_processor_inputs/model_outputs.tsx
@@ -16,7 +16,6 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiSmallButtonIcon,
-  EuiSpacer,
   EuiSuperSelectOption,
   EuiText,
 } from '@elastic/eui';
@@ -38,7 +37,7 @@ import {
   Transform,
   MapCache,
 } from '../../../../../../common';
-import { BooleanField, TextField } from '../../input_fields';
+import { TextField } from '../../input_fields';
 import { AppState } from '../../../../../store';
 import { ConfigureMultiExpressionModal } from './modals';
 import { updateCache } from './utils';
@@ -75,38 +74,6 @@ export function ModelOutputs(props: ModelOutputsProps) {
   ) as IConfigField;
   const modelFieldPath = `${props.baseConfigPath}.${props.config.id}.${modelField.id}`;
   const outputMapFieldPath = `${props.baseConfigPath}.${props.config.id}.output_map.0`; // Assuming no more than one set of output map entries.
-
-  const oneToOnePath = `${props.baseConfigPath}.${props.config.id}.one_to_one`;
-  const extOutputPath = `${props.baseConfigPath}.${props.config.id}.ext_output`;
-
-  // Automatically update "ext_output" field based on changes to "one_to_one".
-  // Handles BWC automatically by populating the form value, even if it is undefined.
-  useEffect(() => {
-    const oneToOneVal = getIn(values, oneToOnePath);
-    const extOutputVal = getIn(values, extOutputPath);
-    console.log('one to one val: ', oneToOneVal);
-    console.log('ext output val: ', extOutputVal);
-    if (
-      props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE &&
-      oneToOneVal !== undefined
-    ) {
-      if (
-        oneToOneVal === true &&
-        (extOutputVal === true || extOutputVal === undefined)
-      ) {
-        console.log('one to one set. reset ext_output to false by default');
-        setFieldValue(extOutputPath, false);
-        setFieldTouched(extOutputPath, true);
-      } else if (
-        oneToOneVal === false &&
-        (extOutputVal === false || extOutputVal === undefined)
-      ) {
-        console.log('many to one set. reset ext output to true by default');
-        setFieldValue(extOutputPath, true);
-        setFieldTouched(extOutputPath, true);
-      }
-    }
-  }, [getIn(values, oneToOnePath)]);
 
   // various modal states
   const [expressionsModalIdx, setExpressionsModalIdx] = useState<
@@ -159,19 +126,6 @@ export function ModelOutputs(props: ModelOutputsProps) {
           <>
             {populatedMap ? (
               <EuiPanel>
-                {props.context === PROCESSOR_CONTEXT.SEARCH_RESPONSE && (
-                  <>
-                    <BooleanField
-                      fieldPath={extOutputPath}
-                      label="Save outputs externally"
-                      type="Switch"
-                      inverse={false}
-                      helpText="Save model responses to ext.ml_inference for easier readability in the search response."
-                      disabled={getIn(values, oneToOnePath, false) === true}
-                    />
-                    <EuiSpacer size="s" />
-                  </>
-                )}
                 <EuiCompressedFormRow
                   fullWidth={true}
                   key={outputMapFieldPath}

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -242,10 +242,22 @@ export function processorConfigsToTemplateProcessors(
         // process where the returned values from the output map should be stored.
         // we persist a UI-specific "ext_output" field to determine if storing the model outputs
         // in "ext.ml_inference" or not.
-        const extOutput = formValues?.ext_output as boolean | undefined;
+        // For BWC purposes, set a default value for extOutput if it is not persisted to mimic
+        // the legacy hardcoded behavior.
+        const oneToOne = formValues?.one_to_one as boolean | undefined;
+        const tempExtOutput = formValues?.ext_output as boolean | undefined;
+        const finalExtOutput =
+          tempExtOutput !== undefined
+            ? tempExtOutput
+            : oneToOne === true
+            ? false
+            : oneToOne === false
+            ? true
+            : undefined;
+
         if (
-          extOutput !== undefined &&
-          extOutput === true &&
+          finalExtOutput !== undefined &&
+          finalExtOutput === true &&
           processor.ml_inference?.output_map !== undefined
         ) {
           const updatedOutputMap = processor.ml_inference.output_map?.map(

--- a/public/utils/config_to_template_utils.ts
+++ b/public/utils/config_to_template_utils.ts
@@ -240,13 +240,12 @@ export function processorConfigsToTemplateProcessors(
         }
 
         // process where the returned values from the output map should be stored.
-        // by default, if many-to-one, append with "ext.ml_inference", such that the outputs
-        // will be stored in a standalone field in the search response, instead of appended
-        // to each document redundantly.
-        const oneToOne = formValues?.one_to_one as boolean | undefined;
+        // we persist a UI-specific "ext_output" field to determine if storing the model outputs
+        // in "ext.ml_inference" or not.
+        const extOutput = formValues?.ext_output as boolean | undefined;
         if (
-          oneToOne !== undefined &&
-          oneToOne === false &&
+          extOutput !== undefined &&
+          extOutput === true &&
           processor.ml_inference?.output_map !== undefined
         ) {
           const updatedOutputMap = processor.ml_inference.output_map?.map(
@@ -266,14 +265,16 @@ export function processorConfigsToTemplateProcessors(
 
         // process optional fields
         let additionalFormValues = {} as FormikValues;
-        Object.keys(formValues).forEach((formKey: string) => {
-          const formValue = formValues[formKey];
-          additionalFormValues = optionallyAddToFinalForm(
-            additionalFormValues,
-            formKey,
-            formValue
-          );
-        });
+        Object.keys(formValues)
+          .filter((formKey) => formKey !== 'ext_output') // ignore UI-specific "ext_output" field
+          .forEach((formKey: string) => {
+            const formValue = formValues[formKey];
+            additionalFormValues = optionallyAddToFinalForm(
+              additionalFormValues,
+              formKey,
+              formValue
+            );
+          });
 
         processor.ml_inference = {
           ...processor.ml_inference,


### PR DESCRIPTION
### Description

Misc form-related enhancements to the ML processor inputs:
1. Loosens the constraints on the "Custom string" data transform value to allow for whitespace, which could be a common config value set. (for example, an LLM with 2 inputs, one being an image string, another being directions on what to do with the image - "Describe the image", "What is in the image?", etc.)
2. Allows flexibility and custom toggling of how the model response is stored in the search response context, when applicable. Before, the behavior was hardcoded to always store the responses nested within `ext.ml_inference`, which is the preferred way to view model outputs in the final search response. But, some use cases, such as batched reranking, we may want to write back to the documents themselves instead of storing in `ext.ml_inference`. To handle this, we add a UI-specific `ext_output` config field and expose it. See demo video below for how it works.

**A note on backwards compatibility**
Since `ext_output` is a new config field in the processor, it won't be present in processors created from an older version of the UI. To handle this, we don't expose the new field in such cases; only workflows created from the latest UI will be able to leverage it. To keep the legacy behavior, there is added logic in `config_to_template_utils` to replicate the existing behavior (when `ext_output` isn't defined). Tested this by creating a workflow before this change (without `ext_output`) and with this change (with `ext_output`) and verified no issues. The old workflow doesn't show the field, and existing behavior works as expected. The new workflow with the field renders as expected, and allows the ability to toggle correctly.

Demo video, showing both whitespace in the `Custom string` field option, and the new "Separate outputs from search hits" config field, as a nested parameter (only visible in the search response context). Note the parameter is disabled when `one_to_one=true`, since the processor does not support writing to `ext.ml_inference` when that is the case.

[screen-capture (32).webm](https://github.com/user-attachments/assets/31b5e763-3aab-48b1-b08e-51ac8d895987)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
