### PR TITLE
Fix broken tutorial link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 - React 18 compatibility changes ([#843](https://github.com/opensearch-project/dashboards-flow-framework/pull/843))
 ### Documentation
+- Fix broken tutorial link in README ([#860](https://github.com/opensearch-project/dashboards-flow-framework/pull/860))
 ### Maintenance
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.x](https://github.com/opensearch-project/dashboards-flow-framework/compare/3.4...HEAD)
+## [Unreleased 3.x](https://github.com/opensearch-project/dashboards-flow-framework/compare/3.6...HEAD)
 ### Features
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
-- React 18 compatibility changes ([#843](https://github.com/opensearch-project/dashboards-flow-framework/pull/843))
 ### Documentation
 - Fix broken tutorial link in README ([#860](https://github.com/opensearch-project/dashboards-flow-framework/pull/860))
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The OpenSearch Flow plugin on OpenSearch Dashboards (OSD) gives users the ability to iteratively build out search and ingest pipelines, initially focusing on ease-of-use for AI/ML-enhanced use cases via [ML inference processors](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/). Behind the scenes, the plugin uses the [Flow Framework OpenSearch plugin](https://opensearch.org/docs/latest/automating-configurations/index/) for resource management for each use case / workflow a user creates. For example, most use cases involve configuring and creating indices, ingest pipelines, and search pipelines. All of these resources are created, updated, deleted, and maintained by the Flow Framework plugin. When users are satisfied with a use case they have built out, they can export the produced [Workflow Template](https://opensearch.org/docs/latest/automating-configurations/workflow-templates/) to re-create resources for their use cases across different clusters / data sources.
 
-For tutorials on how to leverage this plugin to build out different AI/ML use cases, see [here](./documentation/tutorial.md).
+For tutorials on how to leverage this plugin to build out different AI/ML use cases, see [the workflow tutorial documentation](https://opensearch.org/docs/latest/automating-configurations/workflow-tutorial/).
 
 For how to set up this plugin in a development environment, see [DEVELOPER_GUIDE](./DEVELOPER_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The OpenSearch Flow plugin on OpenSearch Dashboards (OSD) gives users the ability to iteratively build out search and ingest pipelines, initially focusing on ease-of-use for AI/ML-enhanced use cases via [ML inference processors](https://opensearch.org/docs/latest/ingest-pipelines/processors/ml-inference/). Behind the scenes, the plugin uses the [Flow Framework OpenSearch plugin](https://opensearch.org/docs/latest/automating-configurations/index/) for resource management for each use case / workflow a user creates. For example, most use cases involve configuring and creating indices, ingest pipelines, and search pipelines. All of these resources are created, updated, deleted, and maintained by the Flow Framework plugin. When users are satisfied with a use case they have built out, they can export the produced [Workflow Template](https://opensearch.org/docs/latest/automating-configurations/workflow-templates/) to re-create resources for their use cases across different clusters / data sources.
 
-For tutorials on how to leverage this plugin to build out different AI/ML use cases, see [the workflow tutorial documentation](https://opensearch.org/docs/latest/automating-configurations/workflow-tutorial/).
+For tutorials on how to leverage this plugin to build out different AI/ML use cases, see [the workflow builder documentation](https://docs.opensearch.org/latest/vector-search/ai-search/workflow-builder/).
 
 For how to set up this plugin in a development environment, see [DEVELOPER_GUIDE](./DEVELOPER_GUIDE.md).
 


### PR DESCRIPTION
### Description

Fixes the broken tutorial link in the README. The previous link pointed to `./documentation/tutorial.md` which doesn't exist in the repo. Updated to point to the official OpenSearch workflow tutorial documentation.

### Issues Resolved

Closes #857

### Check List
- [x] New functionality includes testing
  - N/A - documentation-only change
- [x] New functionality has been documented
  - N/A - this fixes existing documentation
- [x] Commits are signed per the DCO using `--signoff`