### PR TITLE
Improve error handling from server-side

### DIFF
--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -4,7 +4,7 @@
  */
 
 import { isEmpty } from 'lodash';
-import { CoreStart, HttpFetchError } from '../../../src/core/public';
+import { CoreStart } from '../../../src/core/public';
 import {
   CREATE_WORKFLOW_NODE_API_PATH,
   DELETE_WORKFLOW_NODE_API_PATH,
@@ -45,22 +45,10 @@ import {
  * Used in redux by wrapping them in async thunk functions which mutate redux state when executed.
  */
 export interface RouteService {
-  getWorkflow: (
-    workflowId: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  searchWorkflows: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getWorkflowState: (
-    workflowId: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  createWorkflow: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  getWorkflow: (workflowId: string, dataSourceId?: string) => Promise<any>;
+  searchWorkflows: (body: {}, dataSourceId?: string) => Promise<any>;
+  getWorkflowState: (workflowId: string, dataSourceId?: string) => Promise<any>;
+  createWorkflow: (body: {}, dataSourceId?: string) => Promise<any>;
   updateWorkflow: (
     workflowId: string,
     workflowTemplate: WorkflowTemplate,
@@ -68,12 +56,12 @@ export interface RouteService {
     reprovision: boolean,
     dataSourceId?: string,
     dataSourceVersion?: string
-  ) => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
   provisionWorkflow: (
     workflowId: string,
     dataSourceId?: string,
     dataSourceVersion?: string
-  ) => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
   deprovisionWorkflow: ({
     workflowId,
     dataSourceId,
@@ -82,24 +70,12 @@ export interface RouteService {
     workflowId: string;
     dataSourceId?: string;
     resourceIds?: string;
-  }) => Promise<any | HttpFetchError>;
-  deleteWorkflow: (
-    workflowId: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getWorkflowPresets: () => Promise<any | HttpFetchError>;
-  catIndices: (
-    pattern: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getMappings: (
-    index: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getIndex: (
-    index: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  }) => Promise<any>;
+  deleteWorkflow: (workflowId: string, dataSourceId?: string) => Promise<any>;
+  getWorkflowPresets: () => Promise<any>;
+  catIndices: (pattern: string, dataSourceId?: string) => Promise<any>;
+  getMappings: (index: string, dataSourceId?: string) => Promise<any>;
+  getIndex: (index: string, dataSourceId?: string) => Promise<any>;
   searchIndex: ({
     index,
     body,
@@ -114,12 +90,8 @@ export interface RouteService {
     dataSourceVersion?: string;
     searchPipeline?: string;
     verbose?: boolean;
-  }) => Promise<any | HttpFetchError>;
-  ingest: (
-    index: string,
-    doc: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  }) => Promise<any>;
+  ingest: (index: string, doc: {}, dataSourceId?: string) => Promise<any>;
   bulk: ({
     body,
     dataSourceId,
@@ -128,32 +100,17 @@ export interface RouteService {
     body: {};
     dataSourceId?: string;
     ingestPipeline?: string;
-  }) => Promise<any | HttpFetchError>;
-  searchModels: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  searchConnectors: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  registerAgent: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  }) => Promise<any>;
+  searchModels: (body: {}, dataSourceId?: string) => Promise<any>;
+  searchConnectors: (body: {}, dataSourceId?: string) => Promise<any>;
+  registerAgent: (body: {}, dataSourceId?: string) => Promise<any>;
   updateAgent: (
     agentId: string,
     body: {},
     dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  searchAgents: (
-    body: {},
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getAgent: (
-    agentId: string,
-    dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
+  searchAgents: (body: {}, dataSourceId?: string) => Promise<any>;
+  getAgent: (agentId: string, dataSourceId?: string) => Promise<any>;
   simulatePipeline: (
     body: {
       pipeline?: IngestPipelineConfig;
@@ -162,17 +119,17 @@ export interface RouteService {
     dataSourceId?: string,
     pipelineId?: string,
     verbose?: boolean
-  ) => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
   getIngestPipeline: (
     pipelineId: string,
     dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
   getSearchPipeline: (
     pipelineId: string,
     dataSourceId?: string
-  ) => Promise<any | HttpFetchError>;
-  getSearchTemplates: (dataSourceId?: string) => Promise<any | HttpFetchError>;
-  getLocalClusterVersion: () => Promise<any | HttpFetchError>;
+  ) => Promise<any>;
+  getSearchTemplates: (dataSourceId?: string) => Promise<any>;
+  getLocalClusterVersion: () => Promise<any>;
 }
 
 export function configureRoutes(core: CoreStart): RouteService {
@@ -187,7 +144,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     searchWorkflows: async (body: {}, dataSourceId?: string) => {
@@ -200,7 +157,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getWorkflowState: async (workflowId: string, dataSourceId?: string) => {
@@ -213,7 +170,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     createWorkflow: async (body: {}, dataSourceId?: string) => {
@@ -226,7 +183,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     updateWorkflow: async (
@@ -252,7 +209,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     provisionWorkflow: async (
@@ -274,7 +231,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     deprovisionWorkflow: async ({
@@ -296,7 +253,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         const response = await core.http.post<{ respString: string }>(path);
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     deleteWorkflow: async (workflowId: string, dataSourceId?: string) => {
@@ -309,7 +266,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getWorkflowPresets: async () => {
@@ -319,7 +276,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     catIndices: async (pattern: string, dataSourceId?: string) => {
@@ -332,7 +289,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getMappings: async (index: string, dataSourceId?: string) => {
@@ -345,7 +302,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getLocalClusterVersion: async () => {
@@ -355,7 +312,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response.version.number;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getIndex: async (index: string, dataSourceId?: string) => {
@@ -368,7 +325,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     searchIndex: async ({
@@ -403,7 +360,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     ingest: async (index: string, doc: {}, dataSourceId?: string) => {
@@ -419,7 +376,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     bulk: async ({
@@ -441,7 +398,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     searchModels: async (body: {}, dataSourceId?: string) => {
@@ -454,7 +411,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     searchConnectors: async (body: {}, dataSourceId?: string) => {
@@ -467,7 +424,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
 
@@ -481,7 +438,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
 
@@ -496,7 +453,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
 
@@ -510,7 +467,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
 
@@ -524,7 +481,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
 
@@ -550,7 +507,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         });
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getSearchPipeline: async (pipelineId: string, dataSourceId?: string) => {
@@ -563,7 +520,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getSearchTemplates: async (dataSourceId?: string) => {
@@ -574,7 +531,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         const response = await core.http.get<{ respString: string }>(url);
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
     getIngestPipeline: async (pipelineId: string, dataSourceId?: string) => {
@@ -587,7 +544,7 @@ export function configureRoutes(core: CoreStart): RouteService {
         );
         return response;
       } catch (e: any) {
-        return e as HttpFetchError;
+        throw e;
       }
     },
   };

--- a/public/store/reducers/ml_reducer.ts
+++ b/public/store/reducers/ml_reducer.ts
@@ -5,8 +5,8 @@
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { Agent, AgentDict, ConnectorDict, ModelDict } from '../../../common';
-import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
+import { formatRouteServiceError } from '../../utils';
 
 export const INITIAL_ML_STATE = {
   loading: false,
@@ -32,16 +32,12 @@ export const searchModels = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response: any | HttpFetchError = await getRouteService().searchModels(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().searchModels(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error searching models: ' + response.body.message
+        formatRouteServiceError(e, 'Error searching models')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -52,18 +48,12 @@ export const searchConnectors = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().searchConnectors(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().searchConnectors(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error searching connectors: ' + response.body.message
+        formatRouteServiceError(e, 'Error searching connectors')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -74,18 +64,12 @@ export const registerAgent = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().registerAgent(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().registerAgent(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error registering agent: ' + response.body.message
+        formatRouteServiceError(e, 'Error registering agent')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -96,16 +80,12 @@ export const searchAgents = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response: any | HttpFetchError = await getRouteService().searchAgents(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().searchAgents(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error searching agents: ' + response.body.message
+        formatRouteServiceError(e, 'Error searching agents')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -120,15 +100,12 @@ export const updateAgent = createAsyncThunk(
     }: { agentId: string; body: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response: any | HttpFetchError = await getRouteService().updateAgent(
-      agentId,
-      body,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
-      return rejectWithValue('Error updating agent: ' + response.body.message);
-    } else {
-      return response;
+    try {
+      return await getRouteService().updateAgent(agentId, body, dataSourceId);
+    } catch (e) {
+      return rejectWithValue(
+        formatRouteServiceError(e, 'Error updating agent')
+      );
     }
   }
 );
@@ -139,14 +116,10 @@ export const getAgent = createAsyncThunk(
     { agentId, dataSourceId }: { agentId: string; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response: any | HttpFetchError = await getRouteService().getAgent(
-      agentId,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
-      return rejectWithValue('Error getting agent: ' + response.body.message);
-    } else {
-      return response;
+    try {
+      return await getRouteService().getAgent(agentId, dataSourceId);
+    } catch (e) {
+      return rejectWithValue(formatRouteServiceError(e, 'Error getting agent'));
     }
   }
 );

--- a/public/store/reducers/presets_reducer.ts
+++ b/public/store/reducers/presets_reducer.ts
@@ -5,8 +5,8 @@
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { WorkflowTemplate } from '../../../common';
-import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
+import { formatRouteServiceError } from '../../utils';
 
 export const INITIAL_PRESETS_STATE = {
   loading: false,
@@ -20,15 +20,12 @@ const GET_WORKFLOW_PRESETS_ACTION = `${PRESET_ACTION_PREFIX}/getPresets`;
 export const getWorkflowPresets = createAsyncThunk(
   GET_WORKFLOW_PRESETS_ACTION,
   async (_, { rejectWithValue }) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().getWorkflowPresets();
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().getWorkflowPresets();
+    } catch (e) {
       return rejectWithValue(
-        'Error getting workflow presets: ' + response.body.message
+        formatRouteServiceError(e, 'Error getting workflow presets')
       );
-    } else {
-      return response;
     }
   }
 );

--- a/public/store/reducers/workflows_reducer.ts
+++ b/public/store/reducers/workflows_reducer.ts
@@ -5,8 +5,8 @@
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { WorkflowDict, WorkflowTemplate } from '../../../common';
-import { HttpFetchError } from '../../../../../src/core/public';
 import { getRouteService } from '../../services';
+import { formatRouteServiceError } from '../../utils';
 
 export const INITIAL_WORKFLOWS_STATE = {
   loading: false,
@@ -30,16 +30,12 @@ export const getWorkflow = createAsyncThunk(
     { workflowId, dataSourceId }: { workflowId: string; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response: any | HttpFetchError = await getRouteService().getWorkflow(
-      workflowId,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().getWorkflow(workflowId, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error getting workflow: ' + response.body.message
+        formatRouteServiceError(e, 'Error getting workflow')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -50,18 +46,12 @@ export const searchWorkflows = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().searchWorkflows(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().searchWorkflows(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error searching workflows: ' + response.body.message
+        formatRouteServiceError(e, 'Error searching workflows')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -72,18 +62,12 @@ export const getWorkflowState = createAsyncThunk(
     { workflowId, dataSourceId }: { workflowId: string; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().getWorkflowState(
-      workflowId,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().getWorkflowState(workflowId, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error getting workflow state: ' + response.body.message
+        formatRouteServiceError(e, 'Error getting workflow state')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -94,18 +78,12 @@ export const createWorkflow = createAsyncThunk(
     { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().createWorkflow(
-      apiBody,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().createWorkflow(apiBody, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error creating workflow: ' + response.body.message
+        formatRouteServiceError(e, 'Error creating workflow')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -129,23 +107,25 @@ export const updateWorkflow = createAsyncThunk(
     },
     { rejectWithValue }
   ) => {
-    const { workflowId, workflowTemplate, updateFields, reprovision } = apiBody;
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().updateWorkflow(
-      workflowId,
-      workflowTemplate,
-      updateFields || false,
-      reprovision || false,
-      dataSourceId,
-      dataSourceVersion
-    );
-    if (response instanceof HttpFetchError) {
-      return rejectWithValue(
-        'Error updating workflow: ' + response.body.message
+    try {
+      const {
+        workflowId,
+        workflowTemplate,
+        updateFields,
+        reprovision,
+      } = apiBody;
+      return await getRouteService().updateWorkflow(
+        workflowId,
+        workflowTemplate,
+        updateFields || false,
+        reprovision || false,
+        dataSourceId,
+        dataSourceVersion
       );
-    } else {
-      return response;
+    } catch (e) {
+      return rejectWithValue(
+        formatRouteServiceError(e, 'Error updating workflow')
+      );
     }
   }
 );
@@ -164,19 +144,16 @@ export const provisionWorkflow = createAsyncThunk(
     },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().provisionWorkflow(
-      workflowId,
-      dataSourceId,
-      dataSourceVersion
-    );
-    if (response instanceof HttpFetchError) {
-      return rejectWithValue(
-        'Error provisioning workflow: ' + response.body.message
+    try {
+      return await getRouteService().provisionWorkflow(
+        workflowId,
+        dataSourceId,
+        dataSourceVersion
       );
-    } else {
-      return response;
+    } catch (e) {
+      return rejectWithValue(
+        formatRouteServiceError(e, 'Error provisioning workflow')
+      );
     }
   }
 );
@@ -193,20 +170,17 @@ export const deprovisionWorkflow = createAsyncThunk(
     },
     { rejectWithValue }
   ) => {
-    const { workflowId, resourceIds } = apiBody;
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().deprovisionWorkflow({
-      workflowId,
-      resourceIds,
-      dataSourceId,
-    });
-    if (response instanceof HttpFetchError) {
+    try {
+      const { workflowId, resourceIds } = apiBody;
+      return await getRouteService().deprovisionWorkflow({
+        workflowId,
+        resourceIds,
+        dataSourceId,
+      });
+    } catch (e) {
       return rejectWithValue(
-        'Error deprovisioning workflow: ' + response.body.message
+        formatRouteServiceError(e, 'Error deprovisioning workflow')
       );
-    } else {
-      return response;
     }
   }
 );
@@ -217,18 +191,12 @@ export const deleteWorkflow = createAsyncThunk(
     { workflowId, dataSourceId }: { workflowId: string; dataSourceId?: string },
     { rejectWithValue }
   ) => {
-    const response:
-      | any
-      | HttpFetchError = await getRouteService().deleteWorkflow(
-      workflowId,
-      dataSourceId
-    );
-    if (response instanceof HttpFetchError) {
+    try {
+      return await getRouteService().deleteWorkflow(workflowId, dataSourceId);
+    } catch (e) {
       return rejectWithValue(
-        'Error deleting workflow: ' + response.body.message
+        formatRouteServiceError(e, 'Error deleting workflow')
       );
-    } else {
-      return response;
     }
   }
 );

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1150,3 +1150,7 @@ function sanitizeObjInput(formField: any): {} {
 function sanitizeBooleanInput(formField: any): boolean {
   return typeof formField === 'boolean' ? formField : false;
 }
+
+export function formatRouteServiceError(e: any, prefix: string) {
+  return `${prefix}: ${e.body?.message ?? e.message ?? 'Unknown error'}`;
+}


### PR DESCRIPTION
### Description

Changes the error handling pattern for server-side errors. Rather than propagating strings and checking for errors based on `instanceof HttpFetchError`, we throw the errors directly, and catch them to be rejected in redux. This prevents issues under certain bundled builds, where the `instanceof` check will fail, and an error will be swallowed, leaving to corrupt redux store variables and unexpected NPEs.

### Issues Resolved

Closes #788 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
