### PR TITLE
Consolidate ingest response and errors into the console section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,39 @@
 # CHANGELOG
+
 All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/anomaly-detection/compare/2.x...HEAD)
+
 ### Features
+
 ### Enhancements
+
 ### Bug Fixes
+
 ### Infrastructure
+
 ### Documentation
+
 ### Maintenance
+
 ### Refactoring
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/anomaly-detection/compare/2.19...2.x)
+
 ### Features
+
 ### Enhancements
-## [Refactor UI for 2.20] (https://github.com/opensearch-project/dashboards-flow-framework/pull/700)
+
+## [Refactor UI] (https://github.com/opensearch-project/dashboards-flow-framework/pull/707)
+
 ### Bug Fixes
+
 ### Infrastructure
+
 ### Documentation
+
 ### Maintenance
+
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/anomaly-detection/compare/2.19...2.x)
 ### Features
 ### Enhancements
+## [Refactor UI for 2.20] (https://github.com/opensearch-project/dashboards-flow-framework/pull/700)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -898,3 +898,21 @@ export const INSPECTOR_TABS = [
     disabled: false,
   },
 ];
+
+export const getVisibleTabs = () => {
+  const tabs = [];
+
+  tabs.push({
+    id: INSPECTOR_TAB_ID.TEST,
+    name: 'Test flow',
+    disabled: false,
+  });
+
+  tabs.push({
+    id: INSPECTOR_TAB_ID.RESOURCES,
+    name: 'Resources',
+    disabled: false,
+  });
+
+  return tabs;
+};

--- a/public/pages/workflow_detail/console/Console.tsx
+++ b/public/pages/workflow_detail/console/Console.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import {
   EuiFlexGroup,

--- a/public/pages/workflow_detail/console/Console.tsx
+++ b/public/pages/workflow_detail/console/Console.tsx
@@ -93,6 +93,8 @@ export function Console(props: ConsoleProps) {
                 overflowX: 'hidden',
                 overflowY:
                   hasContent && content.length > 500 ? 'auto' : 'hidden',
+                width: '100%',
+                wordWrap: 'break-word',
               }}
               className="hideFullScreenButton"
             >

