### PR TITLE
Misc improvements III

### DIFF
--- a/public/general_components/results/results.tsx
+++ b/public/general_components/results/results.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiSmallButtonGroup,
 } from '@elastic/eui';
-import { SearchResponse } from '../../../common';
+import { SearchResponse, SimulateIngestPipelineDoc } from '../../../common';
 import { ResultsTable } from './results_table';
 import { ResultsJSON } from './results_json';
 import { MLOutputs } from './ml_outputs';
@@ -31,6 +31,12 @@ enum VIEW {
  * or the raw JSON response.
  */
 export function Results(props: ResultsProps) {
+  // hits state
+  const [hits, setHits] = useState<SimulateIngestPipelineDoc[]>([]);
+  useEffect(() => {
+    setHits(props.response?.hits?.hits || []);
+  }, [props.response]);
+
   // selected view state. auto-navigate to ML outputs if there is values found
   // in "ext.ml_inference" in the search response.
   const [selectedView, setSelectedView] = useState<VIEW>(VIEW.HITS_TABLE);
@@ -76,9 +82,7 @@ export function Results(props: ResultsProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={true}>
           <>
-            {selectedView === VIEW.HITS_TABLE && (
-              <ResultsTable hits={props.response?.hits?.hits || []} />
-            )}
+            {selectedView === VIEW.HITS_TABLE && <ResultsTable hits={hits} />}
             {selectedView === VIEW.ML_OUTPUTS && (
               <MLOutputs
                 mlOutputs={getMLResponseFromSearchResponse(props.response)}

--- a/public/pages/workflow_detail/component_input/component_input.tsx
+++ b/public/pages/workflow_detail/component_input/component_input.tsx
@@ -183,7 +183,10 @@ export function ComponentInput(props: ComponentInputProps) {
         break;
       }
     }
-    if (isProcessorComponent(props.selectedComponentId)) {
+    if (
+      isProcessorComponent(props.selectedComponentId) &&
+      processor !== undefined
+    ) {
       iconType = 'compute';
     }
     return iconType !== undefined ? (

--- a/public/pages/workflow_detail/component_input/component_input.tsx
+++ b/public/pages/workflow_detail/component_input/component_input.tsx
@@ -183,8 +183,11 @@ export function ComponentInput(props: ComponentInputProps) {
         break;
       }
     }
+    if (isProcessorComponent(props.selectedComponentId)) {
+      iconType = 'compute';
+    }
     return iconType !== undefined ? (
-      <EuiFlexItem grow={false} style={{ paddingTop: '8px' }}>
+      <EuiFlexItem grow={false} style={{ paddingTop: '6px' }}>
         <EuiIcon type={iconType} size="m" />
       </EuiFlexItem>
     ) : undefined;

--- a/public/pages/workflow_detail/component_input/input_fields/model_field.tsx
+++ b/public/pages/workflow_detail/component_input/input_fields/model_field.tsx
@@ -31,7 +31,11 @@ import {
   ML_INTERFACE_LINK,
 } from '../../../../../common';
 import { AppState, searchModels, useAppDispatch } from '../../../../store';
-import { getDataSourceId } from '../../../../utils';
+import {
+  getDataSourceId,
+  getIsPreV219,
+  useDataSourceVersion,
+} from '../../../../utils';
 import { ModelInfoPopover } from './models_info_popover';
 
 interface ModelFieldProps {
@@ -54,6 +58,9 @@ interface ModelFieldProps {
 export function ModelField(props: ModelFieldProps) {
   const dispatch = useAppDispatch();
   const dataSourceId = getDataSourceId();
+  const dataSourceVersion = useDataSourceVersion(dataSourceId);
+  const isPreV219 = getIsPreV219(dataSourceVersion);
+
   // Initial store is fetched when loading base <DetectorDetail /> page. We don't
   // re-fetch here as it could overload client-side if user clicks back and forth /
   // keeps re-rendering this component (and subsequently re-fetching data) as they're building flows
@@ -92,7 +99,8 @@ export function ModelField(props: ModelFieldProps) {
     <>
       {showMissingInterfaceCallout &&
         !hasModelInterface &&
-        !isEmpty(getIn(values, props.fieldPath)?.id) && (
+        !isEmpty(getIn(values, props.fieldPath)?.id) &&
+        !isPreV219 && (
           <>
             <EuiCallOut
               size="s"

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -16,7 +16,6 @@ import {
   EuiPanel,
   EuiSmallButton,
   EuiSmallButtonIcon,
-  EuiSpacer,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -793,8 +792,7 @@ export function LeftNav(props: LeftNavProps) {
         borderRadius="l"
         style={{
           paddingBottom: '48px',
-          paddingRight: '0px',
-          paddingLeft: '12px',
+          marginRight: '0px',
         }}
       >
         <EuiFlexItem grow={false}>
@@ -806,7 +804,7 @@ export function LeftNav(props: LeftNavProps) {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButtonIcon
-                style={{ marginRight: '12px', marginTop: '8px' }}
+                style={{ marginTop: '8px' }}
                 data-testid="hideLeftNavButton"
                 aria-label="hideLeftNavButton"
                 iconType={'menuLeft'}

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -336,8 +336,7 @@ export function LeftNav(props: LeftNavProps) {
         )
       : false;
   const searchUpdateRequired =
-    ((searchProvisioned && searchTemplatesDifferent) || searchRequestUpdated) &&
-    searchProvisioned;
+    (searchTemplatesDifferent || searchRequestUpdated) && searchProvisioned;
   const onSearchAndUpdateRequired = onSearch && searchUpdateRequired;
 
   // Only block ingest updates if search has been provisioned and ALSO requires update.

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -896,30 +896,24 @@ export function LeftNav(props: LeftNavProps) {
                 <EuiHorizontalRule margin="m" />
               </EuiFlexItem>
               {onIngestAndSearchUpdateRequired && (
-                <>
-                  <EuiFlexItem grow={false} style={{ marginTop: '-8px' }}>
-                    <EuiCallOut
-                      color="warning"
-                      iconType={'help'}
-                      title="Create/update your search flow before updating an ingest flow"
-                    />
-                  </EuiFlexItem>
-                  <EuiSpacer size="s" />
-                </>
+                <EuiFlexItem grow={false} style={{ marginTop: '-8px' }}>
+                  <EuiCallOut
+                    color="warning"
+                    iconType={'help'}
+                    title="Create/update your search flow before updating an ingest flow"
+                  />
+                </EuiFlexItem>
               )}
               {onSearchAndIngestUpdateRequired && (
-                <>
-                  <EuiFlexItem grow={false} style={{ marginTop: '-8px' }}>
-                    <EuiCallOut
-                      color="warning"
-                      iconType={'help'}
-                      title={
-                        'Create/update your ingest flow before updating a search flow.'
-                      }
-                    />
-                  </EuiFlexItem>
-                  <EuiSpacer size="s" />
-                </>
+                <EuiFlexItem grow={false} style={{ marginTop: '-8px' }}>
+                  <EuiCallOut
+                    color="warning"
+                    iconType={'help'}
+                    title={
+                      'Create/update your ingest flow before updating a search flow.'
+                    }
+                  />
+                </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -336,7 +336,8 @@ export function LeftNav(props: LeftNavProps) {
         )
       : false;
   const searchUpdateRequired =
-    (searchProvisioned && searchTemplatesDifferent) || searchRequestUpdated;
+    ((searchProvisioned && searchTemplatesDifferent) || searchRequestUpdated) &&
+    searchProvisioned;
   const onSearchAndUpdateRequired = onSearch && searchUpdateRequired;
 
   // Only block ingest updates if search has been provisioned and ALSO requires update.
@@ -456,10 +457,16 @@ export function LeftNav(props: LeftNavProps) {
   // Details on the reprovision API is here: https://github.com/opensearch-project/flow-framework/pull/804
   async function updateWorkflowAndResources(
     updatedWorkflow: Workflow,
-    reprovision: boolean
+    reprovision: boolean,
+    includeIngest: boolean
   ): Promise<boolean> {
     let success = false;
-    if (!ingestTemplatesDifferent && !searchTemplatesDifferent) {
+    // If we are only doing a UI change, don't do any deprovision/reprovision
+    if (
+      !ingestTemplatesDifferent &&
+      !searchTemplatesDifferent &&
+      !includeIngest
+    ) {
       success = await updateWorkflowUiConfig();
     } else if (reprovision) {
       await dispatch(
@@ -649,7 +656,8 @@ export function LeftNav(props: LeftNavProps) {
           } as Workflow;
           success = await updateWorkflowAndResources(
             updatedWorkflow,
-            reprovision
+            reprovision,
+            includeIngest
           );
         }
       })
@@ -888,7 +896,7 @@ export function LeftNav(props: LeftNavProps) {
               )}
             </>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ marginRight: '12px' }}>
+          <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
                 <EuiHorizontalRule margin="m" />

--- a/public/pages/workflow_detail/left_nav/left_nav.tsx
+++ b/public/pages/workflow_detail/left_nav/left_nav.tsx
@@ -935,6 +935,7 @@ export function LeftNav(props: LeftNavProps) {
                     !searchUpdateRequired && (
                       <EuiFlexItem grow={true}>
                         <EuiSmallButton
+                          data-test-subj="updateAndRunIngestButton"
                           fill={true}
                           isLoading={isProvisioningIngest}
                           onClick={() => validateAndRunIngestion()}
@@ -973,6 +974,7 @@ export function LeftNav(props: LeftNavProps) {
                     !(ingestEnabled && !ingestProvisioned) && (
                       <EuiFlexItem grow={true}>
                         <EuiSmallButton
+                          data-test-subj="updateSearchButton"
                           fill={true}
                           disabled={isProvisioningSearch}
                           isLoading={isProvisioningSearch}

--- a/public/pages/workflow_detail/left_nav/nav_content/ingest_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/ingest_content.tsx
@@ -22,6 +22,7 @@ import {
   EuiSmallButtonEmpty,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   CachedFormikState,
@@ -223,80 +224,89 @@ export function IngestContent(props: IngestContentProps) {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row" gutterSize="xs">
               <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
-                <EuiPopover
-                  button={
-                    <EuiButtonIcon
-                      data-testid="toggleIngestButtonSwitch"
-                      iconType="controlsHorizontal"
-                      size="s"
-                      isDisabled={props.readonly}
-                      aria-label="disableEnableIngest"
-                      onClick={() => {
-                        setPopoverOpen(true);
-                      }}
-                    />
+                <EuiToolTip
+                  position="top"
+                  content={
+                    ingestEnabled ? 'Delete ingest flow' : 'Enable ingest flow'
                   }
-                  isOpen={popoverOpen}
-                  onClick={() => setPopoverOpen(!popoverOpen)}
-                  closePopover={() => setPopoverOpen(false)}
                 >
-                  <EuiButtonEmpty
-                    data-testid="toggleIngestButton"
-                    onClick={() => {
-                      if (ingestEnabled && props.ingestProvisioned) {
-                        setDeleteModalOpen(true);
-                      } else {
-                        // clear out or re-configure the search index, if disabling or enabling ingest, respectively
-                        if (ingestEnabled) {
-                          setFieldValue('search.index.name', '');
-                        } else {
-                          setFieldValue(
-                            'search.index.name',
-                            getIn(values, 'ingest.index.name')
-                          );
-                          props.setSelectedComponentId(
-                            COMPONENT_ID.SOURCE_DATA
-                          );
-                        }
-                        setFieldValue('ingest.enabled', !ingestEnabled);
-                      }
-                      setPopoverOpen(false);
-                    }}
-                    iconSide={
-                      ingestEnabled && props.ingestProvisioned
-                        ? 'left'
-                        : undefined
+                  <EuiPopover
+                    button={
+                      <EuiButtonIcon
+                        data-testid="toggleIngestButtonSwitch"
+                        iconType="controlsHorizontal"
+                        size="s"
+                        isDisabled={props.readonly}
+                        aria-label="disableEnableIngest"
+                        onClick={() => {
+                          setPopoverOpen(true);
+                        }}
+                      />
                     }
-                    iconType={
-                      ingestEnabled && props.ingestProvisioned
-                        ? 'trash'
-                        : undefined
-                    }
-                    color={
-                      ingestEnabled && props.ingestProvisioned
-                        ? 'danger'
-                        : undefined
-                    }
+                    isOpen={popoverOpen}
+                    onClick={() => setPopoverOpen(!popoverOpen)}
+                    closePopover={() => setPopoverOpen(false)}
                   >
-                    {ingestEnabled && props.ingestProvisioned
-                      ? 'Delete ingest flow'
-                      : ingestEnabled
-                      ? 'Disable ingest flow'
-                      : 'Enable ingest flow'}
-                  </EuiButtonEmpty>
-                </EuiPopover>
+                    <EuiButtonEmpty
+                      data-testid="toggleIngestButton"
+                      onClick={() => {
+                        if (ingestEnabled && props.ingestProvisioned) {
+                          setDeleteModalOpen(true);
+                        } else {
+                          // clear out or re-configure the search index, if disabling or enabling ingest, respectively
+                          if (ingestEnabled) {
+                            setFieldValue('search.index.name', '');
+                          } else {
+                            setFieldValue(
+                              'search.index.name',
+                              getIn(values, 'ingest.index.name')
+                            );
+                            props.setSelectedComponentId(
+                              COMPONENT_ID.SOURCE_DATA
+                            );
+                          }
+                          setFieldValue('ingest.enabled', !ingestEnabled);
+                        }
+                        setPopoverOpen(false);
+                      }}
+                      iconSide={
+                        ingestEnabled && props.ingestProvisioned
+                          ? 'left'
+                          : undefined
+                      }
+                      iconType={
+                        ingestEnabled && props.ingestProvisioned
+                          ? 'trash'
+                          : undefined
+                      }
+                      color={
+                        ingestEnabled && props.ingestProvisioned
+                          ? 'danger'
+                          : undefined
+                      }
+                    >
+                      {ingestEnabled && props.ingestProvisioned
+                        ? 'Delete ingest flow'
+                        : ingestEnabled
+                        ? 'Disable ingest flow'
+                        : 'Enable ingest flow'}
+                    </EuiButtonEmpty>
+                  </EuiPopover>
+                </EuiToolTip>
               </EuiFlexItem>
               {props.ingestProvisioned && (
                 <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
-                  <EuiButtonIcon
-                    iconType="inspect"
-                    size="s"
-                    aria-label="inspect"
-                    onClick={() => {
-                      props.setResourcesFlyoutContext(CONFIG_STEP.INGEST);
-                      props.setResourcesFlyoutOpen(true);
-                    }}
-                  />
+                  <EuiToolTip position="top" content="View ingest resources">
+                    <EuiButtonIcon
+                      iconType="inspect"
+                      size="s"
+                      aria-label="inspect"
+                      onClick={() => {
+                        props.setResourcesFlyoutContext(CONFIG_STEP.INGEST);
+                        props.setResourcesFlyoutOpen(true);
+                      }}
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               )}
               <EuiFlexItem

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/nav_component.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/nav_component.tsx
@@ -23,6 +23,7 @@ interface NavComponentProps {
   isDisabled?: boolean;
   isSelected?: boolean;
   isError?: boolean;
+  dataTestId?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ interface NavComponentProps {
 export function NavComponent(props: NavComponentProps) {
   return (
     <EuiCard
+      data-testid={props.dataTestId || 'navComponent'}
       layout="horizontal"
       icon={
         props.icon ? (

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -584,6 +584,12 @@ export function ProcessorList(props: ProcessorListProps) {
                 >
                   <EuiFlexItem style={{ width: '325px' }} grow={false}>
                     <EuiFlexGroup direction="row" gutterSize="m">
+                      <EuiFlexItem
+                        grow={false}
+                        style={{ marginTop: '13px', marginRight: '0px' }}
+                      >
+                        <EuiIcon type="compute" />
+                      </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiText color={errorFound ? 'danger' : undefined}>
                           {processor.name}

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -588,7 +588,10 @@ export function ProcessorList(props: ProcessorListProps) {
                         grow={false}
                         style={{ marginTop: '13px', marginRight: '0px' }}
                       >
-                        <EuiIcon type="compute" />
+                        <EuiIcon
+                          type="compute"
+                          color={errorFound ? 'danger' : undefined}
+                        />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiText color={errorFound ? 'danger' : undefined}>

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -551,7 +551,7 @@ export function ProcessorList(props: ProcessorListProps) {
                 marginLeft: '5px',
                 marginBottom: '8px',
                 width: '460px',
-                height: isEmpty(modelName) ? '55px' : '75px',
+                height: isEmpty(modelName) ? '50px' : '75px',
                 border:
                   props.selectedComponentId === processorPath
                     ? LEFT_NAV_SELECTED_STYLE

--- a/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/nav_components/processor_list.tsx
@@ -550,8 +550,8 @@ export function ProcessorList(props: ProcessorListProps) {
                 paddingTop: '8px',
                 marginLeft: '5px',
                 marginBottom: '8px',
-                width: '450px',
-                height: isEmpty(modelName) ? '55px' : '80px',
+                width: '460px',
+                height: isEmpty(modelName) ? '55px' : '75px',
                 border:
                   props.selectedComponentId === processorPath
                     ? LEFT_NAV_SELECTED_STYLE

--- a/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
@@ -14,6 +14,7 @@ import {
   EuiHealth,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   CachedFormikState,
@@ -63,25 +64,29 @@ export function SearchContent(props: SearchContentProps) {
             <EuiFlexGroup direction="row" gutterSize="xs">
               {props.ingestProvisioned && (
                 <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
-                  <EuiButtonIcon
-                    iconType="play"
-                    size="s"
-                    aria-label="test"
-                    onClick={() => props.displaySearchPanel()}
-                  />
+                  <EuiToolTip position="top" content="Test with Inspect tool">
+                    <EuiButtonIcon
+                      iconType="play"
+                      size="s"
+                      aria-label="test"
+                      onClick={() => props.displaySearchPanel()}
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               )}
               {props.searchProvisioned && (
                 <EuiFlexItem grow={false} style={{ marginTop: '6px' }}>
-                  <EuiButtonIcon
-                    iconType="inspect"
-                    size="s"
-                    aria-label="inspect"
-                    onClick={() => {
-                      props.setResourcesFlyoutContext(CONFIG_STEP.SEARCH);
-                      props.setResourcesFlyoutOpen(true);
-                    }}
-                  />
+                  <EuiToolTip position="top" content="View search resources">
+                    <EuiButtonIcon
+                      iconType="inspect"
+                      size="s"
+                      aria-label="inspect"
+                      onClick={() => {
+                        props.setResourcesFlyoutContext(CONFIG_STEP.SEARCH);
+                        props.setResourcesFlyoutOpen(true);
+                      }}
+                    />
+                  </EuiToolTip>
                 </EuiFlexItem>
               )}
               <EuiFlexItem

--- a/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
@@ -118,6 +118,7 @@ export function SearchContent(props: SearchContentProps) {
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem grow={false}>
           <NavComponent
+            dataTestId="searchPipelineButton" // for historical reasons, the naming of this component's test id doesn't exactly match its purpose
             title="Sample query"
             icon="editorCodeBlock"
             onClick={() => {

--- a/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
+++ b/public/pages/workflow_detail/left_nav/nav_content/search_content.tsx
@@ -148,15 +148,19 @@ export function SearchContent(props: SearchContentProps) {
           />
         </EuiFlexItem>
         <DownArrow />
-        <EuiFlexItem grow={false}>
-          <NavComponent
+        <EuiFlexItem grow={false} style={{ alignItems: 'center' }}>
+          <EuiText>Run query</EuiText>
+          {/**
+           * TODO: add back "Run query" panel once the content has been finalized
+           */}
+          {/* <NavComponent
             title="Run query"
             icon="list"
             onClick={() => {
               props.setSelectedComponentId(COMPONENT_ID.RUN_QUERY);
             }}
             isSelected={props.selectedComponentId === COMPONENT_ID.RUN_QUERY}
-          />
+          /> */}
         </EuiFlexItem>
         <DownArrow />
         <EuiFlexItem grow={false}>
@@ -172,7 +176,12 @@ export function SearchContent(props: SearchContentProps) {
           />
         </EuiFlexItem>
         <DownArrow />
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem grow={false} style={{ alignItems: 'center' }}>
+          <EuiText>Search results</EuiText>
+          {/**
+           * TODO: add back "Search results" panel once the content has been finalized
+           */}
+          {/* 
           <NavComponent
             title="Search results"
             icon="list"
@@ -182,7 +191,7 @@ export function SearchContent(props: SearchContentProps) {
             isSelected={
               props.selectedComponentId === COMPONENT_ID.SEARCH_RESULTS
             }
-          />
+          /> */}
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiAccordion>

--- a/public/pages/workflows/new_workflow/quick_configure_modal.tsx
+++ b/public/pages/workflows/new_workflow/quick_configure_modal.tsx
@@ -297,7 +297,12 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                     <ModelField
                       modelCategory={MODEL_CATEGORY.LLM}
                       fieldPath="llm"
-                      showMissingInterfaceCallout={false}
+                      showMissingInterfaceCallout={true}
+                      hasModelInterface={
+                        !isEmpty(
+                          models[getIn(formikProps.values, 'llm.id')]?.interface
+                        )
+                      }
                       label="Large language model"
                       helpText="The large language model to generate user-friendly responses."
                       fullWidth={true}
@@ -329,6 +334,13 @@ export function QuickConfigureModal(props: QuickConfigureModalProps) {
                           modelCategory={MODEL_CATEGORY.EMBEDDING}
                           fieldPath="embeddingModel"
                           showMissingInterfaceCallout={true}
+                          hasModelInterface={
+                            !isEmpty(
+                              models[
+                                getIn(formikProps.values, 'embeddingModel.id')
+                              ]?.interface
+                            )
+                          }
                           label="Embedding model"
                           helpText="The model to generate embeddings."
                           fullWidth={true}


### PR DESCRIPTION
### Description

Continuation of #735.

- add default icons for processors - all being the same `compute` icon type
- fixes logic of "missing interface" callout to only render if datasource >= 2.19, and fixes an issue of it unnecessarily showing for certain model types in the quick configure modal
- updates the "Run query" and "Search results" panels to be static, unclickable text to prevent confusion on the content. Later on, when there is a standard pattern with contextual info for all component types, can add back.
- add/update some test IDs to be compatible with existing integ tests
- Add informational tooltips for leftnav actions
- Fixes bug of certain scenarios causing hits table not to refresh correctly
- Fix index creation failed on re-enabling ingest
- Make processor icon error color if applicable

Screenshot - shows processor icon, & updated "Run query" / "Search results" to be static text
![general](https://github.com/user-attachments/assets/303b0cdd-45e5-4e64-bb32-9bbe192a6150)

Screenshot - tooltip to action btns:
![tooltip](https://github.com/user-attachments/assets/bd030bf7-8480-485f-94ff-8363301323e0)


Integ tests:
```
  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/dashboards-flow-framework/c      02:41        6        6        -        -        - │
  │    reate_workflow_spec.js                                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        02:41        6        6        -        -        -  
```

Unit tests:
```
Test Suites: 6 passed, 6 total
Tests:       30 passed, 30 total
Snapshots:   0 total
Time:        14.21 s, estimated 48 s
Ran all test suites.
✨  Done in 15.56s.
```

Screenshots:

![compute-icon](https://github.com/user-attachments/assets/856b1916-4a88-4ece-90e9-abbbfd8ed4bb)


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
