### PR TITLE
Merge ingest response and error in the editor panel into a console panel

### DIFF
--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiResizableContainer,
   EuiText,
+  EuiPanel,
 } from '@elastic/eui';
 import {
   CONFIG_STEP,
@@ -61,6 +62,8 @@ const TOOLS_PANEL_ID = 'tools_panel_id';
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Preview side panel state. This panel encapsulates the tools panel as a child resizable panel.
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(true);
+  const [consoleContent, setConsoleContent] = useState<React.ReactNode>(null);
+  const [isConsoleExpanded, setIsConsoleExpanded] = useState<boolean>(false);
   const collapseFnHorizontal = useRef(
     (id: string, options: { direction: 'left' | 'right' }) => {}
   );
@@ -98,131 +101,192 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   }, [props.workflow]);
 
   return isValidWorkflow ? (
-    <EuiResizableContainer
-      direction="horizontal"
+    <EuiFlexGroup
+      direction="column"
       className="stretch-absolute"
-      style={{
-        marginTop: USE_NEW_HOME_PAGE ? '0' : '58px',
-        height: USE_NEW_HOME_PAGE ? '100%' : 'calc(100% - 58px)',
-        gap: '4px',
-      }}
+      gutterSize="none"
+      style={{ height: '100%' }}
     >
-      {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-        if (togglePanel) {
-          collapseFnHorizontal.current = (panelId: string, { direction }) =>
-            togglePanel(panelId, { direction });
-        }
-        return (
-          <>
-            <EuiResizablePanel
-              id={WORKFLOW_INPUTS_PANEL_ID}
-              mode="main"
-              initialSize={60}
-              minSize="25%"
-              paddingSize="none"
-              scrollable={false}
-            >
-              <WorkflowInputs
-                workflow={props.workflow}
-                uiConfig={props.uiConfig}
-                setUiConfig={props.setUiConfig}
-                setIngestResponse={setIngestResponse}
-                ingestDocs={props.ingestDocs}
-                setIngestDocs={props.setIngestDocs}
-                isRunningIngest={props.isRunningIngest}
-                setIsRunningIngest={props.setIsRunningIngest}
-                isRunningSearch={props.isRunningSearch}
-                setIsRunningSearch={props.setIsRunningSearch}
-                selectedStep={props.selectedStep}
-                setSelectedStep={props.setSelectedStep}
-                setUnsavedIngestProcessors={props.setUnsavedIngestProcessors}
-                setUnsavedSearchProcessors={props.setUnsavedSearchProcessors}
-                displaySearchPanel={() => {
-                  if (!isToolsPanelOpen) {
-                    onToggleToolsChange();
-                  }
-                  setSelectedInspectorTabId(INSPECTOR_TAB_ID.TEST);
-                }}
-                setCachedFormikState={props.setCachedFormikState}
-              />
-            </EuiResizablePanel>
-            <EuiResizableButton />
-            <EuiResizablePanel
-              id={PREVIEW_PANEL_ID}
-              mode="collapsible"
-              initialSize={60}
-              minSize="25%"
-              paddingSize="none"
-              borderRadius="l"
-              onToggleCollapsedInternal={() => onTogglePreviewChange()}
-            >
-              <EuiResizableContainer
-                className="workspace-panel"
-                direction="vertical"
-                style={{
-                  gap: '4px',
-                }}
-              >
-                {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-                  if (togglePanel) {
-                    collapseFnVertical.current = (
-                      panelId: string,
-                      { direction }
-                    ) =>
-                      // ignore is added since docs are incorrectly missing "top" and "bottom"
-                      // as valid direction options for vertically-configured resizable panels.
-                      // @ts-ignore
-                      togglePanel(panelId, { direction });
-                  }
-                  return (
-                    <>
-                      <EuiResizablePanel
-                        mode="main"
-                        initialSize={60}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                      >
-                        <EuiFlexGroup
-                          direction="column"
-                          gutterSize="none"
-                          style={{ height: '100%' }}
-                        >
-                          <EuiFlexItem>
-                            <Workspace
+      <EuiFlexItem style={{ marginBottom: 0 }}>
+        <EuiResizableContainer
+          direction="horizontal"
+          style={{
+            marginTop: USE_NEW_HOME_PAGE ? '0' : '58px',
+            height: USE_NEW_HOME_PAGE
+              ? 'calc(100% - 50px)'
+              : 'calc(100% - 108px)',
+            gap: '0px',
+          }}
+        >
+          {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
+            if (togglePanel) {
+              collapseFnHorizontal.current = (panelId: string, { direction }) =>
+                togglePanel(panelId, { direction });
+            }
+            return (
+              <>
+                <EuiResizablePanel
+                  id={WORKFLOW_INPUTS_PANEL_ID}
+                  mode="main"
+                  initialSize={60}
+                  minSize="25%"
+                  paddingSize="none"
+                  scrollable={false}
+                >
+                  <WorkflowInputs
+                    setConsoleContent={setConsoleContent}
+                    isConsoleExpanded={isConsoleExpanded}
+                    setIsConsoleExpanded={setIsConsoleExpanded}
+                    hideConsole={true}
+                    workflow={props.workflow}
+                    uiConfig={props.uiConfig}
+                    setUiConfig={props.setUiConfig}
+                    ingestResponse={ingestResponse}
+                    setIngestResponse={setIngestResponse}
+                    ingestDocs={props.ingestDocs}
+                    setIngestDocs={props.setIngestDocs}
+                    isRunningIngest={props.isRunningIngest}
+                    setIsRunningIngest={props.setIsRunningIngest}
+                    isRunningSearch={props.isRunningSearch}
+                    setIsRunningSearch={props.setIsRunningSearch}
+                    selectedStep={props.selectedStep}
+                    setSelectedStep={props.setSelectedStep}
+                    setUnsavedIngestProcessors={
+                      props.setUnsavedIngestProcessors
+                    }
+                    setUnsavedSearchProcessors={
+                      props.setUnsavedSearchProcessors
+                    }
+                    displaySearchPanel={() => {
+                      if (!isToolsPanelOpen) {
+                        onToggleToolsChange();
+                      }
+                      setSelectedInspectorTabId(INSPECTOR_TAB_ID.TEST);
+                    }}
+                    setCachedFormikState={props.setCachedFormikState}
+                    context={
+                      props.selectedStep === CONFIG_STEP.INGEST
+                        ? 'INGEST'
+                        : 'SEARCH'
+                    }
+                  />
+                </EuiResizablePanel>
+                <EuiResizableButton />
+                <EuiResizablePanel
+                  id={PREVIEW_PANEL_ID}
+                  mode="collapsible"
+                  initialSize={60}
+                  minSize="25%"
+                  paddingSize="none"
+                  borderRadius="l"
+                  onToggleCollapsedInternal={() => onTogglePreviewChange()}
+                >
+                  <EuiResizableContainer
+                    className="workspace-panel"
+                    direction="vertical"
+                    style={{
+                      gap: '4px',
+                    }}
+                  >
+                    {(
+                      EuiResizablePanel,
+                      EuiResizableButton,
+                      { togglePanel }
+                    ) => {
+                      if (togglePanel) {
+                        collapseFnVertical.current = (
+                          panelId: string,
+                          { direction }
+                        ) =>
+                          // ignore is added since docs are incorrectly missing "top" and "bottom"
+                          // as valid direction options for vertically-configured resizable panels.
+                          // @ts-ignore
+                          togglePanel(panelId, { direction });
+                      }
+                      return (
+                        <>
+                          <EuiResizablePanel
+                            mode="main"
+                            initialSize={60}
+                            minSize="25%"
+                            paddingSize="none"
+                            borderRadius="l"
+                          >
+                            <EuiFlexGroup
+                              direction="column"
+                              gutterSize="none"
+                              style={{ height: '100%' }}
+                            >
+                              <EuiFlexItem>
+                                <Workspace
+                                  workflow={props.workflow}
+                                  uiConfig={props.uiConfig}
+                                />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiResizablePanel>
+                          <EuiResizableButton />
+                          <EuiResizablePanel
+                            id={TOOLS_PANEL_ID}
+                            mode="collapsible"
+                            initialSize={50}
+                            minSize="25%"
+                            paddingSize="none"
+                            borderRadius="l"
+                            onToggleCollapsedInternal={() =>
+                              onToggleToolsChange()
+                            }
+                          >
+                            <Tools
                               workflow={props.workflow}
-                              uiConfig={props.uiConfig}
+                              ingestResponse={ingestResponse}
+                              selectedTabId={selectedInspectorTabId}
+                              setSelectedTabId={setSelectedInspectorTabId}
+                              selectedStep={props.selectedStep}
+                              hideIngestResponseTab={true}
+                              hideErrorsTab={true}
                             />
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      </EuiResizablePanel>
-                      <EuiResizableButton />
-                      <EuiResizablePanel
-                        id={TOOLS_PANEL_ID}
-                        mode="collapsible"
-                        initialSize={50}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                        onToggleCollapsedInternal={() => onToggleToolsChange()}
-                      >
-                        <Tools
-                          workflow={props.workflow}
-                          ingestResponse={ingestResponse}
-                          selectedTabId={selectedInspectorTabId}
-                          setSelectedTabId={setSelectedInspectorTabId}
-                          selectedStep={props.selectedStep}
-                        />
-                      </EuiResizablePanel>
-                    </>
-                  );
-                }}
-              </EuiResizableContainer>
-            </EuiResizablePanel>
-          </>
-        );
-      }}
-    </EuiResizableContainer>
+                          </EuiResizablePanel>
+                        </>
+                      );
+                    }}
+                  </EuiResizableContainer>
+                </EuiResizablePanel>
+              </>
+            );
+          }}
+        </EuiResizableContainer>
+      </EuiFlexItem>
+
+      {/* Console section that spans across the entire width */}
+      <EuiFlexItem
+        grow={false}
+        style={{
+          height: 'auto',
+          maxHeight: '40px',
+          padding: '0',
+          marginTop: '2px',
+          position: 'absolute',
+          bottom: 0,
+          left: '0',
+          right: '0',
+          transition: 'max-height 0.3s ease-in-out',
+          ...(isConsoleExpanded && { maxHeight: '250px' }),
+        }}
+      >
+        <EuiPanel
+          paddingSize="s"
+          style={{
+            height: '100%',
+            borderRadius: '0',
+            margin: '0',
+            boxShadow: 'none',
+          }}
+        >
+          {consoleContent}
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   ) : (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={3}>

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -43,6 +43,8 @@ interface ToolsProps {
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
   selectedStep: CONFIG_STEP;
+  hideIngestResponseTab?: boolean;
+  hideErrorsTab?: boolean;
 }
 
 const PANEL_TITLE = 'Inspect flows';
@@ -63,6 +65,13 @@ export function Tools(props: ToolsProps) {
     (string | ReactNode)[]
   >([]);
   const { values } = useFormikContext<WorkflowFormValues>();
+
+  const visibleTabs = INSPECTOR_TABS.filter((tab) => {
+    if (props.hideIngestResponseTab && tab.id === INSPECTOR_TAB_ID.INGEST)
+      return false;
+    if (props.hideErrorsTab && tab.id === INSPECTOR_TAB_ID.ERRORS) return false;
+    return true;
+  });
 
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value.
@@ -123,14 +132,14 @@ export function Tools(props: ToolsProps) {
 
   // auto-navigate to errors tab if new errors have been found
   useEffect(() => {
-    if (curErrorMessages.length > 0) {
+    if (curErrorMessages.length > 0 && !props.hideErrorsTab) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [curErrorMessages]);
 
   // auto-navigate to ingest tab if a populated value has been set, indicating ingest has been ran
   useEffect(() => {
-    if (!isEmpty(props.ingestResponse)) {
+    if (!isEmpty(props.ingestResponse) && !props.hideIngestResponseTab) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.INGEST);
     }
   }, [props.ingestResponse]);
@@ -157,7 +166,7 @@ export function Tools(props: ToolsProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiTabs size="s" expand={false}>
-            {INSPECTOR_TABS.map((tab, idx) => {
+            {visibleTabs.map((tab, idx) => {
               return (
                 <EuiTab
                   onClick={() => props.setSelectedTabId(tab.id)}

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -83,6 +83,8 @@ describe('WorkflowDetail Page with create ingestion option', () => {
         getByText,
         getByRole,
         getByTestId,
+        queryByRole,
+        queryByText,
       } = renderWithRouter(workflowId, workflowName, type);
 
       expect(getAllByText(workflowName).length).toBeGreaterThan(0);
@@ -95,9 +97,19 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(getByText('Export')).toBeInTheDocument();
       expect(getByText('Visual')).toBeInTheDocument();
       expect(getByText('JSON')).toBeInTheDocument();
+
+      // Test flow tab should exist regardless
       expect(getByRole('tab', { name: 'Test flow' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Ingest response' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
+
+      // Look for either the original tabs OR console header
+      const ingestResponseTab = queryByRole('tab', { name: 'Ingest response' });
+      const errorsTab = queryByRole('tab', { name: 'Errors' });
+      const consoleHeader = queryByText('Console');
+
+      // At least one of the approaches should be present
+      expect((ingestResponseTab && errorsTab) || consoleHeader).toBeTruthy();
+
+      // Resources tab should still exist
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
 
       // "Search pipeline" button should be disabled by default

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
 import {
@@ -28,12 +28,15 @@ import {
 
 interface AdvancedSettingsProps {
   setHasInvalidDimensions: (hasInvalidDimensions: boolean) => void;
+  onToggle?: (isExpanded: boolean) => void;
 }
 
 /**
  * Input component for configuring ingest-side advanced settings
  */
 export function AdvancedSettings(props: AdvancedSettingsProps) {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
   const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
   const { models, connectors } = useSelector((state: AppState) => state.ml);
   const ingestMLProcessors = (Object.values(
@@ -133,9 +136,25 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
   }, [getIn(values, indexMappingsPath)]);
 
   return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiAccordion id="advancedSettings" buttonContent="Advanced settings">
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem
+        grow={false}
+        style={{
+          marginTop: isExpanded ? '0px' : '-50px',
+          marginBottom: isExpanded ? '0px' : '-10px',
+        }}
+      >
+        <EuiAccordion
+          id="advancedSettings"
+          buttonContent="Advanced settings"
+          paddingSize="s"
+          onToggle={(expanded) => {
+            setIsExpanded(expanded);
+            if (props.onToggle) {
+              props.onToggle(expanded);
+            }
+          }}
+        >
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="column">
             <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -9,6 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
+  EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { TextField } from '../input_fields';
@@ -22,6 +23,9 @@ interface IngestDataProps {}
  */
 export function IngestData(props: IngestDataProps) {
   const [hasInvalidDimensions, setHasInvalidDimensions] = useState<boolean>(
+    false
+  );
+  const [isAccordionExpanded, setIsAccordionExpanded] = useState<boolean>(
     false
   );
 
@@ -55,8 +59,13 @@ export function IngestData(props: IngestDataProps) {
           showError={true}
         />
       </EuiFlexItem>
-      <EuiFlexItem>
-        <AdvancedSettings setHasInvalidDimensions={setHasInvalidDimensions} />
+
+      <EuiSpacer size="xs" />
+      <EuiFlexItem style={{ marginTop: isAccordionExpanded ? '0' : '-24px' }}>
+        <AdvancedSettings
+          setHasInvalidDimensions={setHasInvalidDimensions}
+          onToggle={(isExpanded) => setIsAccordionExpanded(isExpanded)}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -28,7 +28,7 @@ interface IngestInputsProps {
  */
 export function IngestInputs(props: IngestInputsProps) {
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" style={{ height: '100%' }}>
       <EuiFlexItem grow={false}>
         <SourceData
           workflow={props.workflow}
@@ -50,7 +50,7 @@ export function IngestInputs(props: IngestInputsProps) {
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={true} style={{ overflow: 'auto' }}>
         <IngestData />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -110,6 +110,7 @@ export function SourceData(props: SourceDataProps) {
                 <h3>Import sample data</h3>
               </EuiText>
             </EuiFlexItem>
+
             {docsPopulated && (
               <EuiFlexItem grow={false}>
                 <EuiSmallButtonEmpty

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -1033,8 +1033,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
-
-          {/* Console section is now handled by the parent component via setConsoleContent */}
         </>
       )}
 


### PR DESCRIPTION
### Description

Currently we have ingest response and error showing on the right panel (editor). The new UI requires to merge the two sections into a console panel and locate the panel at the bottom of the work flow page.

### Issues Resolved
NONE

### To-dos:
Currently when clicking the unfold button, the panel only shrinks/expands at the bottom area. Will continue to working on expanding the panel to overlay existing panels.

Some z-fighting is going on with the code editor and `update` button. Second version of this PR will address these two concerns. 


### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
