### PR TITLE
Misc improvements II

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -249,6 +249,8 @@ export const ML_INFERENCE_RESPONSE_DOCS_LINK =
   'https://opensearch.org/docs/latest/search-plugins/search-pipelines/ml-inference-search-response/#request-fields';
 export const ML_REMOTE_MODEL_LINK =
   'https://docs.opensearch.org/docs/latest/ml-commons-plugin/remote-models/supported-connectors/';
+export const ML_INTERFACE_LINK =
+  'https://docs.opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/register-model/#the-interface-parameter';
 export const TEXT_CHUNKING_PROCESSOR_LINK =
   'https://opensearch.org/docs/latest/ingest-pipelines/processors/text-chunking/';
 export const CREATE_WORKFLOW_LINK =

--- a/public/pages/workflow_detail/component_input/component_input.tsx
+++ b/public/pages/workflow_detail/component_input/component_input.tsx
@@ -62,7 +62,7 @@ export function ComponentInput(props: ComponentInputProps) {
 
   const { values } = useFormikContext<WorkflowFormValues>();
 
-  // top-level edit button state. Currently implemented as a model, and only applicable for (and only integrated with)
+  // top-level edit button state. Currently implemented as a modal, and only applicable for (and only integrated with)
   // the "Source Data" component. In the future, the edit content may be moved into a contextual panel,
   // and there may be more top-level actions, such as "preview transformations" for individual processors.
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);

