### PR TITLE
Integrate preview panel into inspector panel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 2.x](https://github.com/opensearch-project/anomaly-detection/compare/2.19...2.x)
 ### Features
 ### Enhancements
+#### Integrate preview panel into inspector panel (https://github.com/opensearch-project/dashboards-flow-framework/pull/720)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -874,6 +874,7 @@ export enum INSPECTOR_TAB_ID {
   INGEST = 'ingest',
   ERRORS = 'errors',
   RESOURCES = 'resources',
+  PREVIEW = 'preview',
 }
 
 export const INSPECTOR_TABS = [
@@ -895,6 +896,11 @@ export const INSPECTOR_TABS = [
   {
     id: INSPECTOR_TAB_ID.RESOURCES,
     name: 'Resources',
+    disabled: false,
+  },
+  {
+    id: INSPECTOR_TAB_ID.PREVIEW,
+    name: 'Preview',
     disabled: false,
   },
 ];

--- a/public/pages/workflow_detail/resizable_workspace.tsx
+++ b/public/pages/workflow_detail/resizable_workspace.tsx
@@ -26,7 +26,6 @@ import {
   USE_NEW_HOME_PAGE,
 } from '../../utils';
 import { WorkflowInputs } from './workflow_inputs';
-import { Workspace } from './workspace';
 import { Tools } from './tools';
 
 // styling
@@ -51,7 +50,6 @@ interface ResizableWorkspaceProps {
 }
 
 const WORKFLOW_INPUTS_PANEL_ID = 'workflow_inputs_panel_id';
-const PREVIEW_PANEL_ID = 'preview_panel_id';
 const TOOLS_PANEL_ID = 'tools_panel_id';
 
 /**
@@ -59,25 +57,12 @@ const TOOLS_PANEL_ID = 'tools_panel_id';
  * panels - the ReactFlow workspace panel and the selected component details panel.
  */
 export function ResizableWorkspace(props: ResizableWorkspaceProps) {
-  // Preview side panel state. This panel encapsulates the tools panel as a child resizable panel.
-  const [isPreviewPanelOpen, setIsPreviewPanelOpen] = useState<boolean>(true);
+  const [isToolsPanelOpen, setIsToolsPanelOpen] = useState<boolean>(true);
   const collapseFnHorizontal = useRef(
     (id: string, options: { direction: 'left' | 'right' }) => {}
   );
-  const onTogglePreviewChange = () => {
-    collapseFnHorizontal.current(PREVIEW_PANEL_ID, {
-      direction: 'right',
-    });
-    setIsPreviewPanelOpen(!isPreviewPanelOpen);
-  };
-
-  // Tools side panel state
-  const [isToolsPanelOpen, setIsToolsPanelOpen] = useState<boolean>(true);
-  const collapseFnVertical = useRef(
-    (id: string, options: { direction: 'top' | 'bottom' }) => {}
-  );
   const onToggleToolsChange = () => {
-    collapseFnVertical.current(TOOLS_PANEL_ID, { direction: 'bottom' });
+    collapseFnHorizontal.current(TOOLS_PANEL_ID, { direction: 'right' });
     setIsToolsPanelOpen(!isToolsPanelOpen);
   };
 
@@ -117,7 +102,7 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             <EuiResizablePanel
               id={WORKFLOW_INPUTS_PANEL_ID}
               mode="main"
-              initialSize={60}
+              initialSize={50}
               minSize="25%"
               paddingSize="none"
               scrollable={false}
@@ -148,76 +133,22 @@ export function ResizableWorkspace(props: ResizableWorkspaceProps) {
             </EuiResizablePanel>
             <EuiResizableButton />
             <EuiResizablePanel
-              id={PREVIEW_PANEL_ID}
+              id={TOOLS_PANEL_ID}
               mode="collapsible"
-              initialSize={60}
+              initialSize={50}
               minSize="25%"
               paddingSize="none"
               borderRadius="l"
-              onToggleCollapsedInternal={() => onTogglePreviewChange()}
+              onToggleCollapsedInternal={() => onToggleToolsChange()}
             >
-              <EuiResizableContainer
-                className="workspace-panel"
-                direction="vertical"
-                style={{
-                  gap: '4px',
-                }}
-              >
-                {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
-                  if (togglePanel) {
-                    collapseFnVertical.current = (
-                      panelId: string,
-                      { direction }
-                    ) =>
-                      // ignore is added since docs are incorrectly missing "top" and "bottom"
-                      // as valid direction options for vertically-configured resizable panels.
-                      // @ts-ignore
-                      togglePanel(panelId, { direction });
-                  }
-                  return (
-                    <>
-                      <EuiResizablePanel
-                        mode="main"
-                        initialSize={60}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                      >
-                        <EuiFlexGroup
-                          direction="column"
-                          gutterSize="none"
-                          style={{ height: '100%' }}
-                        >
-                          <EuiFlexItem>
-                            <Workspace
-                              workflow={props.workflow}
-                              uiConfig={props.uiConfig}
-                            />
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      </EuiResizablePanel>
-                      <EuiResizableButton />
-                      <EuiResizablePanel
-                        id={TOOLS_PANEL_ID}
-                        mode="collapsible"
-                        initialSize={50}
-                        minSize="25%"
-                        paddingSize="none"
-                        borderRadius="l"
-                        onToggleCollapsedInternal={() => onToggleToolsChange()}
-                      >
-                        <Tools
-                          workflow={props.workflow}
-                          ingestResponse={ingestResponse}
-                          selectedTabId={selectedInspectorTabId}
-                          setSelectedTabId={setSelectedInspectorTabId}
-                          selectedStep={props.selectedStep}
-                        />
-                      </EuiResizablePanel>
-                    </>
-                  );
-                }}
-              </EuiResizableContainer>
+              <Tools
+                workflow={props.workflow}
+                ingestResponse={ingestResponse}
+                selectedTabId={selectedInspectorTabId}
+                setSelectedTabId={setSelectedInspectorTabId}
+                selectedStep={props.selectedStep}
+                uiConfig={props.uiConfig}
+              />
             </EuiResizablePanel>
           </>
         );

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -139,6 +139,9 @@ export function Tools(props: ToolsProps) {
     }
   }, [props.ingestResponse]);
 
