### PR TITLE
Opt out of AnalyticEngine data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased 3.x](https://github.com/opensearch-project/dashboards-flow-framework/compare/3.6...HEAD)
 ### Features
 ### Enhancements
+- Opt out of AnalyticEngine data sources ([#892](https://github.com/opensearch-project/dashboards-flow-framework/pull/892))
 - Update Inspect tab to Search ([#844](https://github.com/opensearch-project/dashboards-flow-framework/pull/844))
 - Add index alias support in agentic search UI ([#871](https://github.com/opensearch-project/dashboards-flow-framework/pull/871))
 - Add fallback query configuration for QueryPlanningTool ([#872](https://github.com/opensearch-project/dashboards-flow-framework/pull/872))

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -19,6 +19,9 @@
     "opensearch-ml",
     "opensearch-flow-framework"
   ],
+  "unsupportedOSDataSourceEngineTypes": [
+    "AnalyticEngine"
+  ],
   "configPath": [
     "flowFrameworkDashboards"
   ]

--- a/public/utils/utils.test.ts
+++ b/public/utils/utils.test.ts
@@ -27,6 +27,7 @@ import {
   getTransformedQuery,
   getExistingVectorField,
   removeVectorFieldFromIndexMappings,
+  dataSourceFilterFn,
 } from './utils';
 import {
   WORKFLOW_RESOURCE_TYPE,
@@ -380,6 +381,55 @@ describe('utils', () => {
     });
     test('returns original string on invalid JSON', () => {
       expect(removeVectorFieldFromIndexMappings('not json')).toBe('not json');
+    });
+  });
+
+  describe('dataSourceFilterFn', () => {
+    const buildDataSource = (
+      version: string,
+      plugins: string[],
+      engineType?: string
+    ) =>
+      ({
+        attributes: {
+          dataSourceVersion: version,
+          installedPlugins: plugins,
+          ...(engineType && { dataSourceEngineType: engineType }),
+        },
+      } as any);
+
+    test('accepts compatible data source', () => {
+      const ds = buildDataSource('2.17.0', [
+        'opensearch-ml',
+        'opensearch-flow-framework',
+      ]);
+      expect(dataSourceFilterFn(ds)).toBe(true);
+    });
+
+    test('rejects AnalyticEngine data source', () => {
+      const ds = buildDataSource(
+        '2.17.0',
+        ['opensearch-ml', 'opensearch-flow-framework'],
+        'AnalyticEngine'
+      );
+      expect(dataSourceFilterFn(ds)).toBe(false);
+    });
+
+    test('accepts OpenSearch engine type', () => {
+      const ds = buildDataSource(
+        '2.17.0',
+        ['opensearch-ml', 'opensearch-flow-framework'],
+        'OpenSearch'
+      );
+      expect(dataSourceFilterFn(ds)).toBe(true);
+    });
+
+    test('accepts when engine type is undefined', () => {
+      const ds = buildDataSource('2.17.0', [
+        'opensearch-ml',
+        'opensearch-flow-framework',
+      ]);
+      expect(dataSourceFilterFn(ds)).toBe(true);
     });
   });
 });

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -638,6 +638,10 @@ export const dataSourceFilterFn = (
 ) => {
   const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
   const installedPlugins = dataSource?.attributes?.installedPlugins || [];
+  const engineType = dataSource?.attributes?.dataSourceEngineType;
+  const unsupportedEngines =
+    (pluginManifest as { unsupportedOSDataSourceEngineTypes?: string[] })
+      .unsupportedOSDataSourceEngineTypes ?? [];
   return (
     semver.satisfies(
       dataSourceVersion,
@@ -645,7 +649,8 @@ export const dataSourceFilterFn = (
     ) &&
     pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
       installedPlugins.includes(plugin)
-    )
+    ) &&
+    (!engineType || !unsupportedEngines.includes(engineType))
   );
 };
 


### PR DESCRIPTION
### Description

Declares AnalyticEngine as an unsupported data source engine type for this plugin, per the campaign in opensearch-project/OpenSearch-Dashboards#11882 and the reference implementation in opensearch-project/OpenSearch-Dashboards#12023.

AnalyticEngine (Mustang) clusters do not have the `opensearch-flow-framework` or `opensearch-ml` backend plugins, so this plugin cannot function against them. This change ensures AnalyticEngine domains are hidden from the data source picker.

#### Changes

1. **`opensearch_dashboards.json`** — Added `"unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"]`
2. **`public/utils/utils.tsx`** — Extended `dataSourceFilterFn` to check the data source engine type against the manifest declaration
3. **`public/utils/utils.test.ts`** — Added 4 unit tests for the engine type filtering

### Issues Resolved

Refs opensearch-project/OpenSearch-Dashboards#11882

### Testing

#### Unit tests

4 new tests added to `public/utils/utils.test.ts` covering:
- Compatible data source accepted
- AnalyticEngine data source rejected
- Explicit OpenSearch engine type accepted
- Undefined engine type accepted (backward compat)

All 68 tests pass:
```
PASS public/utils/utils.test.ts (28.252 s)
  dataSourceFilterFn
    ✓ accepts compatible data source
    ✓ rejects AnalyticEngine data source
    ✓ accepts OpenSearch engine type
    ✓ accepts when engine type is undefined

Test Suites: 1 passed, 1 total
Tests:       68 passed, 68 total
```

#### Manual / integration verification

1. Bootstrapped OSD 3.7.0 locally with `data_source.enabled=true` and this plugin installed
2. Created two data sources via the saved objects API:
   - "AnalyticEngine Test Domain" with `dataSourceEngineType: "AnalyticEngine"` and both required plugins present
   - "Normal OpenSearch Domain" with `dataSourceEngineType: "OpenSearch"` and both required plugins present
3. Verified the filter result:
   - AnalyticEngine Test Domain → **filtered out** (not shown in picker)
   - Normal OpenSearch Domain → **passes filter** (shown in picker)
4. Confirmed plugin status is green: `plugin:flowFrameworkDashboards@3.7.0: green`

### Check List

- [x] All tests pass (`yarn test:jest`)
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`
