### PR TITLE
Add agentic memory support for conversational agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add index alias support in agentic search UI ([#871](https://github.com/opensearch-project/dashboards-flow-framework/pull/871))
 - Add fallback query configuration for QueryPlanningTool ([#872](https://github.com/opensearch-project/dashboards-flow-framework/pull/872))
 - Add embedding model ID configuration for agentic search ([#875](https://github.com/opensearch-project/dashboards-flow-framework/pull/875))
+- Add agentic memory support for conversational agents ([#883](https://github.com/opensearch-project/dashboards-flow-framework/pull/883))
 ### Bug Fixes
 ### Infrastructure
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -36,6 +36,8 @@ export const ML_SEARCH_MODELS_ROUTE = `${ML_MODEL_ROUTE_PREFIX}/_search`;
 export const ML_SEARCH_CONNECTORS_ROUTE = `${ML_CONNECTOR_ROUTE_PREFIX}/_search`;
 export const ML_REGISTER_AGENT_ROUTE = `${ML_AGENT_ROUTE_PREFIX}/_register`;
 export const ML_SEARCH_AGENTS_ROUTE = `${ML_AGENT_ROUTE_PREFIX}/_search`;
+export const ML_MEMORY_CONTAINER_ROUTE_PREFIX = `${ML_API_ROUTE_PREFIX}/memory_containers`;
+export const ML_SEARCH_MEMORY_CONTAINERS_ROUTE = `${ML_MEMORY_CONTAINER_ROUTE_PREFIX}/_search`;
 export const ML_GET_AGENT_ROUTE = `${ML_AGENT_ROUTE_PREFIX}/{agentId}`;
 
 /**
@@ -80,6 +82,8 @@ export const BASE_CONNECTOR_NODE_API_PATH = `${BASE_NODE_API_PATH}/connector`;
 export const BASE_AGENT_NODE_API_PATH = `${BASE_NODE_API_PATH}/agent`;
 export const SEARCH_MODELS_NODE_API_PATH = `${BASE_MODEL_NODE_API_PATH}/search`;
 export const SEARCH_CONNECTORS_NODE_API_PATH = `${BASE_CONNECTOR_NODE_API_PATH}/search`;
+export const BASE_MEMORY_CONTAINER_NODE_API_PATH = `${BASE_NODE_API_PATH}/memory_container`;
+export const SEARCH_MEMORY_CONTAINERS_NODE_API_PATH = `${BASE_MEMORY_CONTAINER_NODE_API_PATH}/search`;
 export const REGISTER_AGENT_NODE_API_PATH = `${BASE_AGENT_NODE_API_PATH}/register`;
 export const UPDATE_AGENT_NODE_API_PATH = `${BASE_AGENT_NODE_API_PATH}/update`;
 export const SEARCH_AGENTS_NODE_API_PATH = `${BASE_AGENT_NODE_API_PATH}/search`;
@@ -349,7 +353,7 @@ export const AGENT_FIELDS_DOCS_LINK =
 export const TOOLS_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/';
 export const MEMORY_DOCS_LINK =
-  'https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/';
+  'https://docs.opensearch.org/latest/ml-commons-plugin/api/index/#memory-apis-comparison';
 export const QUERY_PLANNING_TOOL_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/query-planning-tool#register-parameters';
 export const QUERY_PLANNING_MODEL_DOCS_LINK =
@@ -357,6 +361,9 @@ export const QUERY_PLANNING_MODEL_DOCS_LINK =
 export const EMBEDDING_MODEL_LABEL = 'Embedding model';
 export const EMBEDDING_MODEL_HELP_TEXT =
   'Enables the LLM to generate neural queries for semantic search.';
+export const NO_DEPLOYED_LLMS_TEXT = 'No deployed large language models found';
+export const NO_DEPLOYED_EMBEDDING_MODELS_TEXT =
+  'No deployed embedding models found';
 export const NONE_OPTION = { value: '', text: '- None -' };
 export const WEB_SEARCH_TOOL_DOCS_LINK =
   'https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/web-search-tool/#register-parameters';
@@ -1084,6 +1091,7 @@ export enum TOOL_DESCRIPTION {
 // Derived from https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/register-agent/
 export enum AGENT_MEMORY_TYPE {
   CONVERSATION_INDEX = 'conversation_index',
+  AGENTIC_MEMORY = 'agentic_memory',
 }
 
 export enum CONNECTOR_PROTOCOL {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -512,6 +512,15 @@ export type ConnectorDict = {
   [connectorId: string]: Connector;
 };
 
+export type MemoryContainer = {
+  id: string;
+  name: string;
+};
+
+export type MemoryContainerDict = {
+  [containerId: string]: MemoryContainer;
+};
+
 export type MCPConnector = {
   mcp_connector_id: string;
   tool_filters: string[];
@@ -536,6 +545,7 @@ export type AgentLLM = {
 
 export type AgentMemory = {
   type: AGENT_MEMORY_TYPE;
+  memory_container_id?: string;
 };
 
 export type Agent = {

--- a/public/pages/workflow_detail/agentic_search/agentic_search_components.test.tsx
+++ b/public/pages/workflow_detail/agentic_search/agentic_search_components.test.tsx
@@ -6,9 +6,34 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import { AgenticSearchInfoModal } from './components/agentic_search_info_modal';
 import { AgentMemory } from './configure_flow/agent_memory';
 import { AGENT_MEMORY_TYPE } from '../../../../common';
+import { INITIAL_ML_STATE } from '../../../store';
+
+// Mock services to avoid UISettings error
+jest.mock('../../../services', () => {
+  const { mockCoreServices } = require('../../../../test/mocks');
+  return {
+    ...jest.requireActual('../../../services'),
+    ...mockCoreServices,
+  };
+});
+
+const mockStore = configureStore([]);
+const store = mockStore({
+  ml: {
+    ...INITIAL_ML_STATE,
+    memoryContainers: {
+      'container-1': { id: 'container-1', name: 'Test Container' },
+    },
+  },
+});
+
+const renderWithStore = (ui: React.ReactElement) =>
+  render(<Provider store={store}>{ui}</Provider>);
 
 describe('AgenticSearchInfoModal', () => {
   test('renders modal title and content', () => {
@@ -31,14 +56,14 @@ describe('AgenticSearchInfoModal', () => {
 
 describe('AgentMemory', () => {
   test('renders memory type selector', () => {
-    render(
+    renderWithStore(
       <AgentMemory agentForm={{}} setAgentForm={jest.fn()} />
     );
     expect(screen.getByLabelText('Select memory type')).toBeInTheDocument();
   });
 
   test('renders conversation index option', () => {
-    render(
+    renderWithStore(
       <AgentMemory
         agentForm={{ memory: { type: AGENT_MEMORY_TYPE.CONVERSATION_INDEX } }}
         setAgentForm={jest.fn()}
@@ -49,12 +74,96 @@ describe('AgentMemory', () => {
 
   test('calls setAgentForm on change', () => {
     const mockSetForm = jest.fn();
-    render(
+    renderWithStore(
       <AgentMemory agentForm={{}} setAgentForm={mockSetForm} />
     );
     fireEvent.change(screen.getByLabelText('Select memory type'), {
       target: { value: AGENT_MEMORY_TYPE.CONVERSATION_INDEX },
     });
     expect(mockSetForm).toHaveBeenCalled();
+  });
+
+  test('shows container dropdown when agentic memory is selected', () => {
+    renderWithStore(
+      <AgentMemory
+        agentForm={{ memory: { type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY } }}
+        setAgentForm={jest.fn()}
+      />
+    );
+    expect(screen.getByLabelText('Select memory container')).toBeInTheDocument();
+    expect(screen.getByText('Test Container')).toBeInTheDocument();
+  });
+
+  test('does not show container dropdown for conversation index', () => {
+    renderWithStore(
+      <AgentMemory
+        agentForm={{ memory: { type: AGENT_MEMORY_TYPE.CONVERSATION_INDEX } }}
+        setAgentForm={jest.fn()}
+      />
+    );
+    expect(screen.queryByLabelText('Select memory container')).toBeNull();
+  });
+
+  test('calls setAgentForm with memory_container_id on container selection', () => {
+    const mockSetForm = jest.fn();
+    renderWithStore(
+      <AgentMemory
+        agentForm={{ memory: { type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY } }}
+        setAgentForm={mockSetForm}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Select memory container'), {
+      target: { value: 'container-1' },
+    });
+    expect(mockSetForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memory: expect.objectContaining({
+          type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY,
+          memory_container_id: 'container-1',
+        }),
+      })
+    );
+  });
+
+  test('disables dropdowns when readOnly is true', () => {
+    renderWithStore(
+      <AgentMemory
+        agentForm={{
+          memory: {
+            type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY,
+            memory_container_id: 'container-1',
+          },
+        }}
+        setAgentForm={jest.fn()}
+        readOnly={true}
+      />
+    );
+    expect(screen.getByLabelText('Select memory type')).toBeDisabled();
+    expect(screen.getByLabelText('Select memory container')).toBeDisabled();
+  });
+
+  test('agentic memory without container ID should be considered invalid', () => {
+    // This mirrors the validation in configure_flow.tsx:
+    // agentForm.memory.type === AGENTIC_MEMORY && isEmpty(memory_container_id)
+    const agentFormNoContainer = {
+      memory: { type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY },
+    };
+    const agentFormWithContainer = {
+      memory: {
+        type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY,
+        memory_container_id: 'container-1',
+      },
+    };
+    const agentFormConversation = {
+      memory: { type: AGENT_MEMORY_TYPE.CONVERSATION_INDEX },
+    };
+
+    const isInvalid = (form: any) =>
+      form?.memory?.type === AGENT_MEMORY_TYPE.AGENTIC_MEMORY &&
+      !form?.memory?.memory_container_id;
+
+    expect(isInvalid(agentFormNoContainer)).toBe(true);
+    expect(isInvalid(agentFormWithContainer)).toBe(false);
+    expect(isInvalid(agentFormConversation)).toBe(false);
   });
 });

--- a/public/pages/workflow_detail/agentic_search/components/no_deployed_models_callout.tsx
+++ b/public/pages/workflow_detail/agentic_search/components/no_deployed_models_callout.tsx
@@ -7,17 +7,18 @@ import React from 'react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { AGENTIC_SEARCH_DOCS_LINK } from '../../../../../common';
 
+interface NoDeployedModelsCalloutProps {
+  title?: string;
+}
+
 /**
  * Basic callout component with links to documentation.
  */
-export function NoDeployedModelsCallout({}) {
+export function NoDeployedModelsCallout({
+  title = 'No deployed models found',
+}: NoDeployedModelsCalloutProps) {
   return (
-    <EuiCallOut
-      size="s"
-      color="warning"
-      iconType={'alert'}
-      title="No deployed models found"
-    >
+    <EuiCallOut size="s" color="warning" iconType={'alert'} title={title}>
       Deploy models compatible with agentic search. For more information, see
       the{' '}
       <EuiLink target="_blank" href={AGENTIC_SEARCH_DOCS_LINK}>

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_advanced_settings.tsx
@@ -8,7 +8,9 @@ import { useSelector } from 'react-redux';
 import { getIn } from 'formik';
 import { cloneDeep, isEmpty, set } from 'lodash';
 import {
+  EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiSpacer,
   EuiFormRow,
   EuiAccordion,
@@ -16,6 +18,7 @@ import {
   EuiLink,
   EuiComboBox,
   EuiSelect,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   Agent,
@@ -29,6 +32,7 @@ import {
   MEMORY_DOCS_LINK,
   MODEL_STATE,
   ModelDict,
+  NO_DEPLOYED_EMBEDDING_MODELS_TEXT,
   NONE_OPTION,
 } from '../../../../../common';
 import { AgentMemory } from './agent_memory';
@@ -39,6 +43,7 @@ import { NoDeployedModelsCallout } from '../components';
 interface AgentAdvancedSettingsProps {
   agentForm: Partial<Agent>;
   setAgentForm: (agentForm: Partial<Agent>) => void;
+  isNewAgent?: boolean;
 }
 
 const LLM_INTERFACE_OPTIONS = Object.values(AGENT_LLM_INTERFACE_TYPE).map(
@@ -86,7 +91,11 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
         ...props.agentForm,
         parameters: {
           ...props.agentForm?.parameters,
-          _llm_interface: getRelevantInterface(agentModelId, models, connectors),
+          _llm_interface: getRelevantInterface(
+            agentModelId,
+            models,
+            connectors
+          ),
         },
       });
     }
@@ -103,7 +112,24 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
         <>
           <EuiFlexItem grow={false}>
             <EuiFormRow
-              label={'Memory'}
+              label={
+                <EuiFlexGroup gutterSize="xs" alignItems="center">
+                  <EuiFlexItem grow={false}>Memory</EuiFlexItem>
+                  <EuiFlexItem grow={false} style={{ marginTop: '-2px' }}>
+                    <EuiToolTip
+                      content={
+                        'Memory type cannot be changed after agent creation.'
+                      }
+                    >
+                      <EuiIcon
+                        type={props.isNewAgent ? 'lockOpen' : 'lock'}
+                        size="s"
+                        color="subdued"
+                      />
+                    </EuiToolTip>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
               labelAppend={
                 <EuiText size="xs">
                   <EuiLink href={MEMORY_DOCS_LINK} target="_blank">
@@ -116,6 +142,7 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
               <AgentMemory
                 agentForm={props.agentForm}
                 setAgentForm={props.setAgentForm}
+                readOnly={!props.isNewAgent}
               />
             </EuiFormRow>
           </EuiFlexItem>
@@ -168,25 +195,33 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
           <EuiSpacer size="s" />
           <EuiFlexItem grow={false}>
             <EuiFormRow
-              label={<>{EMBEDDING_MODEL_LABEL}<i> - optional</i></>}
+              label={
+                <>
+                  {EMBEDDING_MODEL_LABEL}
+                  <i> - optional</i>
+                </>
+              }
               helpText={EMBEDDING_MODEL_HELP_TEXT}
               data-testid="embeddingModelField"
               fullWidth
             >
               <>
                 {embeddingModelOptions.length === 0 ? (
-                  <NoDeployedModelsCallout />
+                  <NoDeployedModelsCallout
+                    title={NO_DEPLOYED_EMBEDDING_MODELS_TEXT}
+                  />
                 ) : (
                   <EuiSelect
-                    options={[
-                      NONE_OPTION,
-                      ...embeddingModelOptions,
-                    ]}
+                    options={[NONE_OPTION, ...embeddingModelOptions]}
                     value={selectedEmbeddingModelId}
                     onChange={(e) => {
                       let updatedAgentForm = cloneDeep(props.agentForm);
                       if (e.target.value === '') {
-                        const params = getIn(updatedAgentForm, 'llm.parameters', {});
+                        const params = getIn(
+                          updatedAgentForm,
+                          'llm.parameters',
+                          {}
+                        );
                         delete params.embedding_model_id;
                         set(updatedAgentForm, 'llm.parameters', params);
                       } else {
@@ -214,7 +249,9 @@ export function AgentAdvancedSettings(props: AgentAdvancedSettingsProps) {
 }
 
 // Basic util fn to hide the interface complexity, and just display the model provider/company
-export function getReadableInterface(interfaceType: AGENT_LLM_INTERFACE_TYPE): string {
+export function getReadableInterface(
+  interfaceType: AGENT_LLM_INTERFACE_TYPE
+): string {
   switch (interfaceType) {
     case AGENT_LLM_INTERFACE_TYPE.OPENAI:
       return 'OpenAI';

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_configuration.tsx
@@ -547,6 +547,7 @@ export function AgentConfiguration(props: AgentConfigurationProps) {
                                 <AgentAdvancedSettings
                                   agentForm={props.agentForm}
                                   setAgentForm={props.setAgentForm}
+                                  isNewAgent={props.newAndUnsaved}
                                 />
                               </EuiFlexItem>
                             </>

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_llm_fields.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_llm_fields.tsx
@@ -16,6 +16,7 @@ import {
   Model,
   MODEL_STATE,
   ModelDict,
+  NO_DEPLOYED_LLMS_TEXT,
   Tool,
   TOOL_TYPE,
 } from '../../../../../common';
@@ -86,7 +87,7 @@ export function AgentLLMFields({
     >
       <>
         {modelOptions.length === 0 ? (
-          <NoDeployedModelsCallout />
+          <NoDeployedModelsCallout title={NO_DEPLOYED_LLMS_TEXT} />
         ) : (
           <EuiSelect
             key={selectedModelId}

--- a/public/pages/workflow_detail/agentic_search/configure_flow/agent_memory.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/agent_memory.tsx
@@ -4,28 +4,58 @@
  */
 
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { getIn } from 'formik';
 import { isEmpty } from 'lodash';
-import { EuiFlexGroup, EuiFlexItem, EuiSelect } from '@elastic/eui';
-import { Agent, AGENT_MEMORY_TYPE } from '../../../../../common';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiIcon,
+  EuiSelect,
+  EuiSpacer,
+  EuiToolTip,
+} from '@elastic/eui';
+import {
+  Agent,
+  AGENT_MEMORY_TYPE,
+  AgentMemory as AgentMemoryType,
+} from '../../../../../common';
+import { AppState } from '../../../../store';
 
 interface AgentMemoryProps {
   agentForm: Partial<Agent>;
   setAgentForm: (agentForm: Partial<Agent>) => void;
+  readOnly?: boolean;
 }
 
 const CONVERSATION_INDEX_DISPLAY_TEXT = 'Conversation index';
+const AGENTIC_MEMORY_DISPLAY_TEXT = 'Agentic memory';
 
 /**
  * The general component containing all of the memory-related fields for an agent.
  */
-export function AgentMemory({ agentForm, setAgentForm }: AgentMemoryProps) {
+export function AgentMemory({
+  agentForm,
+  setAgentForm,
+  readOnly,
+}: AgentMemoryProps) {
   const memoryForm = getIn(agentForm, 'memory.type', '');
+  const memoryContainerId = getIn(agentForm, 'memory.memory_container_id', '');
+  const { memoryContainers } = useSelector((state: AppState) => state.ml);
+  const containerOptions = Object.values(memoryContainers || {}).map(
+    (container) => ({
+      value: container.id,
+      text: container.name || container.id,
+    })
+  );
   const memoryOptions = Object.values(AGENT_MEMORY_TYPE).map((memoryType) => ({
     value: memoryType,
     text:
       memoryType === AGENT_MEMORY_TYPE.CONVERSATION_INDEX
         ? CONVERSATION_INDEX_DISPLAY_TEXT
+        : memoryType === AGENT_MEMORY_TYPE.AGENTIC_MEMORY
+        ? AGENTIC_MEMORY_DISPLAY_TEXT
         : memoryType,
   }));
   const memoryFound = memoryOptions.some(
@@ -34,39 +64,90 @@ export function AgentMemory({ agentForm, setAgentForm }: AgentMemoryProps) {
   const memoryEmpty = isEmpty(memoryForm);
 
   return (
-    <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
-      <EuiFlexItem>
-        <EuiSelect
-          key={memoryForm}
-          options={
-            memoryFound || memoryEmpty
-              ? memoryOptions
-              : [
-                  ...memoryOptions,
-                  {
-                    value: memoryForm,
-                    text: `Unknown memory type: ${memoryForm}`,
-                  },
-                ]
-          }
-          value={memoryForm}
-          onChange={(e) => {
-            setAgentForm({
-              ...agentForm,
-              memory: {
-                ...agentForm?.memory,
-                type: (e.target.value as string) as AGENT_MEMORY_TYPE,
-              },
-            });
-          }}
-          aria-label="Select memory type"
-          placeholder="Select a memory type"
-          hasNoInitialSelection={true}
-          isInvalid={!memoryFound && !memoryEmpty}
-          fullWidth
-          compressed
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <>
+      <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+        <EuiFlexItem>
+          <EuiSelect
+            key={memoryForm}
+            options={
+              memoryFound || memoryEmpty
+                ? memoryOptions
+                : [
+                    ...memoryOptions,
+                    {
+                      value: memoryForm,
+                      text: `Unknown memory type: ${memoryForm}`,
+                    },
+                  ]
+            }
+            value={memoryForm}
+            onChange={(e) => {
+              const newType = e.target.value as AGENT_MEMORY_TYPE;
+              const memory: AgentMemoryType = { type: newType };
+              if (
+                newType === AGENT_MEMORY_TYPE.AGENTIC_MEMORY &&
+                memoryContainerId
+              ) {
+                memory.memory_container_id = memoryContainerId;
+              }
+              setAgentForm({ ...agentForm, memory });
+            }}
+            aria-label="Select memory type"
+            placeholder="Select a memory type"
+            hasNoInitialSelection={true}
+            isInvalid={!memoryFound && !memoryEmpty}
+            disabled={readOnly}
+            fullWidth
+            compressed
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {memoryForm === AGENT_MEMORY_TYPE.AGENTIC_MEMORY && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={
+              <EuiFlexGroup gutterSize="xs" alignItems="center">
+                <EuiFlexItem grow={false}>Memory container</EuiFlexItem>
+                <EuiFlexItem grow={false} style={{ marginTop: '-2px' }}>
+                  <EuiToolTip
+                    content={
+                      'Memory container cannot be changed after agent creation.'
+                    }
+                  >
+                    <EuiIcon
+                      type={readOnly ? 'lock' : 'lockOpen'}
+                      size="s"
+                      color="subdued"
+                    />
+                  </EuiToolTip>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            }
+            fullWidth
+          >
+            <EuiSelect
+              options={containerOptions}
+              value={memoryContainerId}
+              onChange={(e) => {
+                const value = e.target.value;
+                const memory: AgentMemoryType = {
+                  type: AGENT_MEMORY_TYPE.AGENTIC_MEMORY,
+                };
+                if (value) {
+                  memory.memory_container_id = value;
+                }
+                setAgentForm({ ...agentForm, memory });
+              }}
+              aria-label="Select memory container"
+              hasNoInitialSelection={isEmpty(memoryContainerId)}
+              disabled={readOnly}
+              fullWidth
+              compressed
+            />
+          </EuiFormRow>
+        </>
+      )}
+    </>
   );
 }

--- a/public/pages/workflow_detail/agentic_search/configure_flow/configure_flow.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/configure_flow.tsx
@@ -19,6 +19,7 @@ import {
 import {
   Agent,
   AGENT_ID_PATH,
+  AGENT_MEMORY_TYPE,
   AGENT_TYPE,
   EMPTY_AGENT,
   MCPConnector,
@@ -110,7 +111,11 @@ export function ConfigureFlow(props: ConfigureFlowProps) {
           ?.parameters?.model_id
       )) ||
     (agentMCPServers.length > 0 &&
-      agentMCPServers.some((mcpServer) => isEmpty(mcpServer.mcp_connector_id)));
+      agentMCPServers.some((mcpServer) =>
+        isEmpty(mcpServer.mcp_connector_id)
+      )) ||
+    (agentForm?.memory?.type === AGENT_MEMORY_TYPE.AGENTIC_MEMORY &&
+      isEmpty(agentForm?.memory?.memory_container_id));
 
   // fine-grained error handling states
   const [errorCreatingAgent, setErrorCreatingAgent] = useState<string>('');

--- a/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
+++ b/public/pages/workflow_detail/agentic_search/configure_flow/tool_forms/query_planning_tool.tsx
@@ -29,6 +29,8 @@ import {
   EMBEDDING_MODEL_LABEL,
   Model,
   MODEL_STATE,
+  NO_DEPLOYED_EMBEDDING_MODELS_TEXT,
+  NO_DEPLOYED_LLMS_TEXT,
   NONE_OPTION,
   QUERY_PLANNING_MODEL_DOCS_LINK,
   QUERY_PLANNING_TOOL_DOCS_LINK,
@@ -230,7 +232,7 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
         >
           <>
             {modelOptions.length === 0 ? (
-              <NoDeployedModelsCallout />
+              <NoDeployedModelsCallout title={NO_DEPLOYED_LLMS_TEXT} />
             ) : (
               <EuiSelect
                 key={selectedModelId}
@@ -296,20 +298,22 @@ export function QueryPlanningTool(props: QueryPlanningToolProps) {
       </EuiFormRow>
       {agentType === AGENT_TYPE.FLOW && (
         <EuiFormRow
-          label={<>{EMBEDDING_MODEL_LABEL}<i> - optional</i></>}
+          label={
+            <>
+              {EMBEDDING_MODEL_LABEL}
+              <i> - optional</i>
+            </>
+          }
           helpText={EMBEDDING_MODEL_HELP_TEXT}
           data-testid="embeddingModelField"
           fullWidth
         >
           <>
             {embeddingModelOptions.length === 0 ? (
-              <NoDeployedModelsCallout />
+              <NoDeployedModelsCallout title={NO_DEPLOYED_EMBEDDING_MODELS_TEXT} />
             ) : (
               <EuiSelect
-                options={[
-                  NONE_OPTION,
-                  ...embeddingModelOptions,
-                ]}
+                options={[NONE_OPTION, ...embeddingModelOptions]}
                 value={toolForm?.parameters?.embedding_model_id || ''}
                 onChange={(e) => {
                   const value = e.target.value;

--- a/public/pages/workflow_detail/workflow_detail.tsx
+++ b/public/pages/workflow_detail/workflow_detail.tsx
@@ -33,6 +33,7 @@ import {
   catIndices,
   getWorkflow,
   searchConnectors,
+  searchMemoryContainers,
   searchModels,
   getSearchTemplates,
   setIngestPipelineErrors,
@@ -94,6 +95,9 @@ export function WorkflowDetail(props: WorkflowDetailProps) {
     dispatch(searchModels({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId }));
     dispatch(
       searchConnectors({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId })
+    );
+    dispatch(
+      searchMemoryContainers({ apiBody: FETCH_ALL_QUERY_LARGE, dataSourceId })
     );
     dispatch(catIndices({ pattern: OMIT_SYSTEM_INDEX_PATTERN, dataSourceId }));
     dispatch(getSearchTemplates({ dataSourceId }));

--- a/public/route_service.ts
+++ b/public/route_service.ts
@@ -26,6 +26,7 @@ import {
   BULK_NODE_API_PATH,
   BASE_NODE_API_PATH,
   SEARCH_CONNECTORS_NODE_API_PATH,
+  SEARCH_MEMORY_CONTAINERS_NODE_API_PATH,
   GET_MAPPINGS_NODE_API_PATH,
   SEARCH_PIPELINE_NODE_API_PATH,
   INGEST_PIPELINE_NODE_API_PATH,
@@ -107,6 +108,7 @@ export interface RouteService {
   }) => Promise<any>;
   searchModels: (body: {}, dataSourceId?: string) => Promise<any>;
   searchConnectors: (body: {}, dataSourceId?: string) => Promise<any>;
+  searchMemoryContainers: (body: {}, dataSourceId?: string) => Promise<any>;
   registerAgent: (body: {}, dataSourceId?: string) => Promise<any>;
   updateAgent: (
     agentId: string,
@@ -437,6 +439,19 @@ export function configureRoutes(core: CoreStart): RouteService {
         const url = dataSourceId
           ? `${BASE_NODE_API_PATH}/${dataSourceId}/connector/search`
           : SEARCH_CONNECTORS_NODE_API_PATH;
+        const response = await core.http.post<{ respString: string }>(url, {
+          body: JSON.stringify(body),
+        });
+        return response;
+      } catch (e: any) {
+        throw e;
+      }
+    },
+    searchMemoryContainers: async (body: {}, dataSourceId?: string) => {
+      try {
+        const url = dataSourceId
+          ? `${BASE_NODE_API_PATH}/${dataSourceId}/memory_container/search`
+          : SEARCH_MEMORY_CONTAINERS_NODE_API_PATH;
         const response = await core.http.post<{ respString: string }>(url, {
           body: JSON.stringify(body),
         });

--- a/public/store/reducers/ml_reducer.ts
+++ b/public/store/reducers/ml_reducer.ts
@@ -4,7 +4,13 @@
  */
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { Agent, AgentDict, ConnectorDict, ModelDict } from '../../../common';
+import {
+  Agent,
+  AgentDict,
+  ConnectorDict,
+  MemoryContainerDict,
+  ModelDict,
+} from '../../../common';
 import { getRouteService } from '../../services';
 import { formatRouteServiceError } from '../../utils';
 
@@ -14,13 +20,16 @@ export const INITIAL_ML_STATE = {
   models: {} as ModelDict,
   connectors: {} as ConnectorDict,
   agents: {} as AgentDict,
+  memoryContainers: {} as MemoryContainerDict,
 };
 
 const MODELS_ACTION_PREFIX = 'models';
 const CONNECTORS_ACTION_PREFIX = 'connectors';
 const AGENTS_ACTION_PREFIX = 'agents';
+const MEMORY_CONTAINERS_ACTION_PREFIX = 'memoryContainers';
 const SEARCH_MODELS_ACTION = `${MODELS_ACTION_PREFIX}/search`;
 const SEARCH_CONNECTORS_ACTION = `${CONNECTORS_ACTION_PREFIX}/search`;
+const SEARCH_MEMORY_CONTAINERS_ACTION = `${MEMORY_CONTAINERS_ACTION_PREFIX}/search`;
 const REGISTER_AGENT_ACTION = `${AGENTS_ACTION_PREFIX}/register`;
 const UPDATE_AGENT_ACTION = `${AGENTS_ACTION_PREFIX}/update`;
 const SEARCH_AGENTS_ACTION = `${AGENTS_ACTION_PREFIX}/search`;
@@ -53,6 +62,25 @@ export const searchConnectors = createAsyncThunk(
     } catch (e) {
       return rejectWithValue(
         formatRouteServiceError(e, 'Error searching connectors')
+      );
+    }
+  }
+);
+
+export const searchMemoryContainers = createAsyncThunk(
+  SEARCH_MEMORY_CONTAINERS_ACTION,
+  async (
+    { apiBody, dataSourceId }: { apiBody: {}; dataSourceId?: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      return await getRouteService().searchMemoryContainers(
+        apiBody,
+        dataSourceId
+      );
+    } catch (e) {
+      return rejectWithValue(
+        formatRouteServiceError(e, 'Error searching memory containers')
       );
     }
   }
@@ -139,6 +167,10 @@ const mlSlice = createSlice({
         state.loading = true;
         state.errorMessage = '';
       })
+      .addCase(searchMemoryContainers.pending, (state) => {
+        state.loading = true;
+        state.errorMessage = '';
+      })
       .addCase(registerAgent.pending, (state) => {
         state.loading = true;
         state.errorMessage = '';
@@ -165,6 +197,14 @@ const mlSlice = createSlice({
       .addCase(searchConnectors.fulfilled, (state, action) => {
         const { connectors } = action.payload as { connectors: ConnectorDict };
         state.connectors = connectors;
+        state.loading = false;
+        state.errorMessage = '';
+      })
+      .addCase(searchMemoryContainers.fulfilled, (state, action) => {
+        const { memoryContainers } = action.payload as {
+          memoryContainers: MemoryContainerDict;
+        };
+        state.memoryContainers = memoryContainers;
         state.loading = false;
         state.errorMessage = '';
       })
@@ -213,6 +253,10 @@ const mlSlice = createSlice({
         state.loading = false;
       })
       .addCase(searchConnectors.rejected, (state, action) => {
+        state.errorMessage = action.payload as string;
+        state.loading = false;
+      })
+      .addCase(searchMemoryContainers.rejected, (state, action) => {
         state.errorMessage = action.payload as string;
         state.loading = false;
       })

--- a/server/cluster/ml_plugin.ts
+++ b/server/cluster/ml_plugin.ts
@@ -9,6 +9,7 @@ import {
   ML_REGISTER_AGENT_ROUTE,
   ML_SEARCH_AGENTS_ROUTE,
   ML_AGENT_ROUTE_PREFIX,
+  ML_SEARCH_MEMORY_CONTAINERS_ROUTE,
 } from '../../common';
 
 /**
@@ -80,5 +81,13 @@ export function mlPlugin(Client: any, config: any, components: any) {
       },
     },
     method: 'GET',
+  });
+
+  mlClient.searchMemoryContainers = ca({
+    url: {
+      fmt: ML_SEARCH_MEMORY_CONTAINERS_ROUTE,
+    },
+    needBody: true,
+    method: 'POST',
   });
 }

--- a/server/routes/ml_routes_service.ts
+++ b/server/routes/ml_routes_service.ts
@@ -16,6 +16,7 @@ import {
   BASE_NODE_API_PATH,
   SearchHit,
   SEARCH_CONNECTORS_NODE_API_PATH,
+  SEARCH_MEMORY_CONTAINERS_NODE_API_PATH,
   REGISTER_AGENT_NODE_API_PATH,
   SEARCH_AGENTS_NODE_API_PATH,
   GET_AGENT_NODE_API_PATH,
@@ -24,6 +25,7 @@ import {
   AgentDict,
   ModelDict,
   ConnectorDict,
+  MemoryContainerDict,
 } from '../../common';
 import {
   generateCustomError,
@@ -84,6 +86,28 @@ export function registerMLRoutes(
       },
     },
     mlRoutesService.searchConnectors
+  );
+
+  router.post(
+    {
+      path: SEARCH_MEMORY_CONTAINERS_NODE_API_PATH,
+      validate: {
+        body: schema.any(),
+      },
+    },
+    mlRoutesService.searchMemoryContainers
+  );
+  router.post(
+    {
+      path: `${BASE_NODE_API_PATH}/{data_source_id}/memory_container/search`,
+      validate: {
+        body: schema.any(),
+        params: schema.object({
+          data_source_id: schema.string(),
+        }),
+      },
+    },
+    mlRoutesService.searchMemoryContainers
   );
 
   router.post(
@@ -254,6 +278,46 @@ export class MLRoutesService {
     } catch (err: any) {
       if (isIgnorableError(err)) {
         return res.ok({ body: { connectors: {} as ConnectorDict } });
+      }
+      return generateCustomError(res, err);
+    }
+  };
+
+  searchMemoryContainers = async (
+    context: RequestHandlerContext,
+    req: OpenSearchDashboardsRequest,
+    res: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    const body = req.body;
+    try {
+      const { data_source_id = '' } = req.params as { data_source_id?: string };
+      const callWithRequest = getClientBasedOnDataSource(
+        context,
+        this.dataSourceEnabled,
+        req,
+        data_source_id,
+        this.client
+      );
+      const response = await callWithRequest(
+        'mlClient.searchMemoryContainers',
+        { body }
+      );
+
+      const hits = response.hits.hits as SearchHit[];
+      const containerDict: MemoryContainerDict = {};
+      hits.forEach((hit: SearchHit) => {
+        containerDict[hit._id] = {
+          id: hit._id,
+          name: hit._source?.name || hit._id,
+        };
+      });
+
+      return res.ok({ body: { memoryContainers: containerDict } });
+    } catch (err: any) {
+      if (isIgnorableError(err)) {
+        return res.ok({
+          body: { memoryContainers: {} as MemoryContainerDict },
+        });
       }
       return generateCustomError(res, err);
     }


### PR DESCRIPTION
### Description

Adds agentic memory support to the agentic search UI. Users can now select "Agentic memory" as a memory type when creating conversational agents and pick a pre-created memory container from a dropdown. Memory type and container are locked after agent creation (matching the agent type field pattern). Also improves the `NoDeployedModelsCallout` to show context-specific messages for LLM vs embedding model dropdowns.

The implementation adds a full server route, Redux store integration, and UI components for searching and selecting memory containers, following the existing `searchConnectors`/`searchModels` pattern across all layers.

**Follow-up:** #884 — Support memory container creation directly from the UI.

### Demo video

[screen-capture (2).webm](https://github.com/user-attachments/assets/6778b2e6-2d1e-4f88-b0b7-c011fd10b647)

### Issues Resolved

Resolves #870

### Testing

**Unit tests:** All 323 tests pass (5 new). New tests cover container dropdown rendering, selection, readOnly behavior, and validation logic.

**End-to-end:** Created memory containers via API, created agents with agentic memory in the UI, ran agentic searches, verified conversation continuation, and confirmed memory fields are locked after agent creation.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`