--- a/public/pages/workflow_detail/component_input/component_input.tsx
+++ b/public/pages/workflow_detail/component_input/component_input.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import { getIn, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
 import {
+  EuiButtonIcon,
   EuiCallOut,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -17,7 +18,6 @@ import {
   EuiLoadingSpinner,
   EuiPanel,
   EuiSmallButtonEmpty,
-  EuiSmallButtonIcon,
   EuiTitle,
 } from '@elastic/eui';
 import { SourceData, IngestData } from './ingest_inputs';
@@ -147,10 +147,13 @@ export function ComponentInput(props: ComponentInputProps) {
   function getComponentButton() {
     return !props.leftNavOpen ? (
       <EuiFlexItem grow={false}>
-        <EuiSmallButtonIcon
+        <EuiButtonIcon
+          style={{ marginTop: '4px', marginRight: '8px' }}
           data-testid="showLeftNavButton"
           aria-label="showLeftNavButton"
           iconType={'menuRight'}
+          size="xs"
+          display="base"
           onClick={() => {
             props.openLeftNav();
           }}
@@ -181,7 +184,7 @@ export function ComponentInput(props: ComponentInputProps) {
       }
     }
     return iconType !== undefined ? (
-      <EuiFlexItem grow={false} style={{ paddingTop: '6px' }}>
+      <EuiFlexItem grow={false} style={{ paddingTop: '8px' }}>
         <EuiIcon type={iconType} size="m" />
       </EuiFlexItem>
     ) : undefined;

--- a/public/pages/workflow_detail/component_input/ingest_inputs/source_data.tsx
+++ b/public/pages/workflow_detail/component_input/ingest_inputs/source_data.tsx
@@ -39,6 +39,8 @@ interface SourceDataProps {
   uiConfig: WorkflowConfig;
   setIngestDocs: (docs: string) => void;
   lastIngested: number | undefined;
+  isEditModalOpen: boolean;
+  setIsEditModalOpen: (isEditModalOpen: boolean) => void;
   ingestUpdateRequired: boolean;
   disabled: boolean;
 }
@@ -61,9 +63,6 @@ export function SourceData(props: SourceDataProps) {
     SOURCE_OPTIONS.MANUAL
   );
 
-  // edit modal state
-  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
-
   // bulk API popover state
   const [bulkPopoverOpen, setBulkPopoverOpen] = useState<boolean>(false);
 
@@ -76,7 +75,7 @@ export function SourceData(props: SourceDataProps) {
     // try to clear out any default values for the ML ingest processor, if applicable
     if (
       isVectorSearchUseCase(props.workflow?.ui_metadata?.type) &&
-      isEditModalOpen &&
+      props.isEditModalOpen &&
       selectedOption !== SOURCE_OPTIONS.EXISTING_INDEX
     ) {
       let sampleDoc = undefined as {} | undefined;
@@ -103,33 +102,16 @@ export function SourceData(props: SourceDataProps) {
 
   return (
     <>
-      {isEditModalOpen && (
+      {props.isEditModalOpen && (
         <SourceDataModal
           workflow={props.workflow}
           uiConfig={props.uiConfig}
           selectedOption={selectedOption}
           setSelectedOption={setSelectedOption}
-          setIsModalOpen={setIsEditModalOpen}
+          setIsModalOpen={props.setIsEditModalOpen}
         />
       )}
       <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup direction="row" justifyContent="flexEnd">
-            {docsPopulated && (
-              <EuiFlexItem grow={false}>
-                <EuiSmallButtonEmpty
-                  isDisabled={props.disabled}
-                  onClick={() => setIsEditModalOpen(true)}
-                  data-testid="editSourceDataButton"
-                  iconType="pencil"
-                  iconSide="left"
-                >
-                  Edit
-                </EuiSmallButtonEmpty>
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-        </EuiFlexItem>
         {props.lastIngested !== undefined && (
           <>
             <EuiFlexItem grow={false}>
@@ -222,7 +204,7 @@ export function SourceData(props: SourceDataProps) {
                   <EuiSmallButton
                     fill={true}
                     disabled={props.disabled}
-                    onClick={() => setIsEditModalOpen(true)}
+                    onClick={() => props.setIsEditModalOpen(true)}
                     data-testid="selectDataToImportButton"
                     iconType="plus"
                     iconSide="left"

--- a/public/pages/workflow_detail/component_input/ingest_inputs/source_data_modal.tsx
+++ b/public/pages/workflow_detail/component_input/ingest_inputs/source_data_modal.tsx
@@ -208,13 +208,15 @@ export function SourceDataModal(props: SourceDataProps) {
             maxWidth={false}
             onClose={() => onClose()}
             className="configuration-modal"
+            // overriding the default modal height for this one. Prioritize vertical space for easier viewing of imported documents
+            style={{ height: '80vh' }}
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle>
                 <p>{`Import sample data`}</p>
               </EuiModalHeaderTitle>
             </EuiModalHeader>
-            <EuiModalBody>
+            <EuiModalBody style={{ height: '70vh' }}>
               <>
                 <EuiText size="s" color="subdued">
                   To start configuring an ingest flow, import a sample of your
@@ -313,13 +315,13 @@ export function SourceDataModal(props: SourceDataProps) {
                       </EuiLink>
                     </EuiText>
                   }
-                  editorHeight="40vh"
+                  editorHeight="20vh"
                   readOnly={false}
                   validate={true}
                 />
               </>
             </EuiModalBody>
-            <EuiModalFooter>
+            <EuiModalFooter style={{ marginBottom: '-24px' }}>
               <EuiSmallButtonEmpty
                 onClick={() => onClose()}
                 color="primary"

--- a/public/pages/workflow_detail/component_input/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/component_input/input_fields/model_field.tsx
@@ -25,10 +25,10 @@ import {
   WorkflowFormValues,
   ModelFormValue,
   FETCH_ALL_QUERY_LARGE,
-  UPDATE_MODEL_DOCS_LINK,
   MODEL_CATEGORY,
   ModelItem,
   ML_REMOTE_MODEL_LINK,
+  ML_INTERFACE_LINK,
 } from '../../../../../common';
 import { AppState, searchModels, useAppDispatch } from '../../../../store';
 import { getDataSourceId } from '../../../../utils';
@@ -98,11 +98,15 @@ export function ModelField(props: ModelFieldProps) {
               size="s"
               title={
                 <EuiText size="s">
-                  This model has no interface set up yet.{' '}
-                  <EuiLink href={UPDATE_MODEL_DOCS_LINK} target="_blank">
-                    Learn more
+                  This model has no{' '}
+                  <EuiLink href={ML_INTERFACE_LINK} target="_blank">
+                    interface
                   </EuiLink>{' '}
-                  about updating a model. Refresh the list when you finish.
+                  set up yet. For a list of supported models with sufficient
+                  interfaces, see{' '}
+                  <EuiLink href={ML_REMOTE_MODEL_LINK} target="_blank">
+                    here
+                  </EuiLink>
                 </EuiText>
               }
               color="warning"

--- a/public/pages/workflow_detail/component_input/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/component_input/search_inputs/edit_query_modal.tsx
@@ -127,39 +127,30 @@ export function EditQueryModal(props: EditQueryModalProps) {
     setTempResultsError('');
   }, [queryParams]);
 
-  const SearchButton = (
-    <EuiSmallButton
-      fill={false}
-      isLoading={loading}
-      disabled={containsEmptyValues(queryParams)}
-      onClick={() => {
-        dispatch(
-          searchIndex({
-            apiBody: {
-              index: values?.search?.index?.name,
-              body: injectParameters(queryParams, tempRequest),
-              // Run the query independent of the pipeline inside this modal
-              searchPipeline: '_none',
-            },
-            dataSourceId,
-          })
-        )
-          .unwrap()
-          .then(async (resp: SearchResponse) => {
-            setQueryResponse(resp);
-            setTempResultsError('');
-          })
-          .catch((error: any) => {
-            setQueryResponse(undefined);
-            const errorMsg = `Error running query: ${error}`;
-            setTempResultsError(errorMsg);
-            console.error(errorMsg);
-          });
-      }}
-    >
-      Search
-    </EuiSmallButton>
-  );
+  function executeSearch() {
+    dispatch(
+      searchIndex({
+        apiBody: {
+          index: values?.search?.index?.name,
+          body: injectParameters(queryParams, tempRequest),
+          // Run the query independent of the pipeline inside this modal
+          searchPipeline: '_none',
+        },
+        dataSourceId,
+      })
+    )
+      .unwrap()
+      .then(async (resp: SearchResponse) => {
+        setQueryResponse(resp);
+        setTempResultsError('');
+      })
+      .catch((error: any) => {
+        setQueryResponse(undefined);
+        const errorMsg = `Error running query: ${error}`;
+        setTempResultsError(errorMsg);
+        console.error(errorMsg);
+      });
+  }
 
   return (
     <Formik
@@ -297,7 +288,13 @@ export function EditQueryModal(props: EditQueryModalProps) {
                           </EuiFlexItem>
                           {!isEmpty(queryResponse) && (
                             <EuiFlexItem grow={false}>
-                              {SearchButton}
+                              <EuiSmallButtonEmpty
+                                isLoading={loading}
+                                disabled={containsEmptyValues(queryParams)}
+                                onClick={() => executeSearch()}
+                              >
+                                <EuiText size="m">Search</EuiText>
+                              </EuiSmallButtonEmpty>
                             </EuiFlexItem>
                           )}
                         </EuiFlexGroup>
@@ -324,7 +321,14 @@ export function EditQueryModal(props: EditQueryModalProps) {
                                     Run a search to view results.
                                   </EuiText>
                                   <EuiSpacer size="m" />
-                                  {SearchButton}
+                                  <EuiSmallButton
+                                    fill={false}
+                                    isLoading={loading}
+                                    disabled={containsEmptyValues(queryParams)}
+                                    onClick={() => executeSearch()}
+                                  >
+                                    Search
+                                  </EuiSmallButton>
                                 </>
                               }
                             />

--- a/public/pages/workflow_detail/component_input/search_inputs/edit_query_modal.tsx
+++ b/public/pages/workflow_detail/component_input/search_inputs/edit_query_modal.tsx
@@ -127,6 +127,40 @@ export function EditQueryModal(props: EditQueryModalProps) {
     setTempResultsError('');
   }, [queryParams]);
 
+  const SearchButton = (
+    <EuiSmallButton
+      fill={false}
+      isLoading={loading}
+      disabled={containsEmptyValues(queryParams)}
+      onClick={() => {
+        dispatch(
+          searchIndex({
+            apiBody: {
+              index: values?.search?.index?.name,
+              body: injectParameters(queryParams, tempRequest),
+              // Run the query independent of the pipeline inside this modal
+              searchPipeline: '_none',
+            },
+            dataSourceId,
+          })
+        )
+          .unwrap()
+          .then(async (resp: SearchResponse) => {
+            setQueryResponse(resp);
+            setTempResultsError('');
+          })
+          .catch((error: any) => {
+            setQueryResponse(undefined);
+            const errorMsg = `Error running query: ${error}`;
+            setTempResultsError(errorMsg);
+            console.error(errorMsg);
+          });
+      }}
+    >
+      Search
+    </EuiSmallButton>
+  );
+
   return (
     <Formik
       enableReinitialize={false}
@@ -261,6 +295,11 @@ export function EditQueryModal(props: EditQueryModalProps) {
                           <EuiFlexItem grow={false}>
                             <EuiText size="m">Test query</EuiText>
                           </EuiFlexItem>
+                          {!isEmpty(queryResponse) && (
+                            <EuiFlexItem grow={false}>
+                              {SearchButton}
+                            </EuiFlexItem>
+                          )}
                         </EuiFlexGroup>
                       </EuiFlexItem>
                       {/**
@@ -285,40 +324,7 @@ export function EditQueryModal(props: EditQueryModalProps) {
                                     Run a search to view results.
                                   </EuiText>
                                   <EuiSpacer size="m" />
-                                  <EuiSmallButton
-                                    fill={false}
-                                    isLoading={loading}
-                                    disabled={containsEmptyValues(queryParams)}
-                                    onClick={() => {
-                                      dispatch(
-                                        searchIndex({
-                                          apiBody: {
-                                            index: values?.search?.index?.name,
-                                            body: injectParameters(
-                                              queryParams,
-                                              tempRequest
-                                            ),
-                                            // Run the query independent of the pipeline inside this modal
-                                            searchPipeline: '_none',
-                                          },
-                                          dataSourceId,
-                                        })
-                                      )
-                                        .unwrap()
-                                        .then(async (resp: SearchResponse) => {
-                                          setQueryResponse(resp);
-                                          setTempResultsError('');
-                                        })
-                                        .catch((error: any) => {
-                                          setQueryResponse(undefined);
-                                          const errorMsg = `Error running query: ${error}`;
-                                          setTempResultsError(errorMsg);
-                                          console.error(errorMsg);
-                                        });
-                                    }}
-                                  >
-                                    Search
-                                  </EuiSmallButton>
+                                  {SearchButton}
                                 </>
                               }
                             />

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -790,7 +790,11 @@ export function LeftNav(props: LeftNavProps) {
         grow={false}
         className="workspace-panel left-nav-static-width"
         borderRadius="l"
-        style={{ paddingBottom: '48px' }}
+        style={{
+          paddingBottom: '48px',
+          paddingRight: '0px',
+          paddingLeft: '12px',
+        }}
       >
         <EuiFlexItem grow={false}>
           <EuiFlexGroup direction="row" justifyContent="spaceBetween">
@@ -824,8 +828,8 @@ export function LeftNav(props: LeftNavProps) {
           <EuiFlexItem
             grow={false}
             style={{
-              overflowY: 'auto',
-              scrollbarGutter: 'auto',
+              overflowY: 'scroll',
+              scrollbarGutter: 'stable',
               scrollbarWidth: 'thin',
               overflowX: 'hidden',
             }}

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -824,8 +824,8 @@ export function LeftNav(props: LeftNavProps) {
           <EuiFlexItem
             grow={false}
             style={{
-              overflowY: 'scroll',
-              scrollbarGutter: 'stable',
+              overflowY: 'auto',
+              scrollbarGutter: 'auto',
               scrollbarWidth: 'thin',
               overflowX: 'hidden',
             }}

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { isEmpty, isEqual } from 'lodash';
 import { getIn, useFormikContext } from 'formik';
 import {
+  EuiButtonIcon,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -804,10 +805,13 @@ export function LeftNav(props: LeftNavProps) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiSmallButtonIcon
+              <EuiButtonIcon
+                style={{ marginRight: '12px', marginTop: '8px' }}
                 data-testid="hideLeftNavButton"
                 aria-label="hideLeftNavButton"
                 iconType={'menuLeft'}
+                size="xs"
+                display="base"
                 onClick={() => {
                   props.onClose();
                 }}
@@ -886,7 +890,7 @@ export function LeftNav(props: LeftNavProps) {
               )}
             </>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem grow={false} style={{ marginRight: '12px' }}>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
                 <EuiHorizontalRule margin="m" />

--- a/public/pages/workflow_detail/left_nav/nav_content/ingest_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/ingest_content.tsx
@@ -222,7 +222,7 @@ export function IngestContent(props: IngestContentProps) {
           )}
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row" gutterSize="xs">
-              <EuiFlexItem grow={false} style={{ marginTop: '10px' }}>
+              <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
                 <EuiPopover
                   button={
                     <EuiButtonIcon
@@ -287,7 +287,7 @@ export function IngestContent(props: IngestContentProps) {
                 </EuiPopover>
               </EuiFlexItem>
               {props.ingestProvisioned && (
-                <EuiFlexItem grow={false} style={{ marginTop: '10px' }}>
+                <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
                   <EuiButtonIcon
                     iconType="inspect"
                     size="s"
@@ -301,7 +301,7 @@ export function IngestContent(props: IngestContentProps) {
               )}
               <EuiFlexItem
                 grow={false}
-                style={{ marginLeft: '8px', marginTop: '16px' }}
+                style={{ marginLeft: '8px', marginTop: '12px' }}
               >
                 <EuiHealth
                   textSize="s"

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -550,7 +550,7 @@ export function ProcessorList(props: ProcessorListProps) {
                 paddingTop: '8px',
                 marginLeft: '5px',
                 marginBottom: '8px',
-                width: '462px',
+                width: '450px',
                 height: isEmpty(modelName) ? '55px' : '80px',
                 border:
                   props.selectedComponentId === processorPath
@@ -582,7 +582,7 @@ export function ProcessorList(props: ProcessorListProps) {
                   gutterSize="s"
                   justifyContent="spaceAround"
                 >
-                  <EuiFlexItem style={{ width: '332px' }} grow={false}>
+                  <EuiFlexItem style={{ width: '325px' }} grow={false}>
                     <EuiFlexGroup direction="row" gutterSize="m">
                       <EuiFlexItem grow={false}>
                         <EuiText color={errorFound ? 'danger' : undefined}>

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -550,7 +550,7 @@ export function ProcessorList(props: ProcessorListProps) {
                 paddingTop: '8px',
                 marginLeft: '5px',
                 marginBottom: '8px',
-                width: '452px',
+                width: '462px',
                 height: isEmpty(modelName) ? '55px' : '80px',
                 border:
                   props.selectedComponentId === processorPath
@@ -582,7 +582,7 @@ export function ProcessorList(props: ProcessorListProps) {
                   gutterSize="s"
                   justifyContent="spaceAround"
                 >
-                  <EuiFlexItem style={{ width: '325px' }} grow={false}>
+                  <EuiFlexItem style={{ width: '332px' }} grow={false}>
                     <EuiFlexGroup direction="row" gutterSize="m">
                       <EuiFlexItem grow={false}>
                         <EuiText color={errorFound ? 'danger' : undefined}>

--- a/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
@@ -58,7 +58,7 @@ export function SearchContent(props: SearchContentProps) {
         </EuiText>
       }
       extraAction={
-        <>
+        <div style={{ marginBottom: '8px' }}>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row" gutterSize="xs">
               {props.ingestProvisioned && (
@@ -111,7 +111,7 @@ export function SearchContent(props: SearchContentProps) {
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-        </>
+        </div>
       }
     >
       <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
@@ -62,7 +62,7 @@ export function SearchContent(props: SearchContentProps) {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row" gutterSize="xs">
               {props.ingestProvisioned && (
-                <EuiFlexItem grow={false} style={{ marginTop: '10px' }}>
+                <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
                   <EuiButtonIcon
                     iconType="play"
                     size="s"
@@ -72,7 +72,7 @@ export function SearchContent(props: SearchContentProps) {
                 </EuiFlexItem>
               )}
               {props.searchProvisioned && (
-                <EuiFlexItem grow={false} style={{ marginTop: '10px' }}>
+                <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
                   <EuiButtonIcon
                     iconType="inspect"
                     size="s"
@@ -86,7 +86,7 @@ export function SearchContent(props: SearchContentProps) {
               )}
               <EuiFlexItem
                 grow={false}
-                style={{ marginLeft: '8px', marginTop: '16px' }}
+                style={{ marginLeft: '8px', marginTop: '12px' }}
               >
                 <EuiHealth
                   textSize="s"

--- a/public/pages/workflow_detail/tools/query/query.tsx
+++ b/public/pages/workflow_detail/tools/query/query.tsx
@@ -70,7 +70,7 @@ const SEARCH_OPTIONS = [
     label: 'Only query transformations',
   },
   {
-    label: 'All transformations',
+    label: 'Query and result transformations',
   },
 ];
 
@@ -188,7 +188,12 @@ export function Query(props: QueryProps) {
                       options={
                         props.hasSearchPipeline
                           ? SEARCH_OPTIONS
-                          : [SEARCH_OPTIONS[0]]
+                          : SEARCH_OPTIONS.map((option, idx) => {
+                              return {
+                                ...option,
+                                disabled: idx === 0 ? false : true,
+                              };
+                            })
                       }
                       selectedOptions={[selectedSearchOption]}
                       onChange={(options) => {

--- a/public/pages/workflows/get_started_accordion.tsx
+++ b/public/pages/workflows/get_started_accordion.tsx
@@ -21,11 +21,11 @@ interface GetStartedAccordionProps {
 }
 
 export function GetStartedAccordion(props: GetStartedAccordionProps) {
-  const initialIsOpen = props.initialIsOpen ?? false;
   return (
     <EuiAccordion
+      key={props.initialIsOpen} // re-mount if initialIsOpen changes, otherwise it does not update
       style={{ marginBottom: '-16px' }}
-      initialIsOpen={initialIsOpen}
+      initialIsOpen={props.initialIsOpen}
       id={`accordionGetStarted`}
       buttonContent={
         <EuiFlexGroup direction="row">

--- a/public/pages/workflows/get_started_accordion.tsx
+++ b/public/pages/workflows/get_started_accordion.tsx
@@ -16,13 +16,16 @@ import {
 } from '@elastic/eui';
 import { CREATE_WORKFLOW_LINK, ML_REMOTE_MODEL_LINK } from '../../../common';
 
-interface GetStartedAccordionProps {}
+interface GetStartedAccordionProps {
+  initialIsOpen: boolean;
+}
 
 export function GetStartedAccordion(props: GetStartedAccordionProps) {
+  const initialIsOpen = props.initialIsOpen ?? false;
   return (
     <EuiAccordion
       style={{ marginBottom: '-16px' }}
-      initialIsOpen={false}
+      initialIsOpen={initialIsOpen}
       id={`accordionGetStarted`}
       buttonContent={
         <EuiFlexGroup direction="row">

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -328,7 +328,7 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                         <ModelField
                           modelCategory={MODEL_CATEGORY.EMBEDDING}
                           fieldPath="embeddingModel"
-                          showMissingInterfaceCallout={false}
+                          showMissingInterfaceCallout={true}
                           label="Embedding model"
                           helpText="The model to generate embeddings."
                           fullWidth={true}

--- a/public/pages/workflows/workflows.tsx
+++ b/public/pages/workflows/workflows.tsx
@@ -99,6 +99,7 @@ export function Workflows(props: WorkflowsProps) {
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
+  const noWorkflows = Object.keys(workflows || {}).length === 0 && !loading;
 
   const {
     chrome: { setBreadcrumbs },
@@ -241,7 +242,7 @@ export function Workflows(props: WorkflowsProps) {
         ]}
         setMountPoint={setAppDescriptionControls}
       />
-      <GetStartedAccordion />
+      <GetStartedAccordion initialIsOpen={noWorkflows} />
       <EuiSpacer size="s" />
     </>
   ) : (
@@ -255,7 +256,7 @@ export function Workflows(props: WorkflowsProps) {
       </EuiFlexGroup>
       <EuiText color="subdued">{DESCRIPTION}</EuiText>
       <EuiSpacer size="l" />
-      <GetStartedAccordion />
+      <GetStartedAccordion initialIsOpen={noWorkflows} />
       <EuiSpacer size="s" />
     </EuiFlexGroup>
   );
@@ -398,20 +399,18 @@ export function Workflows(props: WorkflowsProps) {
                     <NewWorkflow />
                   </>
                 )}
-                {selectedTabId === WORKFLOWS_TAB.MANAGE &&
-                  Object.keys(workflows || {}).length === 0 &&
-                  !loading && (
-                    <EmptyListMessage
-                      onClickNewWorkflow={() => {
-                        setSelectedTabId(WORKFLOWS_TAB.CREATE);
-                        replaceActiveTab(
-                          WORKFLOWS_TAB.CREATE,
-                          props,
-                          dataSourceId
-                        );
-                      }}
-                    />
-                  )}
+                {selectedTabId === WORKFLOWS_TAB.MANAGE && noWorkflows && (
+                  <EmptyListMessage
+                    onClickNewWorkflow={() => {
+                      setSelectedTabId(WORKFLOWS_TAB.CREATE);
+                      replaceActiveTab(
+                        WORKFLOWS_TAB.CREATE,
+                        props,
+                        dataSourceId
+                      );
+                    }}
+                  />
+                )}
               </EuiPageContent>
             </>
           )}


### PR DESCRIPTION
### Description

More misc improvements
- tune missing interface callout and show in the quick-configure modal
- move 'Edit' button to top-level in component_input panel
- source data modal improvements: validate on keystroke, and improve spacing. Together, these improve the error handling and visibility if users manually enter JSONLines
- persist a search button after running successful search in Edit Query panel
- make certain transformations visible in search panel, even if disabled (no search pipeline)
- expand the 'Get started' accordion when the workflow list is empty
- fix bug of overflow showing when collapsing search accordion
- various minor spacing updates
- make expand/collapse btn be `display=base` to be more visible

Screenshots:

![callout (modal)](https://github.com/user-attachments/assets/22f9e0df-8662-4579-9b01-ae1eacedfe91)

![callout (processor)](https://github.com/user-attachments/assets/0375ea19-b417-4fdc-a20c-4e8123cc9d6a)

![new edit placement](https://github.com/user-attachments/assets/44901fe0-1dca-4eda-8836-4900c9a9ebf6)

![new search button](https://github.com/user-attachments/assets/da847945-66fa-4d96-ba10-31abe71ef8cc)

![limited transformations](https://github.com/user-attachments/assets/7f204827-cb07-4cb2-9ddf-e489c1aec296)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
