### PR TITLE
Add yarn cache to setup-node step in CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+          cache-dependency-path: './OpenSearch-Dashboards/**/yarn.lock'
       - name: Install Yarn
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))
 - Fix flaky tests by replacing singleton store with mock store ([#878](https://github.com/opensearch-project/dashboards-flow-framework/pull/878))
 - Clean up CI workflows: update actions, fix yarn version bug, remove dead code ([#861](https://github.com/opensearch-project/dashboards-flow-framework/pull/861))
+- Add yarn cache to setup-node step in CI workflow ([#887](https://github.com/opensearch-project/dashboards-flow-framework/pull/887))
 ### Documentation
 - Fix broken tutorial link in README ([#860](https://github.com/opensearch-project/dashboards-flow-framework/pull/860))
 ### Maintenance


### PR DESCRIPTION
### Description

Adds `cache: 'yarn'` to the `actions/setup-node` step in the macOS build job, enabling the [built-in dependency caching](https://github.com/actions/setup-node#caching-packages-data) provided by the setup-node action. This caches yarn dependencies between workflow runs to reduce build times for PRs.

The `cache-dependency-path` is set to `'./OpenSearch-Dashboards/**/yarn.lock'` to match the project's checkout structure.

Note: The Linux job runs in a container using `nvm` directly (no `setup-node` action), so it is not affected by this change.

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
  - N/A (infrastructure-only change, CI runs will validate)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`