--- a/public/pages/workflow_detail/console/Console.tsx
+++ b/public/pages/workflow_detail/console/Console.tsx
@@ -5,7 +5,6 @@ import {
   EuiText,
   EuiButtonIcon,
   EuiCodeBlock,
-  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { CONFIG_STEP } from '../../../../common';
 
@@ -28,7 +27,6 @@ export function Console(props: ConsoleProps) {
     setIsExpanded,
   } = props;
 
-  // Determine what content to show
   let content = '';
   if (context === CONFIG_STEP.INGEST) {
     if (ingestResponse) {
@@ -47,6 +45,15 @@ export function Console(props: ConsoleProps) {
   }
 
   const hasContent = content !== '';
+
+  console.log('Console props:', {
+    context: props.context,
+    hasIngestResponse: !!props.ingestResponse,
+    hasIngestErrors:
+      ingestPipelineErrors && Object.keys(ingestPipelineErrors).length > 0,
+    hasSearchErrors:
+      searchPipelineErrors && Object.keys(searchPipelineErrors).length > 0,
+  });
 
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
@@ -83,6 +90,9 @@ export function Console(props: ConsoleProps) {
               data-test-subj="consoleOutput"
               style={{
                 maxHeight: isExpanded ? undefined : '200px',
+                overflowX: 'hidden',
+                overflowY:
+                  hasContent && content.length > 500 ? 'auto' : 'hidden',
               }}
               className="hideFullScreenButton"
             >
@@ -90,17 +100,12 @@ export function Console(props: ConsoleProps) {
             </EuiCodeBlock>
           </>
         ) : (
-          <EuiEmptyPrompt
-            iconType="console"
-            title={<h4>No output to display</h4>}
-            titleSize="xs"
-            body={
-              context === CONFIG_STEP.INGEST ? (
-                <EuiText size="s">Run ingest to view output here.</EuiText>
-              ) : (
-                <EuiText size="s">No search errors to display.</EuiText>
-              )
-            }
+          <div
+            style={{
+              height: '200px',
+              backgroundColor: 'transparent',
+              border: 'none',
+            }}
           />
         )}
       </EuiFlexItem>

--- a/public/pages/workflow_detail/console/Console.tsx
+++ b/public/pages/workflow_detail/console/Console.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiButtonIcon,
+  EuiCodeBlock,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import { CONFIG_STEP } from '../../../../common';
+
+interface ConsoleProps {
+  context: CONFIG_STEP;
+  ingestResponse: string;
+  ingestPipelineErrors: Record<string, any>;
+  searchPipelineErrors: Record<string, any>;
+  isExpanded: boolean;
+  setIsExpanded: (isExpanded: boolean) => void;
+}
+
+export function Console(props: ConsoleProps) {
+  const {
+    context,
+    ingestResponse,
+    ingestPipelineErrors,
+    searchPipelineErrors,
+    isExpanded,
+    setIsExpanded,
+  } = props;
+
+  // Determine what content to show
+  let content = '';
+  if (context === CONFIG_STEP.INGEST) {
+    if (ingestResponse) {
+      content = ingestResponse;
+    } else if (
+      ingestPipelineErrors &&
+      Object.keys(ingestPipelineErrors).length > 0
+    ) {
+      content = JSON.stringify(ingestPipelineErrors, null, 2);
+    }
+  } else if (
+    searchPipelineErrors &&
+    Object.keys(searchPipelineErrors).length > 0
+  ) {
+    content = JSON.stringify(searchPipelineErrors, null, 2);
+  }
+
+  const hasContent = content !== '';
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem>
+            <EuiText size="s">
+              <h3>Console</h3>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType={isExpanded ? 'fold' : 'unfold'}
+              aria-label={isExpanded ? 'Collapse console' : 'Expand console'}
+              onClick={() => setIsExpanded(!isExpanded)}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        {hasContent ? (
+          <>
+            <style>{`
+              .hideFullScreenButton .euiCodeBlock__fullScreenButton {
+                display: none !important;
+              }
+            `}</style>
+            <EuiCodeBlock
+              language="json"
+              fontSize="s"
+              paddingSize="m"
+              overflowHeight={isExpanded ? undefined : 200}
+              isCopyable={false}
+              data-test-subj="consoleOutput"
+              style={{
+                maxHeight: isExpanded ? undefined : '200px',
+              }}
+              className="hideFullScreenButton"
+            >
+              {content}
+            </EuiCodeBlock>
+          </>
+        ) : (
+          <EuiEmptyPrompt
+            iconType="console"
+            title={<h4>No output to display</h4>}
+            titleSize="xs"
+            body={
+              context === CONFIG_STEP.INGEST ? (
+                <EuiText size="s">Run ingest to view output here.</EuiText>
+              ) : (
+                <EuiText size="s">No search errors to display.</EuiText>
+              )
+            }
+          />
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/workflow_detail/console/Console_errors.tsx
+++ b/public/pages/workflow_detail/console/Console_errors.tsx
@@ -1,7 +1,10 @@
-// console_errors.tsx
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
-
 interface ConsoleErrorsProps {
   errors: Record<string, any>;
   isExpanded: boolean;

--- a/public/pages/workflow_detail/console/Console_errors.tsx
+++ b/public/pages/workflow_detail/console/Console_errors.tsx
@@ -1,0 +1,36 @@
+// console_errors.tsx
+import React from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
+
+interface ConsoleErrorsProps {
+  errors: Record<string, any>;
+  isExpanded: boolean;
+  hasContent: boolean;
+}
+
+export function ConsoleErrors(props: ConsoleErrorsProps) {
+  const { errors, isExpanded, hasContent } = props;
+
+  const content = JSON.stringify(errors, null, 2) || '';
+
+  return (
+    <EuiCodeBlock
+      language="json"
+      fontSize="s"
+      paddingSize="m"
+      overflowHeight={isExpanded ? undefined : 200}
+      isCopyable={false}
+      data-test-subj="consoleOutput"
+      style={{
+        backgroundColor: hasContent ? undefined : 'transparent',
+        border: hasContent ? undefined : 'none',
+        maxHeight: isExpanded ? undefined : '200px',
+      }}
+      className={`${
+        hasContent ? '' : 'euiCodeBlock--transparentBackground'
+      } hideFullScreenButton`}
+    >
+      {content}
+    </EuiCodeBlock>
+  );
+}

--- a/public/pages/workflow_detail/console/Console_ingest.tsx
+++ b/public/pages/workflow_detail/console/Console_ingest.tsx
@@ -1,7 +1,10 @@
-// console_ingest.tsx
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
-
 interface ConsoleIngestProps {
   ingestResponse: string;
   errors: Record<string, any>;

--- a/public/pages/workflow_detail/console/Console_ingest.tsx
+++ b/public/pages/workflow_detail/console/Console_ingest.tsx
@@ -1,0 +1,47 @@
+// console_ingest.tsx
+import React from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
+
+interface ConsoleIngestProps {
+  ingestResponse: string;
+  errors: Record<string, any>;
+  isExpanded: boolean;
+  hasContent: boolean;
+}
+
+export function ConsoleIngest(props: ConsoleIngestProps) {
+  const { ingestResponse, errors, isExpanded, hasContent } = props;
+
+  const content =
+    ingestResponse ||
+    (errors && Object.keys(errors).length > 0
+      ? JSON.stringify(errors, null, 2)
+      : '');
+
+  console.log('ConsoleIngest rendering with:', {
+    hasIngestResponse: !!ingestResponse,
+    hasErrors: errors && Object.keys(errors).length > 0,
+    content: content.substring(0, 100),
+  });
+
+  return (
+    <EuiCodeBlock
+      language="json"
+      fontSize="s"
+      paddingSize="m"
+      overflowHeight={isExpanded ? undefined : 200}
+      isCopyable={false}
+      data-test-subj="consoleOutput"
+      style={{
+        backgroundColor: hasContent ? undefined : 'transparent',
+        border: hasContent ? undefined : 'none',
+        maxHeight: isExpanded ? undefined : '200px',
+      }}
+      className={`${
+        hasContent ? '' : 'euiCodeBlock--transparentBackground'
+      } hideFullScreenButton`}
+    >
+      {content}
+    </EuiCodeBlock>
+  );
+}

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiResizableContainer,
   EuiText,
+  EuiPanel,
 } from '@elastic/eui';
 import {
   CONFIG_STEP,
@@ -61,6 +62,8 @@ const TOOLS_PANEL_ID = 'tools_panel_id';
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   // Preview side panel state. This panel encapsulates the tools panel as a child resizable panel.
   const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(true);
+  const [consoleContent, setConsoleContent] = useState<React.ReactNode>(null);
+  const [isConsoleExpanded, setIsConsoleExpanded] = useState<boolean>(false);
   const collapseFnHorizontal = useRef(
     (id: string, options: { direction: 'left' | 'right' }) => {}
   );
@@ -98,131 +101,192 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
   }, [props.workflow]);
 
   return isValidWorkflow ? (
-    <EuiResizableContainer
-      direction="horizontal"
+    <EuiFlexGroup
+      direction="column"
       className="stretch-absolute"
-      style={{
-        marginTop: USE_NEW_HOME_PAGE ? '0' : '58px',
-        height: USE_NEW_HOME_PAGE ? '100%' : 'calc(100% - 58px)',
-        gap: '4px',
-      }}
+      gutterSize="none"
+      style={{ height: '100%' }}
     >
-      {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-        if (togglePanel) {
-          collapseFnHorizontal.current = (panelId: string, { direction }) =>
-            togglePanel(panelId, { direction });
-        }
-        return (
-          <>
-            <EuiResizablePanel
-              id={WORKFLOW_INPUTS_PANEL_ID}
-              mode="main"
-              initialSize={60}
-              minSize="25%"
-              paddingSize="none"
-              scrollable={false}
-            >
-              <WorkflowInputs
-                workflow={props.workflow}
-                uiConfig={props.uiConfig}
-                setUiConfig={props.setUiConfig}
-                setIngestResponse={setIngestResponse}
-                ingestDocs={props.ingestDocs}
-                setIngestDocs={props.setIngestDocs}
-                isRunningIngest={props.isRunningIngest}
-                setIsRunningIngest={props.setIsRunningIngest}
-                isRunningSearch={props.isRunningSearch}
-                setIsRunningSearch={props.setIsRunningSearch}
-                selectedStep={props.selectedStep}
-                setSelectedStep={props.setSelectedStep}
-                setUnsavedIngestProcessors={props.setUnsavedIngestProcessors}
-                setUnsavedSearchProcessors={props.setUnsavedSearchProcessors}
-                displaySearchPanel={() => {
-                  if (!isToolsPanelOpen) {
-                    onToggleToolsChange();
-                  }
-                  setSelectedInspectorTabId(INSPECTOR_TAB_ID.TEST);
-                }}
-                setCachedFormikState={props.setCachedFormikState}
-              />
-            </EuiResizablePanel>
-            <EuiResizableButton />
-            <EuiResizablePanel
-              id={PREVIEW_PANEL_ID}
-              mode="collapsible"
-              initialSize={60}
-              minSize="25%"
-              paddingSize="none"
-              borderRadius="l"
-              onToggleCollapsedInternal={() => onTogglePreviewChange()}
-            >
-              <EuiResizableContainer
-                className="workspace-panel"
-                direction="vertical"
-                style={{
-                  gap: '4px',
-                }}
-              >
-                {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-                  if (togglePanel) {
-                    collapseFnVertical.current = (
-                      panelId: string,
-                      { direction }
-                    ) =>
-                      // ignore is added since docs are incorrectly missing "top" and "bottom"
-                      // as valid direction options for vertically-configured resizable panels.
-                      // @ts-ignore
-                      togglePanel(panelId, { direction });
-                  }
-                  return (
-                    <>
-                      <EuiResizablePanel
-                        mode="main"
-                        initialSize={60}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                      >
-                        <EuiFlexGroup
-                          direction="column"
-                          gutterSize="none"
-                          style={{ height: '100%' }}
-                        >
-                          <EuiFlexItem>
-                            <Workspace
+      <EuiFlexItem style={{ marginBottom: 0 }}>
+        <EuiResizableContainer
+          direction="horizontal"
+          style={{
+            marginTop: USE_NEW_HOME_PAGE ? '0' : '58px',
+            height: USE_NEW_HOME_PAGE
+              ? 'calc(100% - 50px)'
+              : 'calc(100% - 108px)',
+            gap: '0px',
+          }}
+        >
+          {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
+            if (togglePanel) {
+              collapseFnHorizontal.current = (panelId: string, { direction }) =>
+                togglePanel(panelId, { direction });
+            }
+            return (
+              <>
+                <EuiResizablePanel
+                  id={WORKFLOW_INPUTS_PANEL_ID}
+                  mode="main"
+                  initialSize={60}
+                  minSize="25%"
+                  paddingSize="none"
+                  scrollable={false}
+                >
+                  <WorkflowInputs
+                    setConsoleContent={setConsoleContent}
+                    isConsoleExpanded={isConsoleExpanded}
+                    setIsConsoleExpanded={setIsConsoleExpanded}
+                    hideConsole={true}
+                    workflow={props.workflow}
+                    uiConfig={props.uiConfig}
+                    setUiConfig={props.setUiConfig}
+                    ingestResponse={ingestResponse}
+                    setIngestResponse={setIngestResponse}
+                    ingestDocs={props.ingestDocs}
+                    setIngestDocs={props.setIngestDocs}
+                    isRunningIngest={props.isRunningIngest}
+                    setIsRunningIngest={props.setIsRunningIngest}
+                    isRunningSearch={props.isRunningSearch}
+                    setIsRunningSearch={props.setIsRunningSearch}
+                    selectedStep={props.selectedStep}
+                    setSelectedStep={props.setSelectedStep}
+                    setUnsavedIngestProcessors={
+                      props.setUnsavedIngestProcessors
+                    }
+                    setUnsavedSearchProcessors={
+                      props.setUnsavedSearchProcessors
+                    }
+                    displaySearchPanel={() => {
+                      if (!isToolsPanelOpen) {
+                        onToggleToolsChange();
+                      }
+                      setSelectedInspectorTabId(INSPECTOR_TAB_ID.TEST);
+                    }}
+                    setCachedFormikState={props.setCachedFormikState}
+                    context={
+                      props.selectedStep === CONFIG_STEP.INGEST
+                        ? 'INGEST'
+                        : 'SEARCH'
+                    }
+                  />
+                </EuiResizablePanel>
+                <EuiResizableButton />
+                <EuiResizablePanel
+                  id={PREVIEW_PANEL_ID}
+                  mode="collapsible"
+                  initialSize={60}
+                  minSize="25%"
+                  paddingSize="none"
+                  borderRadius="l"
+                  onToggleCollapsedInternal={() => onTogglePreviewChange()}
+                >
+                  <EuiResizableContainer
+                    className="workspace-panel"
+                    direction="vertical"
+                    style={{
+                      gap: '4px',
+                    }}
+                  >
+                    {(
+                      EuiResizablePanel,
+                      EuiResizableButton,
+                      { togglePanel }
+                    ) => {
+                      if (togglePanel) {
+                        collapseFnVertical.current = (
+                          panelId: string,
+                          { direction }
+                        ) =>
+                          // ignore is added since docs are incorrectly missing "top" and "bottom"
+                          // as valid direction options for vertically-configured resizable panels.
+                          // @ts-ignore
+                          togglePanel(panelId, { direction });
+                      }
+                      return (
+                        <>
+                          <EuiResizablePanel
+                            mode="main"
+                            initialSize={60}
+                            minSize="25%"
+                            paddingSize="none"
+                            borderRadius="l"
+                          >
+                            <EuiFlexGroup
+                              direction="column"
+                              gutterSize="none"
+                              style={{ height: '100%' }}
+                            >
+                              <EuiFlexItem>
+                                <Workspace
+                                  workflow={props.workflow}
+                                  uiConfig={props.uiConfig}
+                                />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiResizablePanel>
+                          <EuiResizableButton />
+                          <EuiResizablePanel
+                            id={TOOLS_PANEL_ID}
+                            mode="collapsible"
+                            initialSize={50}
+                            minSize="25%"
+                            paddingSize="none"
+                            borderRadius="l"
+                            onToggleCollapsedInternal={() =>
+                              onToggleToolsChange()
+                            }
+                          >
+                            <Tools
                               workflow={props.workflow}
-                              uiConfig={props.uiConfig}
+                              ingestResponse={ingestResponse}
+                              selectedTabId={selectedInspectorTabId}
+                              setSelectedTabId={setSelectedInspectorTabId}
+                              selectedStep={props.selectedStep}
+                              hideIngestResponseTab={true}
+                              hideErrorsTab={true}
                             />
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      </EuiResizablePanel>
-                      <EuiResizableButton />
-                      <EuiResizablePanel
-                        id={TOOLS_PANEL_ID}
-                        mode="collapsible"
-                        initialSize={50}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                        onToggleCollapsedInternal={() => onToggleToolsChange()}
-                      >
-                        <Tools
-                          workflow={props.workflow}
-                          ingestResponse={ingestResponse}
-                          selectedTabId={selectedInspectorTabId}
-                          setSelectedTabId={setSelectedInspectorTabId}
-                          selectedStep={props.selectedStep}
-                        />
-                      </EuiResizablePanel>
-                    </>
-                  );
-                }}
-              </EuiResizableContainer>
-            </EuiResizablePanel>
-          </>
-        );
-      }}
-    </EuiResizableContainer>
+                          </EuiResizablePanel>
+                        </>
+                      );
+                    }}
+                  </EuiResizableContainer>
+                </EuiResizablePanel>
+              </>
+            );
+          }}
+        </EuiResizableContainer>
+      </EuiFlexItem>
+
+      {/* Console section that spans across the entire width */}
+      <EuiFlexItem
+        grow={false}
+        style={{
+          height: 'auto',
+          maxHeight: '40px',
+          padding: '0',
+          marginTop: '2px',
+          position: 'absolute',
+          bottom: 0,
+          left: '0',
+          right: '0',
+          transition: 'max-height 0.3s ease-in-out',
+          ...(isConsoleExpanded && { maxHeight: '250px' }),
+        }}
+      >
+        <EuiPanel
+          paddingSize="s"
+          style={{
+            height: '100%',
+            borderRadius: '0',
+            margin: '0',
+            boxShadow: 'none',
+          }}
+        >
+          {consoleContent}
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   ) : (
     <EuiFlexGroup direction="column">
       <EuiFlexItem grow={3}>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -174,8 +174,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                     setCachedFormikState={props.setCachedFormikState}
                     context={
                       props.selectedStep === CONFIG_STEP.INGEST
-                        ? 'INGEST'
-                        : 'SEARCH'
+                        ? CONFIG_STEP.INGEST
+                        : CONFIG_STEP.SEARCH
                     }
                   />
                 </EuiResizablePanel>
@@ -251,8 +251,6 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
                               selectedTabId={selectedInspectorTabId}
                               setSelectedTabId={setSelectedInspectorTabId}
                               selectedStep={props.selectedStep}
-                              hideIngestResponseTab={true}
-                              hideErrorsTab={true}
                             />
                           </EuiResizablePanel>
                         </>

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -113,7 +113,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
           flex: '1 1 auto',
           minHeight: isConsoleExpanded
             ? 'calc(100% - 230px - 2px)'
-            : 'calc(100% - 40px - 2px)',
+            : 'calc(100% - 80px - 2px)',
           overflow: 'auto',
           transition: 'min-height 0.3s ease-in-out',
         }}
@@ -270,14 +270,14 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       <EuiFlexItem
         grow={false}
         style={{
-          height: isConsoleExpanded ? '230px' : '40px',
+          height: isConsoleExpanded ? '230px' : '80px',
           padding: '0',
           marginTop: '2px',
           position: 'relative',
           transition: 'height 0.3s ease-in-out',
           overflow: 'auto',
           flexShrink: 0,
-          borderTop: isConsoleExpanded ? '1px solid #D3DAE6' : 'none',
+          borderTop: '1px solid #D3DAE6',
         }}
       >
         <EuiPanel

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -273,7 +273,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
           marginTop: '2px',
           position: 'relative',
           transition: 'height 0.3s ease-in-out',
-          overflow: 'auto',
+          overflow: 'hidden',
           flexShrink: 0,
           borderTop: '1px solid #D3DAE6',
         }}
