### PR TITLE
Add embedding model ID configuration for agentic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Update Inspect tab to Search ([#844](https://github.com/opensearch-project/dashboards-flow-framework/pull/844))
 - Add index alias support in agentic search UI ([#871](https://github.com/opensearch-project/dashboards-flow-framework/pull/871))
 - Add fallback query configuration for QueryPlanningTool ([#872](https://github.com/opensearch-project/dashboards-flow-framework/pull/872))
+- Add embedding model ID configuration for agentic search ([#875](https://github.com/opensearch-project/dashboards-flow-framework/pull/875))
 ### Bug Fixes
 ### Infrastructure
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -354,6 +354,10 @@ export const QUERY_PLANNING_TOOL_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/query-planning-tool#register-parameters';
 export const QUERY_PLANNING_MODEL_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/query-planning-tool/#step-2-register-and-deploy-a-model';
+export const EMBEDDING_MODEL_LABEL = 'Embedding model';
+export const EMBEDDING_MODEL_HELP_TEXT =
+  'Enables the LLM to generate neural queries for semantic search.';
+export const NONE_OPTION = { value: '', text: '- None -' };
 export const WEB_SEARCH_TOOL_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/web-search-tool/#register-parameters';
 export const SEARCH_TEMPLATES_DOCS_LINK =

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.test.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -98,6 +98,26 @@ describe('AgentAdvancedSettings', () => {
     mockStore({
       ml: { ...INITIAL_ML_STATE, models, connectors: {} },
     });
+
+  test('renders embedding model field for conversational agents', () => {
+    const models = {
+      embeddingModel: {
+        id: 'embeddingModel',
+        state: 'deployed',
+        connector: { parameters: { model: 'amazon.titan-embed-text-v2' } },
+      },
+    };
+    const store = createStore(models);
+    render(
+      <Provider store={store}>
+        <AgentAdvancedSettings
+          agentForm={{ type: AGENT_TYPE.CONVERSATIONAL, llm: { model_id: '' } }}
+          setAgentForm={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(screen.getByText('Embedding model')).toBeInTheDocument();
+  });
 
   test('updates LLM interface when model changes', () => {
     const models = {

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getIn } from 'formik';
-import { isEmpty } from 'lodash';
+import { cloneDeep, isEmpty, set } from 'lodash';
 import {
   EuiFlexItem,
   EuiSpacer,
@@ -15,18 +15,26 @@ import {
   EuiText,
   EuiLink,
   EuiComboBox,
+  EuiSelect,
 } from '@elastic/eui';
 import {
   Agent,
   AGENT_FIELDS_DOCS_LINK,
   AGENT_LLM_INTERFACE_TYPE,
   AGENT_TYPE,
+  AgentLLM,
   ConnectorDict,
+  EMBEDDING_MODEL_HELP_TEXT,
+  EMBEDDING_MODEL_LABEL,
   MEMORY_DOCS_LINK,
+  MODEL_STATE,
   ModelDict,
+  NONE_OPTION,
 } from '../../../../../common';
 import { AgentMemory } from './agent_memory';
 import { AppState } from '../../../../store';
+import { isKnownLLM } from '../../../../utils';
+import { NoDeployedModelsCallout } from '../components';
 
 interface AgentAdvancedSettingsProps {
   agentForm: Partial<Agent>;
@@ -52,6 +60,24 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
     'agentForm.parameters._llm_interface',
     ''
   ) as AGENT_LLM_INTERFACE_TYPE;
+  const llmForm = getIn(props.agentForm, 'llm') as AgentLLM;
+  const selectedEmbeddingModelId = getIn(
+    llmForm,
+    'parameters.embedding_model_id',
+    ''
+  ) as string;
+
+  const [embeddingModelOptions, setEmbeddingModelOptions] = useState<
+    { value: string; text: string }[]
+  >([]);
+  useEffect(() => {
+    setEmbeddingModelOptions(
+      Object.values(models || {})
+        .filter((model) => model.state === MODEL_STATE.DEPLOYED)
+        .filter((model) => !isKnownLLM(model, connectors))
+        .map((model) => ({ value: model.id, text: model.name || model.id }))
+    );
+  }, [models, connectors]);
 
   // listen to agent model changes. Try to automatically set the _llm_interface, if applicable
   useEffect(() => {
@@ -73,9 +99,6 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
       buttonContent="Advanced settings"
     >
       <EuiSpacer size="s" />
-      {/**
-       * For agent types that allow for memory, provide custom form inputs for that.
-       */}
       {agentType === AGENT_TYPE.CONVERSATIONAL && (
         <>
           <EuiFlexItem grow={false}>
@@ -140,6 +163,47 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
                 compressed
                 fullWidth
               />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiSpacer size="s" />
+          <EuiFlexItem grow={false}>
+            <EuiFormRow
+              label={<>{EMBEDDING_MODEL_LABEL}<i> - optional</i></>}
+              helpText={EMBEDDING_MODEL_HELP_TEXT}
+              data-testid="embeddingModelField"
+              fullWidth
+            >
+              <>
+                {embeddingModelOptions.length === 0 ? (
+                  <NoDeployedModelsCallout />
+                ) : (
+                  <EuiSelect
+                    options={[
+                      NONE_OPTION,
+                      ...embeddingModelOptions,
+                    ]}
+                    value={selectedEmbeddingModelId}
+                    onChange={(e) => {
+                      let updatedAgentForm = cloneDeep(props.agentForm);
+                      if (e.target.value === '') {
+                        const params = getIn(updatedAgentForm, 'llm.parameters', {});
+                        delete params.embedding_model_id;
+                        set(updatedAgentForm, 'llm.parameters', params);
+                      } else {
+                        set(
+                          updatedAgentForm,
+                          'llm.parameters.embedding_model_id',
+                          e.target.value
+                        );
+                      }
+                      props.setAgentForm(updatedAgentForm);
+                    }}
+                    aria-label="Select embedding model"
+                    fullWidth
+                    compressed
+                  />
+                )}
+              </>
             </EuiFormRow>
           </EuiFlexItem>
           <EuiSpacer size="s" />

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_llm_fields.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_llm_fields.tsx
@@ -20,6 +20,7 @@ import {
   TOOL_TYPE,
 } from '../../../../../common';
 import { AppState } from '../../../../store';
+import { isKnownEmbeddingModel } from '../../../../utils';
 import { NoDeployedModelsCallout } from '../components';
 
 interface AgentLLMFieldsProps {
@@ -36,8 +37,7 @@ export function AgentLLMFields({
   agentForm,
   setAgentForm,
 }: AgentLLMFieldsProps) {
-  // get redux store for models / search templates / etc. if needed in downstream tool configs
-  const { models } = useSelector((state: AppState) => state.ml);
+  const { models, connectors } = useSelector((state: AppState) => state.ml);
   const [modelOptions, setModelOptions] = useState<
     { value: string; text: string }[]
   >([]);
@@ -45,12 +45,13 @@ export function AgentLLMFields({
     setModelOptions(
       Object.values(models || {})
         .filter((model) => model.state === MODEL_STATE.DEPLOYED)
+        .filter((model) => !isKnownEmbeddingModel(model, connectors))
         .map((model) => ({
           value: model.id,
           text: model.name || model.id,
         }))
     );
-  }, [models]);
+  }, [models, connectors]);
   const llmForm = getIn(agentForm, `llm`) as AgentLLM;
   const toolsField = getIn(agentForm, 'tools', []) as Tool[];
   const queryPlanningToolIndex = toolsField.findIndex(

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_tools.test.tsx
@@ -144,6 +144,9 @@ describe('AgentTools', () => {
     // Should not show Web Search for FLOW agent
     expect(screen.queryByText('Web Search')).toBeNull();
 
+    // Should show embedding model field for FLOW agent
+    expect(screen.getByTestId('embeddingModelField')).toBeInTheDocument();
+
     // Now render with CONVERSATIONAL agent type which should show all tools
     renderAgentTools(
       { ...mockAgentForm, type: AGENT_TYPE.CONVERSATIONAL },

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -25,8 +25,11 @@ import {
   Agent,
   AGENT_TYPE,
   ConnectorDict,
+  EMBEDDING_MODEL_HELP_TEXT,
+  EMBEDDING_MODEL_LABEL,
   Model,
   MODEL_STATE,
+  NONE_OPTION,
   QUERY_PLANNING_MODEL_DOCS_LINK,
   QUERY_PLANNING_TOOL_DOCS_LINK,
   RESPONSE_FILTER_TYPE,
@@ -34,7 +37,11 @@ import {
   TOOL_DESCRIPTION,
 } from '../../../../../../common';
 import { AppState } from '../../../../../store';
-import { parseStringOrJson } from '../../../../../utils';
+import {
+  isKnownEmbeddingModel,
+  isKnownLLM,
+  parseStringOrJson,
+} from '../../../../../utils';
 import {
   NoDeployedModelsCallout,
   NoSearchTemplatesCallout,
@@ -74,16 +81,24 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
   const [modelOptions, setModelOptions] = useState<
     { value: string; text: string }[]
   >([]);
+  const [embeddingModelOptions, setEmbeddingModelOptions] = useState<
+    { value: string; text: string }[]
+  >([]);
   useEffect(() => {
-    setModelOptions(
-      Object.values(models || {})
-        .filter((model) => model.state === MODEL_STATE.DEPLOYED)
-        .map((model) => ({
-          value: model.id,
-          text: model.name || model.id,
-        }))
+    const deployedModels = Object.values(models || {}).filter(
+      (model) => model.state === MODEL_STATE.DEPLOYED
     );
-  }, [models]);
+    setModelOptions(
+      deployedModels
+        .filter((model) => !isKnownEmbeddingModel(model, connectors))
+        .map((model) => ({ value: model.id, text: model.name || model.id }))
+    );
+    setEmbeddingModelOptions(
+      deployedModels
+        .filter((model) => !isKnownLLM(model, connectors))
+        .map((model) => ({ value: model.id, text: model.name || model.id }))
+    );
+  }, [models, connectors]);
   const agentType = getIn(props.agentForm, 'type', '').toLowerCase() as string;
   const toolForm = getIn(props.agentForm, `tools.${props.toolIndex}`) as Tool;
   const generationType =
@@ -279,6 +294,57 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
           data-testid="generationTypeRadioGroup"
         />
       </EuiFormRow>
+      {agentType === AGENT_TYPE.FLOW && (
+        <EuiFormRow
+          label={<>{EMBEDDING_MODEL_LABEL}<i> - optional</i></>}
+          helpText={EMBEDDING_MODEL_HELP_TEXT}
+          data-testid="embeddingModelField"
+          fullWidth
+        >
+          <>
+            {embeddingModelOptions.length === 0 ? (
+              <NoDeployedModelsCallout />
+            ) : (
+              <EuiSelect
+                options={[
+                  NONE_OPTION,
+                  ...embeddingModelOptions,
+                ]}
+                value={toolForm?.parameters?.embedding_model_id || ''}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    const toolsForm = getIn(props.agentForm, 'tools');
+                    const updatedParams = { ...toolForm.parameters };
+                    delete updatedParams.embedding_model_id;
+                    const updatedTool = {
+                      ...toolForm,
+                      parameters: updatedParams,
+                    };
+                    props.setAgentForm({
+                      ...props.agentForm,
+                      tools: toolsForm.map((tool: Tool, i: number) =>
+                        i === props.toolIndex ? updatedTool : tool
+                      ),
+                    });
+                  } else {
+                    updateParameterValue(
+                      props.agentForm,
+                      props.setAgentForm,
+                      props.toolIndex,
+                      'embedding_model_id',
+                      value
+                    );
+                  }
+                }}
+                aria-label="Select embedding model"
+                fullWidth
+                compressed
+              />
+            )}
+          </>
+        </EuiFormRow>
+      )}
       {generationType === GENERATION_TYPE.SEARCH_TEMPLATES && (
         <>
           <EuiSpacer size="s" />

--- a/public/utils/model_filtering.test.tsx
+++ b/public/utils/model_filtering.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Connector, ConnectorDict } from '../../common';
+import { isKnownLLM, isKnownEmbeddingModel } from './utils';
+
+// Mock services to avoid UISettings error
+jest.mock('../services', () => {
+  const { mockCoreServices } = require('../../test/mocks');
+  return {
+    ...jest.requireActual('../services'),
+    ...mockCoreServices,
+  };
+});
+
+describe('isKnownLLM and isKnownEmbeddingModel', () => {
+  const llmConnector = {
+    parameters: { model: 'anthropic.claude-3-sonnet', service_name: 'bedrock' },
+    actions: [
+      {
+        url:
+          'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-3-sonnet/converse',
+      },
+    ],
+  } as Partial<Connector>;
+
+  const embeddingConnector = {
+    parameters: {
+      model: 'amazon.titan-embed-text-v2',
+      service_name: 'bedrock',
+    },
+    actions: [
+      {
+        url:
+          'https://bedrock-runtime.us-west-2.amazonaws.com/model/amazon.titan-embed-text-v2/invoke',
+      },
+    ],
+  } as Partial<Connector>;
+
+  const unknownConnector = {
+    parameters: { model: 'my-custom-model' },
+    actions: [{ url: 'https://my-server.com/predict' }],
+  } as Partial<Connector>;
+
+  const connectors: ConnectorDict = {
+    'llm-conn': llmConnector as Connector,
+    'embed-conn': embeddingConnector as Connector,
+    'unknown-conn': unknownConnector as Connector,
+  };
+
+  // Scenario 1: LLM should only show in LLM dropdown
+  it('identifies Claude as a known LLM', () => {
+    const model = { connector: llmConnector };
+    expect(isKnownLLM(model, {})).toBe(true);
+    expect(isKnownEmbeddingModel(model, {})).toBe(false);
+  });
+
+  it('identifies GPT as a known LLM via URL', () => {
+    const model = {
+      connector: {
+        parameters: { model: 'gpt-4o' },
+        actions: [{ url: 'https://api.openai.com/v1/chat/completions' }],
+      } as Partial<Connector>,
+    };
+    expect(isKnownLLM(model, {})).toBe(true);
+    expect(isKnownEmbeddingModel(model, {})).toBe(false);
+  });
+
+  // Scenario 2: Embedding model should only show in embedding dropdown
+  it('identifies Titan Embedding as a known embedding model', () => {
+    const model = { connector: embeddingConnector };
+    expect(isKnownEmbeddingModel(model, {})).toBe(true);
+    expect(isKnownLLM(model, {})).toBe(false);
+  });
+
+  it('identifies Cohere Embed as a known embedding model', () => {
+    const model = {
+      connector: {
+        parameters: { model: 'embed-english-v3.0' },
+        actions: [{ url: 'https://api.cohere.ai/embed' }],
+      } as Partial<Connector>,
+    };
+    expect(isKnownEmbeddingModel(model, {})).toBe(true);
+    expect(isKnownLLM(model, {})).toBe(false);
+  });
+
+  // Scenario 3: Unknown/local models show in neither exclusion list
+  it('does not identify unknown models as LLM or embedding', () => {
+    const model = { connector: unknownConnector };
+    expect(isKnownLLM(model, {})).toBe(false);
+    expect(isKnownEmbeddingModel(model, {})).toBe(false);
+  });
+
+  // Connector resolution via connectorId
+  it('resolves connector via connectorId', () => {
+    const model = { connectorId: 'llm-conn' };
+    expect(isKnownLLM(model, connectors)).toBe(true);
+
+    const embedModel = { connectorId: 'embed-conn' };
+    expect(isKnownEmbeddingModel(embedModel, connectors)).toBe(true);
+  });
+
+  // No connector at all
+  it('returns false when no connector is available', () => {
+    expect(isKnownLLM({}, {})).toBe(false);
+    expect(isKnownEmbeddingModel({}, {})).toBe(false);
+  });
+
+  // Version suffix stripping
+  it('identifies embedding model with version suffix', () => {
+    const model = {
+      connector: {
+        parameters: { model: 'amazon.titan-embed-text-v2:0' },
+        actions: [
+          {
+            url:
+              'https://bedrock-runtime.us-west-2.amazonaws.com/model/amazon.titan-embed-text-v2:0/invoke',
+          },
+        ],
+      } as Partial<Connector>,
+    };
+    expect(isKnownEmbeddingModel(model, {})).toBe(true);
+    expect(isKnownLLM(model, {})).toBe(false);
+  });
+
+  // URL-based embedding detection
+  it('identifies embedding model by URL pattern', () => {
+    const model = {
+      connector: {
+        parameters: { model: 'custom-embedding-v1' },
+        actions: [{ url: 'https://my-server.com/embed' }],
+      } as Partial<Connector>,
+    };
+    expect(isKnownEmbeddingModel(model, {})).toBe(true);
+  });
+});

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -63,6 +63,7 @@ import {
 } from '../services';
 import {
   Connector,
+  ConnectorDict,
   IngestPipelineErrors,
   InputMapEntry,
   MapFormValue,
@@ -1153,4 +1154,69 @@ function sanitizeBooleanInput(formField: any): boolean {
 
 export function formatRouteServiceError(e: any, prefix: string) {
   return `${prefix}: ${e.body?.message ?? e.message ?? 'Unknown error'}`;
+}
+
+// Resolve a model's connector, whether embedded or referenced by ID.
+function getConnectorForModel(
+  model: { connector?: Partial<Connector>; connectorId?: string },
+  connectors: ConnectorDict
+): Partial<Connector> | undefined {
+  if (!isEmpty(model?.connector)) {
+    return model.connector;
+  }
+  if (model?.connectorId && connectors[model.connectorId]) {
+    return connectors[model.connectorId];
+  }
+  return undefined;
+}
+
+// Returns true if the model is confidently identified as an LLM.
+export function isKnownLLM(
+  model: { connector?: Partial<Connector>; connectorId?: string },
+  connectors: ConnectorDict
+): boolean {
+  const connector = getConnectorForModel(model, connectors);
+  if (!connector) return false;
+  const modelName = (get(connector, 'parameters.model', '') as string).toLowerCase();
+  const url = (get(connector, 'actions[0].url', '') as string).toLowerCase();
+  const llmModelPatterns = ['gpt', 'claude', 'deepseek', 'llama', 'mistral', 'command'];
+  const llmUrlPatterns = ['chat/completions', '/converse'];
+  return (
+    llmModelPatterns.some((p) => modelName.includes(p)) ||
+    llmUrlPatterns.some((p) => url.includes(p))
+  );
+}
+
+// Returns true if the model is confidently identified as an embedding model.
+export function isKnownEmbeddingModel(
+  model: { connector?: Partial<Connector>; connectorId?: string },
+  connectors: ConnectorDict
+): boolean {
+  const connector = getConnectorForModel(model, connectors);
+  if (!connector) return false;
+  const modelName = get(connector, 'parameters.model', '') as string;
+  const baseModelName = modelName.replace(/:[^:]+$/, '');
+  const url = (get(connector, 'actions[0].url', '') as string).toLowerCase();
+  const embeddingUrlPatterns = ['/embed'];
+  const embeddingNamePatterns = ['embed'];
+  return (
+    // @ts-ignore
+    BEDROCK_CONFIGS[modelName] !== undefined ||
+    // @ts-ignore
+    BEDROCK_CONFIGS[baseModelName] !== undefined ||
+    // @ts-ignore
+    COHERE_CONFIGS[modelName] !== undefined ||
+    // @ts-ignore
+    COHERE_CONFIGS[baseModelName] !== undefined ||
+    // @ts-ignore
+    OPENAI_CONFIGS[modelName] !== undefined ||
+    // @ts-ignore
+    OPENAI_CONFIGS[baseModelName] !== undefined ||
+    // @ts-ignore
+    NEURAL_SPARSE_CONFIGS[modelName] !== undefined ||
+    // @ts-ignore
+    NEURAL_SPARSE_CONFIGS[baseModelName] !== undefined ||
+    embeddingNamePatterns.some((p) => modelName.toLowerCase().includes(p)) ||
+    embeddingUrlPatterns.some((p) => url.includes(p))
+  );
 }


### PR DESCRIPTION
### Description

Adds an optional embedding model ID configuration to the agentic search UI, enabling the LLM to generate neural queries for semantic search. Also improves filtering on the model dropdowns for LLMs and embedding models, to filter out any known LLMs under embedding models, and vice versa.

### Changes

**Shared utils** (`public/utils/utils.tsx`):
- `isKnownLLM(model, connectors)` — identifies known LLMs via connector model name/URL patterns
- `isKnownEmbeddingModel(model, connectors)` — identifies known embedding models via config maps, version suffix stripping (e.g., `amazon.titan-embed-text-v2:0` → `amazon.titan-embed-text-v2`), and URL/name-based pattern matching
- Exclusion-based filtering: known LLMs hidden from embedding dropdown, known embedding models hidden from LLM dropdown. Unknown models appear in both (safe default).

**Constants** (`common/constants.ts`):
- `EMBEDDING_MODEL_LABEL`, `EMBEDDING_MODEL_HELP_TEXT`, `NONE_OPTION` — shared across both agent type forms

**Flow agents** (`public/.../tool_forms/query_planning_tool.tsx`):
- Embedding model selector below generation type, sets `tools[n].parameters.embedding_model_id`
- LLM selector now filters out known embedding models
- "- None -" option to clear the selection

**Conversational agents** (`public/.../agent_advanced_settings.tsx`, `public/.../agent_llm_fields.tsx`):
- Embedding model selector in Advanced Settings (below LLM interface), sets `llm.parameters.embedding_model_id`
- LLM selector now filters out known embedding models
- "- None -" option to clear the selection

### Issues Resolved

Resolves #867

### Testing

**Unit tests:** All 319 tests pass across 36 suites, no regressions.

New tests:
- `model_filtering.test.tsx` — 9 tests covering isKnownLLM/isKnownEmbeddingModel for LLM-only, embedding-only, unknown models, connector resolution, edge cases, version suffix stripping, and URL-based detection
- `agent_advanced_settings.test.tsx` — embedding model field renders for conversational agents
- `agent_tools.test.tsx` — embedding model field renders for flow agents

**End-to-end validation:**
1. Set up a local stack following the [agentic search neural search documentation](https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/neural-search/) with Bedrock Claude 4 Sonnet (LLM) and Bedrock Titan Embedding V2 (embedding)
2. Created a vector index with `knn_vector` field, ingest pipeline with text embedding processor, and ingested 10 ecommerce documents with auto-generated embeddings
3. **Flow agent**: confirmed LLM only appears in LLM dropdown, embedding model only in embedding dropdown. Selected embedding model, ran agentic search — agent generated hybrid DSL combining `multi_match` (keyword) + `neural` (semantic) queries using the embedding model ID. Search returned semantically relevant results.
4. **Conversational agent**: confirmed embedding model appears in Advanced Settings below LLM interface. Verified embedding model ID persists in agent config (`llm.parameters.embedding_model_id`).
5. Verified "- None -" option clears the embedding model ID from the agent config

Screenshot (new form field, flow agent)

<img width="1250" height="318" alt="Screenshot 2026-04-13 at 11 25 18 AM" src="https://github.com/user-attachments/assets/e69c43a8-4237-4b6e-a889-d4209493d9ae" />

Screenshot (new form field, conv agent)

<img width="1251" height="264" alt="Screenshot 2026-04-13 at 11 25 48 AM" src="https://github.com/user-attachments/assets/d0b66af0-ef96-42fa-ba07-64346e2c197c" />

Screenshot (e2e testing)

<img width="2549" height="1174" alt="Screenshot 2026-04-13 at 10 57 53 AM" src="https://github.com/user-attachments/assets/3c2f4b5a-bcf8-4df4-abc1-dc1e532790af" />

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`