+  // Force the workspace component to remount when the preview tab becomes active.
+  // The graph cannot be rendered correctly in ReactFlow when initialized in a hidden container/inactive tab
+  // See: https://reactflow.dev/learn/troubleshooting
   useEffect(() => {
     if (props.selectedTabId === INSPECTOR_TAB_ID.PREVIEW) {
       setWorkspaceKey(Date.now());

--- a/public/pages/workflow_detail/tools/tools.tsx
+++ b/public/pages/workflow_detail/tools/tools.tsx
@@ -25,6 +25,7 @@ import {
   QueryParam,
   SearchResponse,
   Workflow,
+  WorkflowConfig,
   WorkflowFormValues,
 } from '../../../../common';
 import { Resources } from './resources';
@@ -36,6 +37,7 @@ import {
   hasProvisionedIngestResources,
   hasProvisionedSearchResources,
 } from '../../../utils';
+import { Workspace } from '../workspace';
 
 interface ToolsProps {
   workflow?: Workflow;
@@ -43,6 +45,7 @@ interface ToolsProps {
   selectedTabId: INSPECTOR_TAB_ID;
   setSelectedTabId: (tabId: INSPECTOR_TAB_ID) => void;
   selectedStep: CONFIG_STEP;
+  uiConfig?: WorkflowConfig;
 }
 
 const PANEL_TITLE = 'Inspect flows';
@@ -51,6 +54,7 @@ const PANEL_TITLE = 'Inspect flows';
  * The base Tools component for performing ingest and search, viewing resources, and debugging.
  */
 export function Tools(props: ToolsProps) {
+  const [workspaceKey, setWorkspaceKey] = useState<number>(0);
   // error message states. Error may come from several different sources.
   const { opensearch, workflows } = useSelector((state: AppState) => state);
   const opensearchError = opensearch.errorMessage;
@@ -135,6 +139,12 @@ export function Tools(props: ToolsProps) {
     }
   }, [props.ingestResponse]);
 
+  useEffect(() => {
+    if (props.selectedTabId === INSPECTOR_TAB_ID.PREVIEW) {
+      setWorkspaceKey(Date.now());
+    }
+  }, [props.selectedTabId]);
+
   return (
     <EuiPanel
       paddingSize="m"
@@ -172,9 +182,26 @@ export function Tools(props: ToolsProps) {
           </EuiTabs>
         </EuiFlexItem>
         <EuiFlexItem grow={true}>
-          <EuiFlexGroup direction="column">
+          <EuiFlexGroup direction="column" style={{ height: '100%' }}>
             <EuiFlexItem grow={true}>
               <>
+                {props.selectedTabId === INSPECTOR_TAB_ID.PREVIEW && (
+                  <div
+                    style={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      overflow: 'hidden',
+                      minHeight: '500px',
+                    }}
+                  >
+                    <Workspace
+                      key={workspaceKey}
+                      workflow={props.workflow}
+                      uiConfig={props.uiConfig}
+                    />
+                  </div>
+                )}
                 {props.selectedTabId === INSPECTOR_TAB_ID.INGEST && (
                   <Ingest ingestResponse={props.ingestResponse} />
                 )}

--- a/public/pages/workflow_detail/workflow_detail.test.tsx
+++ b/public/pages/workflow_detail/workflow_detail.test.tsx
@@ -87,14 +87,11 @@ describe('WorkflowDetail Page with create ingestion option', () => {
 
       expect(getAllByText(workflowName).length).toBeGreaterThan(0);
       expect(getAllByText('Inspect flows').length).toBeGreaterThan(0);
-      expect(getAllByText('Preview flows').length).toBeGreaterThan(0);
       expect(
         getAllByText((content) => content.startsWith('Last saved:')).length
       ).toBeGreaterThan(0);
       expect(getByText('Close')).toBeInTheDocument();
       expect(getByText('Export')).toBeInTheDocument();
-      expect(getByText('Visual')).toBeInTheDocument();
-      expect(getByText('JSON')).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Test flow' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Ingest response' })).toBeInTheDocument();
       expect(getByRole('tab', { name: 'Errors' })).toBeInTheDocument();
@@ -126,8 +123,6 @@ describe('WorkflowDetail Page Functionality (Custom Workflow)', () => {
     });
     // Close the export component
     userEvent.click(getByTestId('exportCloseButton'));
-    // Check workspace button group exists (Visual and JSON)
-    getByTestId('visualJSONToggleButtonGroup');
     // Tools panel should collapse and expand the toggle
     const toolsPanel = container.querySelector('#tools_panel_id');
     expect(toolsPanel).toBeVisible();

--- a/public/pages/workflow_detail/workspace/workspace.tsx
+++ b/public/pages/workflow_detail/workspace/workspace.tsx
@@ -52,8 +52,6 @@ interface WorkspaceProps {
   uiConfig?: WorkflowConfig;
 }
 
-const PANEL_TITLE = 'Preview flows';
-
 const nodeTypes = {
   custom: WorkspaceComponent,
   ingestGroup: IngestGroupComponent,
@@ -151,11 +149,6 @@ export function Workspace(props: WorkspaceProps) {
          */}
         <div>
           <EuiFlexGroup direction="row" style={{ padding: '12px' }}>
-            <EuiFlexItem grow={false}>
-              <EuiText size="s">
-                <h3>{PANEL_TITLE}</h3>
-              </EuiText>
-            </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButtonGroup
                 legend="Toggle between visual and JSON views"

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -11,6 +11,11 @@ module.exports = {
   // when jest tries to interpret these types of files.
   moduleNameMapper: {
     '\\.(css|less|scss|sass|svg)$': '<rootDir>/test/mocks/empty_mock.ts',
+    '@elastic/eui/lib/services/accessibility/html_id_generator':
+      '<rootDir>/test/mocks/html_id_generator.ts',
+
+    '^uuid$': '<rootDir>/test/mocks/uuid_mock.ts',
+    '^uuid/.*$': '<rootDir>/test/mocks/uuid_mock.ts',
   },
   testEnvironment: 'jest-environment-jsdom',
   coverageReporters: ['lcov', 'text', 'cobertura'],

--- a/test/mocks/html_id_generator.ts
+++ b/test/mocks/html_id_generator.ts
@@ -1,0 +1,14 @@
+/**
+ * Mock implementation of EUI's htmlIdGenerator
+ * This avoids the dependency on UUID and crypto.getRandomValues()
+ */
+
+export const htmlIdGenerator = (prefix: string = ''): (() => string) => {
+  let counter = 0;
+  return (): string => {
+    counter += 1;
+    return `${prefix}${counter}`;
+  };
+};
+
+export default htmlIdGenerator;

--- a/test/mocks/uuid_mock.ts
+++ b/test/mocks/uuid_mock.ts
@@ -1,0 +1,34 @@
+/**
+ * Mock implementation for UUID package
+ * This avoids the need for crypto.getRandomValues() in tests
+ */
+
+export function rng(): Uint8Array {
+  const rnds8 = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    rnds8[i] = Math.floor(Math.random() * 256);
+  }
+  return rnds8;
+}
+
+export function v1(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function v4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export default {
+  v1,
+  v4,
+  rng,
+};


### PR DESCRIPTION
### Description

Integrate preview panel as one of the tabs in the inspector panel, leaving more space for the right panel.

### Issues Resolved

NONE

### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