@@ -285,6 +285,8 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             borderRadius: '0',
             margin: '0',
             boxShadow: 'none',
+            overflowX: 'hidden',
+            overflowY: 'auto',
           }}
         >
           {consoleContent}

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -107,14 +107,21 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       gutterSize="none"
       style={{ height: '100%' }}
     >
-      <EuiFlexItem style={{ marginBottom: 0 }}>
+      <EuiFlexItem
+        style={{
+          marginBottom: 0,
+          flex: isConsoleExpanded ? '0 1 auto' : '1 0 calc(100% - 40px)',
+          minHeight: isConsoleExpanded ? '20%' : 'calc(100% - 40px)',
+          maxHeight: isConsoleExpanded ? '30%' : '100%',
+
+          transition: 'all 0.3s ease-in-out',
+        }}
+      >
         <EuiResizableContainer
           direction="horizontal"
           style={{
             marginTop: USE_NEW_HOME_PAGE ? '0' : '58px',
-            height: USE_NEW_HOME_PAGE
-              ? 'calc(100% - 50px)'
-              : 'calc(100% - 108px)',
+            height: '100%',
             gap: '0px',
           }}
         >
@@ -262,16 +269,17 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       <EuiFlexItem
         grow={false}
         style={{
-          height: 'auto',
-          maxHeight: '40px',
+          flex: isConsoleExpanded ? '1 0 auto' : '0 0 40px',
+
+          maxHeight: isConsoleExpanded ? '80vh' : '40px',
+          minHeight: isConsoleExpanded ? '400px' : '40px',
+
           padding: '0',
           marginTop: '2px',
-          position: 'absolute',
-          bottom: 0,
-          left: '0',
-          right: '0',
-          transition: 'max-height 0.3s ease-in-out',
-          ...(isConsoleExpanded && { maxHeight: '250px' }),
+          position: 'relative',
+
+          transition: 'all 0.3s ease-in-out',
+          overflow: 'auto',
         }}
       >
         <EuiPanel

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -110,11 +110,12 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       <EuiFlexItem
         style={{
           marginBottom: 0,
-          flex: isConsoleExpanded ? '0 1 auto' : '1 0 calc(100% - 40px)',
-          minHeight: isConsoleExpanded ? '20%' : 'calc(100% - 40px)',
-          maxHeight: isConsoleExpanded ? '30%' : '100%',
-
-          transition: 'all 0.3s ease-in-out',
+          flex: '1 1 auto',
+          minHeight: isConsoleExpanded
+            ? 'calc(100% - 230px - 2px)'
+            : 'calc(100% - 40px - 2px)',
+          overflow: 'auto',
+          transition: 'min-height 0.3s ease-in-out',
         }}
       >
         <EuiResizableContainer
