### PR TITLE
Add more guardrails based on agent types

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1083,4 +1083,7 @@ export const DEFAULT_AGENT = {
       type: TOOL_TYPE.QUERY_PLANNING,
     },
   ],
+  memory: {
+    type: AGENT_MEMORY_TYPE.CONVERSATION_INDEX,
+  },
 } as Partial<Agent>;

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
@@ -467,7 +467,7 @@ export function AgentConfiguration(props: AgentConfigurationProps) {
                       <>
                         <EuiFlexItem>
                           <EuiFormRow
-                            label={'Memory (optional)'}
+                            label={'Memory'}
                             labelAppend={
                               <EuiText size="xs">
                                 <EuiLink

--- a/public/pages/workflow_detail/agentic_search/test_flow/index_selector.tsx
+++ b/public/pages/workflow_detail/agentic_search/test_flow/index_selector.tsx
@@ -25,13 +25,16 @@ import {
 } from '../../../../store';
 import { getDataSourceId } from '../../../../utils';
 import {
+  AGENT_TYPE,
   OMIT_SYSTEM_INDEX_PATTERN,
   WorkflowFormValues,
 } from '../../../../../common';
 import { IndexDetailsModal } from './index_details_modal';
 import { NoIndicesCallout } from '../components';
 
-interface IndexSelectorProps {}
+interface IndexSelectorProps {
+  agentType?: AGENT_TYPE;
+}
 
 const INDEX_NAME_PATH = 'search.index.name';
 const ALL_INDICES = 'All indices';
@@ -55,20 +58,28 @@ export function IndexSelector(props: IndexSelectorProps) {
   const [indexOptions, setIndexOptions] = useState<
     { value: string; text: string }[]
   >([]);
+
+  // Optionally add an "ALL INDICES" option for eligible agent types (conversational)
   useEffect(() => {
-    setIndexOptions([
-      {
-        text: ALL_INDICES,
-        value: '',
-      },
+    let eligibleIndexOptions = [
       ...Object.values(indices || {})
         .filter((index) => !index.name.startsWith('.')) // Filter out system indices
         .map((index) => ({
           value: index.name,
           text: index.name,
         })),
-    ]);
-  }, [indices]);
+    ];
+    if (props.agentType === AGENT_TYPE.CONVERSATIONAL) {
+      eligibleIndexOptions = [
+        {
+          text: ALL_INDICES,
+          value: '',
+        },
+        ...eligibleIndexOptions,
+      ];
+    }
+    setIndexOptions(eligibleIndexOptions);
+  }, [indices, props.agentType]);
 
   return (
     <>
@@ -129,7 +140,7 @@ export function IndexSelector(props: IndexSelectorProps) {
           {isDetailsModalVisible && (
             <IndexDetailsModal
               onClose={() => setIsDetailsModalVisible(false)}
-              indexName={getIn(values, 'search.index.name')}
+              indexName={selectedIndexName}
             />
           )}
           <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -137,7 +148,12 @@ export function IndexSelector(props: IndexSelectorProps) {
               <EuiSelect
                 options={indexOptions}
                 value={
-                  isEmpty(selectedIndexName) ? ALL_INDICES : selectedIndexName
+                  isEmpty(selectedIndexName)
+                    ? props.agentType === AGENT_TYPE.FLOW ||
+                      isEmpty(props.agentType)
+                      ? undefined
+                      : ALL_INDICES
+                    : selectedIndexName
                 }
                 onChange={(e) => {
                   const value = e.target.value;
@@ -145,7 +161,7 @@ export function IndexSelector(props: IndexSelectorProps) {
                   setFieldTouched(INDEX_NAME_PATH, true);
                 }}
                 aria-label="Select index"
-                hasNoInitialSelection={false}
+                hasNoInitialSelection={true}
                 fullWidth
                 compressed
               />


### PR DESCRIPTION
### Description

Misc guardrail enhancements:
- removes the 'optional' field for memory, and sets the default memory configuration when creating a new conversational agent, as such it's impossible to create a new conversational agent _without_ memory configured now.
- removes the "All indices" option in the index selection for flow agents. If a flow agent is selected, users must select an index. If a conversational index is selected, it is defaulted to "all indices". If a user switches from flow -> conversational, the selected index remains the same. If a user switches from conversational -> flow, and if "all indices" was selected, it is set back to blank/empty.


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
