### PR TITLE
Improve yaml parsing on import

### DIFF
--- a/public/utils/utils.ts
+++ b/public/utils/utils.ts
@@ -131,7 +131,7 @@ export function getObjFromJsonOrYamlString(
   } catch (e) {}
   try {
     // @ts-ignore
-    const yamlObj = yaml.load(fileContents) as object;
+    const yamlObj = yaml.safeLoad(fileContents) as object;
     return yamlObj;
   } catch (e) {}
   return undefined;


### PR DESCRIPTION
### Description

Change from `load()` to `safeLoad()` when parsing `.yaml` files on workflow import. Note this functionality is the default behavior on the updated `js-yaml` dependency in OpenSearch Dashboards 3.x line, so no change is needed there.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
