### PR TITLE
Improve empty agent state

### DIFF
--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
@@ -26,6 +26,7 @@ import {
   EuiText,
   EuiLink,
   EuiSuperSelect,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import {
   Agent,
@@ -149,6 +150,7 @@ export function AgentConfiguration(props: AgentConfigurationProps) {
       }))
     );
   }, [agents]);
+  const noAgentsFound = isEmpty(agentOptions) && !loading;
 
   const handleModeSwitch = (queryMode: string) => {
     setConfigModeSelected(queryMode as CONFIG_MODE);
@@ -235,27 +237,29 @@ export function AgentConfiguration(props: AgentConfigurationProps) {
                     </EuiLink>
                   </EuiText>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButtonGroup
-                    buttonSize="compressed"
-                    legend="Config Mode"
-                    options={[
-                      {
-                        id: CONFIG_MODE.SIMPLE,
-                        label: 'Form',
-                      },
-                      {
-                        id: CONFIG_MODE.ADVANCED,
-                        label: 'JSON',
-                      },
-                    ]}
-                    idSelected={configModeSelected}
-                    onChange={handleModeSwitch}
-                    isFullWidth={false}
-                    style={{ marginLeft: '8px' }}
-                  />
-                </EuiFlexItem>
-                {!props.newAndUnsaved && (
+                {!noAgentsFound && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonGroup
+                      buttonSize="compressed"
+                      legend="Config Mode"
+                      options={[
+                        {
+                          id: CONFIG_MODE.SIMPLE,
+                          label: 'Form',
+                        },
+                        {
+                          id: CONFIG_MODE.ADVANCED,
+                          label: 'JSON',
+                        },
+                      ]}
+                      idSelected={configModeSelected}
+                      onChange={handleModeSwitch}
+                      isFullWidth={false}
+                      style={{ marginLeft: '8px' }}
+                    />
+                  </EuiFlexItem>
+                )}
+                {!props.newAndUnsaved && !noAgentsFound && (
                   <EuiFlexItem grow={false}>
                     <EuiSmallButton
                       fill={false}
@@ -274,22 +278,41 @@ export function AgentConfiguration(props: AgentConfigurationProps) {
           <EuiSpacer size="s" />
           <EuiFlexGroup direction="column" gutterSize="s">
             <EuiFlexItem>
-              <EuiSuperSelect
-                options={agentOptions}
-                valueOfSelected={selectedAgentId}
-                onChange={(value) => {
-                  if (value !== NEW_AGENT_PLACEHOLDER) {
-                    props.setNewAndUnsaved(false);
+              {noAgentsFound ? (
+                <EuiEmptyPrompt
+                  iconType={'generate'}
+                  title={<h4>Create an agent to get started</h4>}
+                  titleSize="xs"
+                  actions={
+                    <EuiSmallButton
+                      fill={false}
+                      onClick={() => {
+                        props.onCreateNew();
+                      }}
+                      iconType="plusInCircle"
+                    >
+                      Create new agent
+                    </EuiSmallButton>
                   }
-                  if (value) {
-                    setFieldValue(AGENT_ID_PATH, value);
-                    setFieldTouched(AGENT_ID_PATH, true);
-                  }
-                }}
-                placeholder="Select an agent"
-                compressed
-                fullWidth
-              />
+                />
+              ) : (
+                <EuiSuperSelect
+                  options={agentOptions}
+                  valueOfSelected={selectedAgentId}
+                  onChange={(value) => {
+                    if (value !== NEW_AGENT_PLACEHOLDER) {
+                      props.setNewAndUnsaved(false);
+                    }
+                    if (value) {
+                      setFieldValue(AGENT_ID_PATH, value);
+                      setFieldTouched(AGENT_ID_PATH, true);
+                    }
+                  }}
+                  placeholder="Select an agent"
+                  compressed
+                  fullWidth
+                />
+              )}
             </EuiFlexItem>
             {(!isEmpty(props.errorCreatingAgent) ||
               !isEmpty(props.errorUpdatingAgent)) && (


### PR DESCRIPTION
### Description

Improve empty agent state, instead of an empty dropdown.

Before

<img width="848" height="402" alt="before" src="https://github.com/user-attachments/assets/837359b1-fba0-420a-962c-dd877373be92" />

After

<img width="653" height="313" alt="after" src="https://github.com/user-attachments/assets/666c2052-63ff-4481-9b8e-4e6358a93702" />

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