@@ -269,17 +270,14 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
       <EuiFlexItem
         grow={false}
         style={{
-          flex: isConsoleExpanded ? '1 0 auto' : '0 0 40px',
-
-          maxHeight: isConsoleExpanded ? '80vh' : '40px',
-          minHeight: isConsoleExpanded ? '400px' : '40px',
-
+          height: isConsoleExpanded ? '230px' : '40px',
           padding: '0',
           marginTop: '2px',
           position: 'relative',
-
-          transition: 'all 0.3s ease-in-out',
+          transition: 'height 0.3s ease-in-out',
           overflow: 'auto',
+          flexShrink: 0,
+          borderTop: isConsoleExpanded ? '1px solid #D3DAE6' : 'none',
         }}
       >
         <EuiPanel

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -20,8 +20,8 @@ import {
   CONFIG_STEP,
   customStringify,
   FETCH_ALL_QUERY,
+  getVisibleTabs,
   INSPECTOR_TAB_ID,
-  INSPECTOR_TABS,
   QueryParam,
   SearchResponse,
   Workflow,
@@ -43,8 +43,6 @@ interface ToolsProps {
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
   selectedStep: CONFIG_STEP;
-  hideIngestResponseTab?: boolean;
-  hideErrorsTab?: boolean;
 }
 
 const PANEL_TITLE = 'Inspect flows';
@@ -66,12 +64,7 @@ export function Tools(props: ToolsProps) {
   >([]);
   const { values } = useFormikContext<WorkflowFormValues>();
 
-  const visibleTabs = INSPECTOR_TABS.filter((tab) => {
-    if (props.hideIngestResponseTab && tab.id === INSPECTOR_TAB_ID.INGEST)
-      return false;
-    if (props.hideErrorsTab && tab.id === INSPECTOR_TAB_ID.ERRORS) return false;
-    return true;
-  });
+  const visibleTabs = getVisibleTabs();
 
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value.
@@ -132,14 +125,14 @@ export function Tools(props: ToolsProps) {
 
   // auto-navigate to errors tab if new errors have been found
   useEffect(() => {
-    if (curErrorMessages.length > 0 && !props.hideErrorsTab) {
+    if (curErrorMessages.length > 0) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [curErrorMessages]);
 
   // auto-navigate to ingest tab if a populated value has been set, indicating ingest has been ran
   useEffect(() => {
-    if (!isEmpty(props.ingestResponse) && !props.hideIngestResponseTab) {
+    if (!isEmpty(props.ingestResponse)) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.INGEST);
     }
   }, [props.ingestResponse]);

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -43,6 +43,8 @@ interface ToolsProps {
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
   selectedStep: CONFIG_STEP;
+  hideIngestResponseTab?: boolean;
+  hideErrorsTab?: boolean;
 }
 
 const PANEL_TITLE = 'Inspect flows';
@@ -63,6 +65,13 @@ export function Tools(props: ToolsProps) {
     (string | ReactNode)[]
   >([]);
   const { values } = useFormikContext<WorkflowFormValues>();
+
+  const visibleTabs = INSPECTOR_TABS.filter((tab) => {
+    if (props.hideIngestResponseTab && tab.id === INSPECTOR_TAB_ID.INGEST)
+      return false;
+    if (props.hideErrorsTab && tab.id === INSPECTOR_TAB_ID.ERRORS) return false;
+    return true;
+  });
 
   // Standalone / sandboxed search request state. Users can test things out
   // without updating the base form / persisted value.
@@ -123,14 +132,14 @@ export function Tools(props: ToolsProps) {
 
   // auto-navigate to errors tab if new errors have been found
   useEffect(() => {
-    if (curErrorMessages.length > 0) {
+    if (curErrorMessages.length > 0 && !props.hideErrorsTab) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.ERRORS);
     }
   }, [curErrorMessages]);
 
   // auto-navigate to ingest tab if a populated value has been set, indicating ingest has been ran
   useEffect(() => {
-    if (!isEmpty(props.ingestResponse)) {
+    if (!isEmpty(props.ingestResponse) && !props.hideIngestResponseTab) {
       props.setSelectedTabId(INSPECTOR_TAB_ID.INGEST);
     }
   }, [props.ingestResponse]);
@@ -157,7 +166,7 @@ export function Tools(props: ToolsProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiTabs size="s" expand={false}>
-            {INSPECTOR_TABS.map((tab, idx) => {
+            {visibleTabs.map((tab, idx) => {
               return (
                 <EuiTab
                   onClick={() => props.setSelectedTabId(tab.id)}

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -83,6 +83,8 @@ describe('WorkflowDetail Page with create ingestion option', () => {
         getByText,
         getByRole,
         getByTestId,
+        queryByRole,
+        queryByText,
       } = renderWithRouter(workflowId, workflowName, type);
 
       expect(getAllByText(workflowName).length).toBeGreaterThan(0);
@@ -95,9 +97,19 @@ describe('WorkflowDetail Page with create ingestion option', () => {
       expect(getByText('Export')).toBeInTheDocument();
       expect(getByText('Visual')).toBeInTheDocument();
       expect(getByText('JSON')).toBeInTheDocument();
+
+      // Test flow tab should exist regardless
       expect(getByRole('tab', { name: 'Test flow' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Ingest response' })).toBeInTheDocument();
-      expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
+
+      // Look for either the original tabs OR console header
+      const ingestResponseTab = queryByRole('tab', { name: 'Ingest response' });
+      const errorsTab = queryByRole('tab', { name: 'Errors' });
+      const consoleHeader = queryByText('Console');
+
+      // At least one of the approaches should be present
+      expect((ingestResponseTab && errorsTab) || consoleHeader).toBeTruthy();
+
+      // Resources tab should still exist
       expect(getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
 
       // "Search pipeline" button should be disabled by default

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -28,7 +28,6 @@ import {
 
 interface AdvancedSettingsProps {
   setHasInvalidDimensions: (hasInvalidDimensions: boolean) => void;
-  onToggle?: (isExpanded: boolean) => void;
 }
 
 /**
@@ -150,9 +149,6 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
           paddingSize="s"
           onToggle={(expanded) => {
             setIsExpanded(expanded);
-            if (props.onToggle) {
-              props.onToggle(expanded);
-            }
           }}
         >
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -140,8 +140,8 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
       <EuiFlexItem
         grow={false}
         style={{
-          marginTop: isExpanded ? '0px' : '-50px',
-          marginBottom: isExpanded ? '0px' : '-10px',
+          marginTop: isExpanded ? '10px' : '20px',
+          marginBottom: isExpanded ? '0px' : '10px',
         }}
       >
         <EuiAccordion

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
 import {
@@ -28,12 +28,15 @@ import {
 
 interface AdvancedSettingsProps {
   setHasInvalidDimensions: (hasInvalidDimensions: boolean) => void;
+  onToggle?: (isExpanded: boolean) => void;
 }
 
 /**
  * Input component for configuring ingest-side advanced settings
  */
 export function AdvancedSettings(props: AdvancedSettingsProps) {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
   const { values, setFieldValue } = useFormikContext<WorkflowFormValues>();
   const { models, connectors } = useSelector((state: AppState) => state.ml);
   const ingestMLProcessors = (Object.values(
@@ -133,9 +136,25 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
   }, [getIn(values, indexMappingsPath)]);
 
   return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem grow={false}>
-        <EuiAccordion id="advancedSettings" buttonContent="Advanced settings">
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem
+        grow={false}
+        style={{
+          marginTop: isExpanded ? '0px' : '-50px',
+          marginBottom: isExpanded ? '0px' : '-10px',
+        }}
+      >
+        <EuiAccordion
+          id="advancedSettings"
+          buttonContent="Advanced settings"
+          paddingSize="s"
+          onToggle={(expanded) => {
+            setIsExpanded(expanded);
+            if (props.onToggle) {
+              props.onToggle(expanded);
+            }
+          }}
+        >
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="column">
             <EuiFlexItem>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -142,7 +142,6 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
         style={{
           marginTop: isExpanded ? '10px' : '20px',
           marginBottom: isExpanded ? '0px' : '10px',
-          overflowX: 'hidden',
         }}
       >
         <EuiAccordion

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/advanced_settings.tsx
@@ -28,6 +28,7 @@ import {
 
 interface AdvancedSettingsProps {
   setHasInvalidDimensions: (hasInvalidDimensions: boolean) => void;
+  onToggle?: (isExpanded: boolean) => void;
 }
 
 /**
@@ -141,6 +142,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
         style={{
           marginTop: isExpanded ? '10px' : '20px',
           marginBottom: isExpanded ? '0px' : '10px',
+          overflowX: 'hidden',
         }}
       >
         <EuiAccordion
@@ -149,6 +151,9 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
           paddingSize="s"
           onToggle={(expanded) => {
             setIsExpanded(expanded);
+            if (props.onToggle) {
+              props.onToggle(expanded);
+            }
           }}
         >
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_data.tsx
@@ -9,6 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
+  EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { TextField } from '../input_fields';
@@ -22,6 +23,9 @@ interface IngestDataProps {}
  */
 export function IngestData(props: IngestDataProps) {
   const [hasInvalidDimensions, setHasInvalidDimensions] = useState<boolean>(
+    false
+  );
+  const [isAccordionExpanded, setIsAccordionExpanded] = useState<boolean>(
     false
   );
 
@@ -55,8 +59,13 @@ export function IngestData(props: IngestDataProps) {
           showError={true}
         />
       </EuiFlexItem>
-      <EuiFlexItem>
-        <AdvancedSettings setHasInvalidDimensions={setHasInvalidDimensions} />
+
+      <EuiSpacer size="xs" />
+      <EuiFlexItem style={{ marginTop: isAccordionExpanded ? '0' : '-24px' }}>
+        <AdvancedSettings
+          setHasInvalidDimensions={setHasInvalidDimensions}
+          onToggle={(isExpanded) => setIsAccordionExpanded(isExpanded)}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/ingest_inputs.tsx
@@ -28,7 +28,7 @@ interface IngestInputsProps {
  */
 export function IngestInputs(props: IngestInputsProps) {
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" style={{ height: '100%' }}>
       <EuiFlexItem grow={false}>
         <SourceData
           workflow={props.workflow}
@@ -50,7 +50,7 @@ export function IngestInputs(props: IngestInputsProps) {
       <EuiFlexItem grow={false}>
         <EuiHorizontalRule margin="none" />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={true} style={{ overflow: 'auto' }}>
         <IngestData />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/ingest_inputs/source_data.tsx
@@ -110,6 +110,7 @@ export function SourceData(props: SourceDataProps) {
                 <h3>Import sample data</h3>
               </EuiText>
             </EuiFlexItem>
+
             {docsPopulated && (
               <EuiFlexItem grow={false}>
                 <EuiSmallButtonEmpty

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -68,7 +68,7 @@ import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
 import { ResourcesFlyout } from '../tools/resources/resources_flyout';
 import { useSelector } from 'react-redux';
-import { Console } from '../console/console';
+import { Console } from '../console/Console';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -311,8 +311,10 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonIcon
-                  iconType="unfold"
-                  aria-label="Expand console"
+                  iconType={consoleExpanded ? 'fold' : 'unfold'}
+                  aria-label={
+                    consoleExpanded ? 'Collapse console' : 'Expand console'
+                  }
                   onClick={() => setConsoleExpanded(!consoleExpanded)}
                 />
               </EuiFlexItem>
@@ -328,7 +330,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               language="json"
               fontSize="s"
               paddingSize="m"
-              overflowHeight={consoleExpanded ? 400 : 200}
+              overflowHeight={consoleExpanded ? undefined : 200}
               isCopyable={false}
               data-test-subj="consoleOutput"
               style={{
@@ -355,6 +357,8 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                       Object.keys(searchPipelineErrors).length > 0
                     ? undefined
                     : 'none',
+                // allow content to determine the height when expanded
+                maxHeight: consoleExpanded ? undefined : '200px',
               }}
               className={`
                 ${

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -24,7 +24,6 @@ import {
   EuiButtonIcon,
 } from '@elastic/eui';
 import {
-  CONFIG_STEP,
   CachedFormikState,
   SimulateIngestPipelineResponseVerbose,
   TemplateNode,
@@ -34,6 +33,7 @@ import {
   WorkflowFormValues,
   WorkflowTemplate,
   customStringify,
+  CONFIG_STEP,
 } from '../../../../common';
 import { IngestInputs } from './ingest_inputs';
 import { SearchInputs } from './search_inputs';
@@ -89,7 +89,7 @@ interface WorkflowInputsProps {
   setUnsavedSearchProcessors: (unsavedSearchProcessors: boolean) => void;
   displaySearchPanel: () => void;
   setCachedFormikState: (cachedFormikState: CachedFormikState) => void;
-  context: 'INGEST' | 'SEARCH';
+  context: CONFIG_STEP;
   setConsoleContent?: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   isConsoleExpanded?: boolean;
   setIsConsoleExpanded?: React.Dispatch<React.SetStateAction<boolean>>;
@@ -335,7 +335,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               data-test-subj="consoleOutput"
               style={{
                 backgroundColor:
-                  props.context === 'INGEST'
+                  props.context === CONFIG_STEP.INGEST
                     ? props.ingestResponse ||
                       (ingestPipelineErrors &&
                         Object.keys(ingestPipelineErrors).length > 0)
@@ -347,7 +347,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                     : 'transparent',
 
                 border:
-                  props.context === 'INGEST'
+                  props.context === CONFIG_STEP.INGEST
                     ? props.ingestResponse ||
                       (ingestPipelineErrors &&
                         Object.keys(ingestPipelineErrors).length > 0)
@@ -362,7 +362,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               }}
               className={`
                 ${
-                  props.context === 'INGEST'
+                  props.context === CONFIG_STEP.INGEST
                     ? props.ingestResponse ||
                       (ingestPipelineErrors &&
                         Object.keys(ingestPipelineErrors).length > 0)
@@ -375,7 +375,7 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
                 } hideFullScreenButton
               `}
             >
-              {props.context === 'INGEST'
+              {props.context === CONFIG_STEP.INGEST
                 ? props.ingestResponse ||
                   (ingestPipelineErrors &&
                   Object.keys(ingestPipelineErrors).length > 0

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -20,8 +20,6 @@ import {
   EuiIconTip,
   EuiSmallButtonIcon,
   EuiButtonEmpty,
-  EuiCodeBlock,
-  EuiButtonIcon,
 } from '@elastic/eui';
 import {
   CachedFormikState,
@@ -70,6 +68,7 @@ import { BooleanField } from './input_fields';
 import '../workspace/workspace-styles.scss';
 import { ResourcesFlyout } from '../tools/resources/resources_flyout';
 import { useSelector } from 'react-redux';
+import { Console } from '../console/console';
 
 interface WorkflowInputsProps {
   workflow: Workflow | undefined;
@@ -300,94 +299,16 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
 
   useEffect(() => {
     if (props.setConsoleContent) {
-      const consoleContent = (
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexItem>
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiFlexItem>
-                <EuiText size="s">
-                  <h3>Console</h3>
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType={consoleExpanded ? 'fold' : 'unfold'}
-                  aria-label={
-                    consoleExpanded ? 'Collapse console' : 'Expand console'
-                  }
-                  onClick={() => setConsoleExpanded(!consoleExpanded)}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <style>{`
-              .hideFullScreenButton .euiCodeBlock__fullScreenButton {
-                display: none !important;
-              }
-            `}</style>
-            <EuiCodeBlock
-              language="json"
-              fontSize="s"
-              paddingSize="m"
-              overflowHeight={consoleExpanded ? undefined : 200}
-              isCopyable={false}
-              data-test-subj="consoleOutput"
-              style={{
-                backgroundColor:
-                  props.context === CONFIG_STEP.INGEST
-                    ? props.ingestResponse ||
-                      (ingestPipelineErrors &&
-                        Object.keys(ingestPipelineErrors).length > 0)
-                      ? undefined
-                      : 'transparent'
-                    : searchPipelineErrors &&
-                      Object.keys(searchPipelineErrors).length > 0
-                    ? undefined
-                    : 'transparent',
-
-                border:
-                  props.context === CONFIG_STEP.INGEST
-                    ? props.ingestResponse ||
-                      (ingestPipelineErrors &&
-                        Object.keys(ingestPipelineErrors).length > 0)
-                      ? undefined
-                      : 'none'
-                    : searchPipelineErrors &&
-                      Object.keys(searchPipelineErrors).length > 0
-                    ? undefined
-                    : 'none',
-                // allow content to determine the height when expanded
-                maxHeight: consoleExpanded ? undefined : '200px',
-              }}
-              className={`
-                ${
-                  props.context === CONFIG_STEP.INGEST
-                    ? props.ingestResponse ||
-                      (ingestPipelineErrors &&
-                        Object.keys(ingestPipelineErrors).length > 0)
-                      ? ''
-                      : 'euiCodeBlock--transparentBackground'
-                    : searchPipelineErrors &&
-                      Object.keys(searchPipelineErrors).length > 0
-                    ? ''
-                    : 'euiCodeBlock--transparentBackground'
-                } hideFullScreenButton
-              `}
-            >
-              {props.context === CONFIG_STEP.INGEST
-                ? props.ingestResponse ||
-                  (ingestPipelineErrors &&
-                  Object.keys(ingestPipelineErrors).length > 0
-                    ? JSON.stringify(ingestPipelineErrors, null, 2)
-                    : '')
-                : JSON.stringify(searchPipelineErrors, null, 2) || ''}
-            </EuiCodeBlock>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+      props.setConsoleContent(
+        <Console
+          context={props.context}
+          ingestResponse={props.ingestResponse}
+          ingestPipelineErrors={ingestPipelineErrors}
+          searchPipelineErrors={searchPipelineErrors}
+          isExpanded={consoleExpanded}
+          setIsExpanded={setConsoleExpanded}
+        />
       );
-
-      props.setConsoleContent(consoleContent);
     }
   }, [
     props.setConsoleContent,
@@ -397,7 +318,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
     ingestPipelineErrors,
     searchPipelineErrors,
   ]);
-
   // populated ingest docs state
   const [docsPopulated, setDocsPopulated] = useState<boolean>(false);
   useEffect(() => {

--- a/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
+++ b/public/pages/workflow_detail/workflow_inputs/workflow_inputs.tsx
@@ -1033,8 +1033,6 @@ export function WorkflowInputs(props: WorkflowInputsProps) {
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
-
-          {/* Console section is now handled by the parent component via setConsoleContent */}
         </>
       )}
 

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -11,11 +11,9 @@ module.exports = {
   // when jest tries to interpret these types of files.
   moduleNameMapper: {
     '\\.(css|less|scss|sass|svg)$': '<rootDir>/test/mocks/empty_mock.ts',
-    // Direct mock for the html_id_generator module that's causing the error
     '@elastic/eui/lib/services/accessibility/html_id_generator':
       '<rootDir>/test/mocks/html_id_generator.ts',
 
-    // UUID mocks as backup
     '^uuid$': '<rootDir>/test/mocks/uuid_mock.ts',
     '^uuid/.*$': '<rootDir>/test/mocks/uuid_mock.ts',
   },

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -11,6 +11,13 @@ module.exports = {
   // when jest tries to interpret these types of files.
   moduleNameMapper: {
     '\\.(css|less|scss|sass|svg)$': '<rootDir>/test/mocks/empty_mock.ts',
+    // Direct mock for the html_id_generator module that's causing the error
+    '@elastic/eui/lib/services/accessibility/html_id_generator':
+      '<rootDir>/test/mocks/html_id_generator.ts',
+
+    // UUID mocks as backup
+    '^uuid$': '<rootDir>/test/mocks/uuid_mock.ts',
+    '^uuid/.*$': '<rootDir>/test/mocks/uuid_mock.ts',
   },
   testEnvironment: 'jest-environment-jsdom',
   coverageReporters: ['lcov', 'text', 'cobertura'],

--- a/test/mocks/html_id_generator.ts
+++ b/test/mocks/html_id_generator.ts
@@ -3,7 +3,6 @@
  * This avoids the dependency on UUID and crypto.getRandomValues()
  */
 
-// Simple counter-based ID generator
 export const htmlIdGenerator = (prefix: string = ''): (() => string) => {
   let counter = 0;
   return (): string => {
@@ -12,5 +11,4 @@ export const htmlIdGenerator = (prefix: string = ''): (() => string) => {
   };
 };
 
-// Also export as default
 export default htmlIdGenerator;

--- a/test/mocks/html_id_generator.ts
+++ b/test/mocks/html_id_generator.ts
@@ -1,0 +1,16 @@
+/**
+ * Mock implementation of EUI's htmlIdGenerator
+ * This avoids the dependency on UUID and crypto.getRandomValues()
+ */
+
+// Simple counter-based ID generator
+export const htmlIdGenerator = (prefix: string = ''): (() => string) => {
+  let counter = 0;
+  return (): string => {
+    counter += 1;
+    return `${prefix}${counter}`;
+  };
+};
+
+// Also export as default
+export default htmlIdGenerator;

--- a/test/mocks/uuid_mock.ts
+++ b/test/mocks/uuid_mock.ts
@@ -3,7 +3,6 @@
  * This avoids the need for crypto.getRandomValues() in tests
  */
 
-// Mock implementation for the random number generator
 export function rng(): Uint8Array {
   const rnds8 = new Uint8Array(16);
   for (let i = 0; i < 16; i++) {
@@ -12,7 +11,6 @@ export function rng(): Uint8Array {
   return rnds8;
 }
 
-// Mock v1 UUID generation
 export function v1(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     const r = (Math.random() * 16) | 0;
@@ -21,7 +19,6 @@ export function v1(): string {
   });
 }
 
-// Mock v4 UUID generation
 export function v4(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     const r = (Math.random() * 16) | 0;
@@ -30,8 +27,6 @@ export function v4(): string {
   });
 }
 
-// Export in a way compatible with both ES modules and CommonJS
-// Default export for ESM
 export default {
   v1,
   v4,

--- a/test/mocks/uuid_mock.ts
+++ b/test/mocks/uuid_mock.ts
@@ -1,0 +1,39 @@
+/**
+ * Mock implementation for UUID package
+ * This avoids the need for crypto.getRandomValues() in tests
+ */
+
+// Mock implementation for the random number generator
+export function rng(): Uint8Array {
+  const rnds8 = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    rnds8[i] = Math.floor(Math.random() * 256);
+  }
+  return rnds8;
+}
+
+// Mock v1 UUID generation
+export function v1(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// Mock v4 UUID generation
+export function v4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// Export in a way compatible with both ES modules and CommonJS
+// Default export for ESM
+export default {
+  v1,
+  v4,
+  rng,
+};


### PR DESCRIPTION
### Description

Consolidate ingest response and errors into the console section and place the section at the bottom of the workflow page. Upon discussion with UX team, the console section will push other panels up when expanded instead of overlaying other panels.

### Issues Resolved
NONE

### Demo video

https://github.com/user-attachments/assets/9d1b6f9e-67f4-4c98-9e2d-72321b50d7e2

### 2nd Revision Changes:
1. Increase the height of the console section when not expanded.
2. Remove the horizontal bar in the console section. This is not needed since console is expanding  full width horizontally. The other vertical scroll bars are kept since pushing the console section above will hide upper panel content.
3. Refactor the console section into a component with 2 child components.
4. Use enums already defined in the constant file instead of creating new variables



### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
