### PR TITLE
Add fallback query configuration for QueryPlanningTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 - Update Inspect tab to Search ([#844](https://github.com/opensearch-project/dashboards-flow-framework/pull/844))
 - Add index alias support in agentic search UI ([#871](https://github.com/opensearch-project/dashboards-flow-framework/pull/871))
+- Add fallback query configuration for QueryPlanningTool ([#872](https://github.com/opensearch-project/dashboards-flow-framework/pull/872))
 ### Bug Fixes
 ### Infrastructure
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import { AgentTools } from './agent_tools';
@@ -21,6 +21,25 @@ jest.mock('../../../../services', () => {
     ...mockCoreServices,
   };
 });
+
+// Mock SimplifiedJsonField to make onChange/onBlur testable
+let capturedOnChange: ((value: string) => void) | undefined;
+let capturedOnBlur: ((value: string) => void) | undefined;
+jest.mock(
+  '../components/simplified_json_field',
+  () => ({
+    SimplifiedJsonField: (props: any) => {
+      capturedOnChange = props.onChange;
+      capturedOnBlur = props.onBlur;
+      return (
+        <div data-testid="simplifiedJsonField">
+          <span>{props.label}</span>
+          {props.isInvalid && <span data-testid="fallbackQueryError">{props.error}</span>}
+        </div>
+      );
+    },
+  })
+);
 
 // Setup mock store
 const mockStore = configureStore([]);
@@ -134,5 +153,65 @@ describe('AgentTools', () => {
     // Should show both Query Planning and Web Search
     expect(screen.getAllByText('Query Planning').length).toBeGreaterThan(0);
     expect(screen.getByText('Web Search')).toBeInTheDocument();
+  });
+
+  test('fallback query onChange shows error for invalid JSON', () => {
+    renderAgentTools(mockAgentForm, mockSetAgentForm);
+    act(() => {
+      capturedOnChange!('not valid json');
+    });
+    expect(screen.getByTestId('fallbackQueryError')).toHaveTextContent(
+      'Invalid JSON'
+    );
+  });
+
+  test('fallback query onChange clears error for valid JSON', () => {
+    renderAgentTools(mockAgentForm, mockSetAgentForm);
+    act(() => {
+      capturedOnChange!('not valid json');
+    });
+    expect(screen.getByTestId('fallbackQueryError')).toHaveTextContent(
+      'Invalid JSON'
+    );
+    act(() => {
+      capturedOnChange!('{"query": {"match_all": {}}}');
+    });
+    expect(screen.queryByTestId('fallbackQueryError')).toBeNull();
+  });
+
+  test('fallback query onChange removes parameter when cleared', () => {
+    renderAgentTools(mockAgentForm, mockSetAgentForm);
+    act(() => {
+      capturedOnChange!('   ');
+    });
+    expect(mockSetAgentForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            parameters: expect.not.objectContaining({
+              fallback_query: expect.anything(),
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
+  test('fallback query onBlur persists value to form', () => {
+    renderAgentTools(mockAgentForm, mockSetAgentForm);
+    act(() => {
+      capturedOnBlur!('{"query": {"match_all": {}}}');
+    });
+    expect(mockSetAgentForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            parameters: expect.objectContaining({
+              fallback_query: '{"query": {"match_all": {}}}',
+            }),
+          }),
+        ]),
+      })
+    );
   });
 });

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
@@ -107,6 +107,9 @@ describe('AgentTools', () => {
     // Check that the generation type field is rendered
     expect(screen.getByTestId('generationTypeField')).toBeInTheDocument();
     expect(screen.getByTestId('generationTypeRadioGroup')).toBeInTheDocument();
+
+    // Check that the fallback query field is rendered
+    expect(screen.getByText('Fallback query')).toBeInTheDocument();
   });
 
   test('shows different tool options based on agent type', () => {

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -390,13 +390,20 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
         helpText="Query DSL to use when the LLM-generated query fails or returns no results"
         value={toolForm?.parameters?.fallback_query || ''}
         onBlur={(value) => {
-          updateParameterValue(
-            props.agentForm,
-            props.setAgentForm,
-            props.toolIndex,
-            'fallback_query',
-            value
-          );
+          const toolsForm = getIn(props.agentForm, 'tools');
+          const updatedTool = {
+            ...toolForm,
+            parameters: {
+              ...toolForm.parameters,
+              fallback_query: value,
+            },
+          };
+          props.setAgentForm({
+            ...props.agentForm,
+            tools: toolsForm.map((tool: Tool, i: number) =>
+              i === props.toolIndex ? updatedTool : tool
+            ),
+          });
         }}
         editorHeight="10vh"
       />

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -384,6 +384,29 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
           </div>
         </>
       )}
+      <EuiFormRow
+        label="Fallback query"
+        helpText="Query DSL to use when the LLM-generated query fails or returns no results"
+        data-testid="fallbackQueryField"
+        fullWidth
+      >
+        <EuiTextArea
+          value={toolForm?.parameters?.fallback_query || ''}
+          onChange={(e) => {
+            updateParameterValue(
+              props.agentForm,
+              props.setAgentForm,
+              props.toolIndex,
+              'fallback_query',
+              e.target.value
+            );
+          }}
+          placeholder='{"size":10,"query":{"match_all":{}}}'
+          fullWidth
+          compressed
+          rows={3}
+        />
+      </EuiFormRow>
     </>
   );
 }

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -187,6 +187,9 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
   const [openTemplateAccordionIndex, setOpenTemplateAccordionIndex] = useState<
     number | undefined
   >(undefined);
