### PR TITLE
Remove flaky UT on sorting by workflow type

### DIFF
--- a/public/pages/workflows/workflow_list/workflow_list.test.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.test.tsx
@@ -91,20 +91,6 @@ describe('WorkflowList', () => {
     expect(queryByText('workflow_name_9')).toBeInTheDocument();
     expect(queryByText('workflow_name_10')).toBeNull();
     expect(queryByText('workflow_name_19')).toBeNull();
-
-    // Sort workflows list by Type
-    expect(sortButtons[1]).toBeInTheDocument();
-    userEvent.click(sortButtons[1]!);
-    await waitFor(() => {
-      expect(getAllByText('Custom Search').length).toBeGreaterThan(0);
-    });
-    expect(queryByText('Unknown')).toBeNull();
-
-    userEvent.click(sortButtons[1]!);
-    await waitFor(() => {
-      expect(queryByText('Unknown')).toBeNull();
-    });
-    expect(getAllByText('Custom Search').length).toBeGreaterThan(0);
   });
 
   test('pagination functionality', async () => {


### PR DESCRIPTION
### Description

Remove flaky UT on sorting by workflow type, which is inherently not reliable, as the mocked workflow types are randomly generated, and as new workflow types get added, it could change the top/bottom workflows shown in alphabetical order.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
