### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   rootDir: '../',
   roots: ['<rootDir>'],
   coverageDirectory: './coverage',
-  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.ts'],
   // we mock any non-js-related files and return an empty module. This is needed due to errors
   // when jest tries to interpret these types of files.
   moduleNameMapper: {
@@ -17,8 +17,21 @@ module.exports = {
 
     '^uuid$': '<rootDir>/test/mocks/uuid_mock.ts',
     '^uuid/.*$': '<rootDir>/test/mocks/uuid_mock.ts',
+    // query-string v9 is pure ESM; this shim restores the default-import shape
+    // (`import qs from 'query-string'`) under Jest's CJS transform.
+    '^query-string$': '<rootDir>/test/mocks/query_string_mock.js',
   },
   testEnvironment: 'jest-environment-jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false.
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   collectCoverageFrom: [
@@ -42,5 +55,10 @@ module.exports = {
   clearMocks: true,
   modulePathIgnorePatterns: ['<rootDir>/offline-module-cache/'],
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
-  transformIgnorePatterns: ['<rootDir>/node_modules'],
+  // Transform selected ESM-only deps that ship untranspiled `export`/`import` syntax.
+  // jsonpath-plus (+ jsep deps) and query-string (+ its ESM deps) are pure ESM and must
+  // be babel-transformed for the CJS Jest runtime.
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules(?![/\\\\](jsonpath-plus|jsep|@jsep-plugin[/\\\\][^/\\\\]+|query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
+  ],
 };

--- a/test/mocks/query_string_mock.js
+++ b/test/mocks/query_string_mock.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * query-string v9 is a pure ESM module whose index.js has only a default export.
+ * After the Babel + babel-plugin-add-module-exports pipeline the consumer's
+ * `interopRequireDefault(require('query-string')).default` can resolve to `undefined`.
+ *
+ * This shim is the moduleNameMapper target for 'query-string'. It loads the real
+ * package via a hardcoded node_modules path (relative to this file) so Jest's
+ * moduleNameMapper does not intercept the require and recurse into this file.
+ * query-string is hoisted to the parent repo's node_modules, four levels up from
+ * this file (test/mocks -> test -> plugin -> plugins -> repo root).
+ */
+
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require('../../../../node_modules/query-string/index.js');
+
+// Recover the actual API regardless of which shape the transform produced.
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -9,10 +9,15 @@ Object.defineProperty(window, 'innerWidth', {
   value: 1200,
 });
 
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'.
+process.env.HOST = 'http://localhost:5601';
+
 // Mock matchMedia for Monaco Editor and EUI components
 // This mock prevents infinite re-renders in React 18 by not triggering change handlers
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
+  configurable: true,
   value: jest.fn().mockImplementation((query) => {
     return {
       matches: false,
@@ -30,3 +35,72 @@ Object.defineProperty(window, 'matchMedia', {
 jest.mock('@elastic/eui/lib/services/hooks/useIsWithinBreakpoints', () => ({
   useIsWithinBreakpoints: jest.fn(() => true),
 }));
+
+// Globally mock @osd/monaco. monaco-editor ships untranspiled ESM that breaks the CJS
+// Jest runtime (and jsdom); core/public imports @osd/monaco transitively via core_system.
+// Mirrors src/dev/jest/setup/monaco_mock.js in the parent repo.
+jest.mock('@osd/monaco', () => {
+  const monaco = {
+    editor: {
+      defineTheme: jest.fn(),
+      IStandaloneCodeEditor: jest.fn(),
+      ITextModel: jest.fn(),
+    },
+    languages: {
+      CompletionItemKind: {},
+      CompletionItemProvider: jest.fn(),
+      SignatureHelpProvider: jest.fn(),
+      HoverProvider: jest.fn(),
+      LanguageConfiguration: jest.fn(),
+      onLanguage: jest.fn(),
+      register: jest.fn(),
+      registerCompletionItemProvider: jest.fn(),
+      registerSignatureHelpProvider: jest.fn(),
+      registerHoverProvider: jest.fn(),
+      setLanguageConfiguration: jest.fn(),
+      setMonarchTokensProvider: jest.fn(),
+    },
+    KeyCode: { Enter: 13 },
+    KeyMod: { CtrlCmd: 2048 },
+    Position: class {
+      lineNumber: number;
+      column: number;
+      constructor(lineNumber: number, column: number) {
+        this.lineNumber = lineNumber;
+        this.column = column;
+      }
+    },
+    Range: jest.fn(),
+    CancellationToken: jest.fn(),
+    IMonarchLanguage: jest.fn(),
+  };
+
+  class MockWorker {
+    url: string;
+    postMessage = jest.fn();
+    terminate = jest.fn();
+    onmessage = null;
+    onerror = null;
+    constructor(url: string) {
+      this.url = url;
+    }
+  }
+
+  const getWorker = jest.fn(() => new MockWorker('mock-worker-url'));
+
+  return { monaco, getWorker, setBuildHash: jest.fn() };
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});


### PR DESCRIPTION
Closes #905

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `36 suites / 328 tests / 0 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  resolves to `http://localhost:5601` instead of `http://localhost`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults to `false`).
- **Setup (`test/setup.ts`):** set `process.env.HOST = 'http://localhost:5601'` (jest-location-mock
  reads `HOST` as the base URL for its `window.location` mock, keeping it aligned with
  `testEnvironmentOptions.url`); made the `matchMedia` mock `configurable`; re-declared
  non-configurable `localStorage`/`sessionStorage` as configurable (jsdom 26 marks them
  non-configurable, which otherwise breaks tests that override them via `Object.defineProperty`).

This plugin does not use `jest-raw-loader`, snapshot files, `toThrowError`/`toBeCalled*` matchers,
or a `TextEncoder`/`TextDecoder`-dependent server path, so those common shims/codemods were not
needed.

#### Plugin-specific changes
- **`query-string` v9 ESM fix:** `query-string` v9 is a pure-ESM module exposing only a default
  export, and after the Babel + `babel-plugin-add-module-exports` pipeline the consumer's
  `interopRequireDefault(require('query-string')).default` can resolve to `undefined` under Jest's
  CJS runtime. Added a `moduleNameMapper` entry (`^query-string$`) pointing at a new local shim
  `test/mocks/query_string_mock.js` that loads the real package via a hardcoded `node_modules` path
  (four levels up, since query-string is hoisted to the repo root) and normalizes the export shape
  back to a default import regardless of which shape the transform produced.
- **ESM `transformIgnorePatterns`:** replaced the blanket `<rootDir>/node_modules` ignore with a
  negative-lookahead pattern that still babel-transforms the untranspiled ESM-only deps this plugin
  pulls in: `jsonpath-plus` (+ `jsep`, `@jsep-plugin/*`) and `query-string` (+ its ESM deps
  `decode-uri-component`, `filter-obj`, `split-on-first`).
- **Global `@osd/monaco` mock (`test/setup.ts`):** `monaco-editor` ships untranspiled ESM that
  breaks the CJS Jest runtime and jsdom, and `core/public` imports `@osd/monaco` transitively via
  `core_system`. Added a global `jest.mock('@osd/monaco', ...)` providing stubbed `editor`,
  `languages`, `KeyCode`/`KeyMod`, `Position`/`Range` and a mock web worker, mirroring
  `src/dev/jest/setup/monaco_mock.js` in the parent repo.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