+  const [fallbackQueryError, setFallbackQueryError] = useState<
+    string | undefined
+  >(undefined);
 
   return (
     <>
@@ -387,9 +390,32 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
       )}
       <SimplifiedJsonField
         label="Fallback query"
-        helpText="Query DSL to use when the LLM-generated query fails or returns no results"
+        helpText="Query DSL to use when the LLM-generated query fails or returns no results. Clear to use the default."
         value={toolForm?.parameters?.fallback_query || ''}
+        onChange={(value) => {
+          if (value.trim() === '') {
+            setFallbackQueryError(undefined);
+            const toolsForm = getIn(props.agentForm, 'tools');
+            const updatedParams = { ...toolForm.parameters };
+            delete updatedParams.fallback_query;
+            const updatedTool = { ...toolForm, parameters: updatedParams };
+            props.setAgentForm({
+              ...props.agentForm,
+              tools: toolsForm.map((tool: Tool, i: number) =>
+                i === props.toolIndex ? updatedTool : tool
+              ),
+            });
+          } else {
+            try {
+              JSON.parse(value);
+              setFallbackQueryError(undefined);
+            } catch (e) {
+              setFallbackQueryError('Invalid JSON');
+            }
+          }
+        }}
         onBlur={(value) => {
+          setFallbackQueryError(undefined);
           const toolsForm = getIn(props.agentForm, 'tools');
           const updatedTool = {
             ...toolForm,
@@ -406,6 +432,8 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
           });
         }}
         editorHeight="25vh"
+        isInvalid={fallbackQueryError !== undefined}
+        error={fallbackQueryError}
       />
     </>
   );

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -405,7 +405,7 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
             ),
           });
         }}
-        editorHeight="10vh"
+        editorHeight="25vh"
       />
     </>
   );

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -38,6 +38,7 @@ import { parseStringOrJson } from '../../../../../utils';
 import {
   NoDeployedModelsCallout,
   NoSearchTemplatesCallout,
+  SimplifiedJsonField,
 } from '../../components';
 import { updateParameterValue } from './utils';
 
@@ -384,29 +385,21 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
           </div>
         </>
       )}
-      <EuiFormRow
+      <SimplifiedJsonField
         label="Fallback query"
         helpText="Query DSL to use when the LLM-generated query fails or returns no results"
-        data-testid="fallbackQueryField"
-        fullWidth
-      >
-        <EuiTextArea
-          value={toolForm?.parameters?.fallback_query || ''}
-          onChange={(e) => {
-            updateParameterValue(
-              props.agentForm,
-              props.setAgentForm,
-              props.toolIndex,
-              'fallback_query',
-              e.target.value
-            );
-          }}
-          placeholder='{"size":10,"query":{"match_all":{}}}'
-          fullWidth
-          compressed
-          rows={3}
-        />
-      </EuiFormRow>
+        value={toolForm?.parameters?.fallback_query || ''}
+        onBlur={(value) => {
+          updateParameterValue(
+            props.agentForm,
+            props.setAgentForm,
+            props.toolIndex,
+            'fallback_query',
+            value
+          );
+        }}
+        editorHeight="10vh"
+      />
     </>
   );
 }

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -415,6 +415,7 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
           }
         }}
         onBlur={(value) => {
+          // onBlur only fires with valid JSON; clear error as a safeguard
           setFallbackQueryError(undefined);
           const toolsForm = getIn(props.agentForm, 'tools');
           const updatedTool = {


### PR DESCRIPTION
### Description

Adds an optional fallback query configuration field to the QueryPlanningTool in the agentic search UI. When the LLM-generated query fails to parse or returns no results, the backend uses this fallback query instead.

### Changes

**UI** (`public/pages/.../tool_forms/query_planning_tool.tsx`):
- Added `SimplifiedJsonField` (JSON code editor with syntax highlighting and auto-formatting) for the `fallback_query` tool parameter
- Field appears below the generation type config in the QueryPlanningTool accordion
- Value is persisted as a string directly to avoid `parseStringOrJson` converting it to an object (which crashes the Ace editor)

### Issues Resolved

Resolves #868

### Testing

**Unit tests:** All 126 tests pass (23 suites), no regressions.

**End-to-end validation:**
1. Created a flow agent with `QueryPlanningTool` backed by a Bedrock Claude model
2. Configured a custom fallback query via the JSON editor in the UI (e.g., a fuzzy multi_match on title/description using `${parameters.question}`)
3. Verified the fallback query persists in the agent config (`GET /_plugins/_ml/agents/<id>`)
4. Triggered the fallback by asking a question completely unrelated to the index mapping (e.g., "Find all employees hired in 2023" against an ecommerce index) — the LLM generates a query with non-existent fields, causing the fallback to activate
5. Confirmed the fallback query executes and returns relevant results instead of empty results

Demo:

[screen-capture.webm](https://github.com/user-attachments/assets/b54b1cdf-810c-4374-a022-9f8896c0c364)

Error handling (invalid JSON) demo:

[screen-capture (1).webm](https://github.com/user-attachments/assets/a2880a02-278d-4c19-8d64-331bb4b137bd)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`