### PR TITLE
Fix flaky tests by replacing singleton store with mock store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 ### Infrastructure
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))
+- Fix flaky tests by replacing singleton store with mock store ([#878](https://github.com/opensearch-project/dashboards-flow-framework/pull/878))
 ### Documentation
 - Fix broken tutorial link in README ([#860](https://github.com/opensearch-project/dashboards-flow-framework/pull/860))
 ### Maintenance

--- a/public/pages/workflows/import_workflow/import_workflow_modal.test.tsx
+++ b/public/pages/workflows/import_workflow/import_workflow_modal.test.tsx
@@ -7,7 +7,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { store } from '../../../store';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import {
+  INITIAL_OPENSEARCH_STATE,
+  INITIAL_WORKFLOWS_STATE,
+  INITIAL_PRESETS_STATE,
+  INITIAL_ML_STATE,
+  INITIAL_ERRORS_STATE,
+} from '../../../store';
 import { ImportWorkflowModal } from './import_workflow_modal';
 
 jest.mock('../../../services', () => {
@@ -18,8 +26,18 @@ jest.mock('../../../services', () => {
   };
 });
 
-const renderWithRouter = () =>
-  render(
+const mockConfigureStore = configureStore([thunk]);
+const initialState = {
+  opensearch: INITIAL_OPENSEARCH_STATE,
+  workflows: INITIAL_WORKFLOWS_STATE,
+  presets: INITIAL_PRESETS_STATE,
+  ml: INITIAL_ML_STATE,
+  errors: INITIAL_ERRORS_STATE,
+};
+
+const renderWithRouter = () => {
+  const store = mockConfigureStore(initialState);
+  return render(
     <Provider store={store}>
       <Router>
         <Switch>
@@ -36,6 +54,7 @@ const renderWithRouter = () =>
       </Router>
     </Provider>
   );
+};
 
 describe('ImportWorkflowModal', () => {
   beforeEach(() => {

--- a/public/pages/workflows/workflows.test.tsx
+++ b/public/pages/workflows/workflows.test.tsx
@@ -14,7 +14,15 @@ import {
   Route,
   Switch,
 } from 'react-router-dom';
-import { store } from '../../store';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import {
+  INITIAL_OPENSEARCH_STATE,
+  INITIAL_WORKFLOWS_STATE,
+  INITIAL_PRESETS_STATE,
+  INITIAL_ML_STATE,
+  INITIAL_ERRORS_STATE,
+} from '../../store';
 import { Workflows } from './workflows';
 
 jest.mock('../../services', () => {
@@ -25,21 +33,33 @@ jest.mock('../../services', () => {
   };
 });
 
-const renderWithRouter = () => ({
-  ...render(
-    <Provider store={store}>
-      <Router>
-        <Switch>
-          <Route
-            render={(props: RouteComponentProps) => (
-              <Workflows setActionMenu={jest.fn()} {...props} />
-            )}
-          />
-        </Switch>
-      </Router>
-    </Provider>
-  ),
-});
+const mockConfigureStore = configureStore([thunk]);
+const initialState = {
+  opensearch: INITIAL_OPENSEARCH_STATE,
+  workflows: INITIAL_WORKFLOWS_STATE,
+  presets: INITIAL_PRESETS_STATE,
+  ml: INITIAL_ML_STATE,
+  errors: INITIAL_ERRORS_STATE,
+};
+
+const renderWithRouter = () => {
+  const store = mockConfigureStore(initialState);
+  return {
+    ...render(
+      <Provider store={store}>
+        <Router>
+          <Switch>
+            <Route
+              render={(props: RouteComponentProps) => (
+                <Workflows setActionMenu={jest.fn()} {...props} />
+              )}
+            />
+          </Switch>
+        </Router>
+      </Provider>
+    ),
+  };
+};
 
 describe('Workflows', () => {
   beforeEach(() => {


### PR DESCRIPTION
### Description

Fixes flaky test failures in `workflows.test.tsx` and `import_workflow_modal.test.tsx` caused by shared Redux store state leaking between test suites.

### Changes

- Replace the real Redux `store` singleton import with `redux-mock-store` + `thunk` middleware in both test files
- Each test now creates a fresh store with clean initial state, matching the pattern used by all other stable tests in the repo

### Root Cause

Both test files imported the real `store` singleton from `../../store`. When other test suites ran first in the same Jest worker, their dispatched actions mutated the shared store state (e.g., leaving `loading: true`), causing the `Workflows` component to render differently and fail assertions.

### Testing

All 127 tests across 23 suites pass consistently across multiple full suite runs.

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`