### PR TITLE
Integrate centralized resource-sharing share button for workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.x](https://github.com/opensearch-project/dashboards-flow-framework/compare/3.6...HEAD)
 ### Features
+- Integrate centralized resource-sharing share button for workflows ([#909](https://github.com/opensearch-project/dashboards-flow-framework/pull/909))
 ### Enhancements
 - Opt out of AnalyticEngine data sources ([#892](https://github.com/opensearch-project/dashboards-flow-framework/pull/892))
 - Update Inspect tab to Search ([#844](https://github.com/opensearch-project/dashboards-flow-framework/pull/844))

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -15,6 +15,8 @@ import {
 import {
   constructHrefWithDataSourceId,
   getDataSourceId,
+  isResourceSharingAvailable,
+  WORKFLOW_RESOURCE_TYPE,
 } from '../../../utils/utils';
 
 export const columns = (actions: any[]) => {
@@ -59,6 +61,28 @@ export const columns = (actions: any[]) => {
           ? toFormattedDate(lastUpdated)
           : EMPTY_FIELD_STRING,
     },
+    ...(isResourceSharingAvailable()
+      ? [
+          {
+            // Resource-sharing SPI marker column: the centralized Share button
+            // is mounted here by security-dashboards-plugin when installed and
+            // resource sharing is enabled for workflows.
+            name: 'Share',
+            width: '5%',
+            render: (workflow: Workflow) => (
+              <div
+                data-resource-share-button
+                data-resource-id={workflow.id}
+                data-resource-type={WORKFLOW_RESOURCE_TYPE}
+                data-resource-share-display="icon"
+                {...(dataSourceId
+                  ? { 'data-resource-data-source-id': dataSourceId }
+                  : {})}
+              />
+            ),
+          },
+        ]
+      : []),
     {
       name: 'Actions',
       width: '10%',

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -67,13 +67,14 @@ export const columns = (actions: any[]) => {
             // Resource-sharing SPI marker column: the centralized Share button
             // is mounted here by security-dashboards-plugin when installed and
             // resource sharing is enabled for workflows.
-            name: 'Share',
+            name: 'Access',
             width: '5%',
             render: (workflow: Workflow) => (
               <div
                 data-resource-share-button
                 data-resource-id={workflow.id}
                 data-resource-type={WORKFLOW_RESOURCE_TYPE}
+                {...(workflow.name ? { 'data-resource-name': workflow.name } : {})}
                 data-resource-share-display="icon"
                 {...(dataSourceId
                   ? { 'data-resource-data-source-id': dataSourceId }

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -74,7 +74,9 @@ export const columns = (actions: any[]) => {
                 data-resource-share-button
                 data-resource-id={workflow.id}
                 data-resource-type={WORKFLOW_RESOURCE_TYPE}
-                {...(workflow.name ? { 'data-resource-name': workflow.name } : {})}
+                {...(workflow.name
+                  ? { 'data-resource-name': workflow.name }
+                  : {})}
                 data-resource-share-display="icon"
                 {...(dataSourceId
                   ? { 'data-resource-data-source-id': dataSourceId }

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -16,7 +16,7 @@ import {
   constructHrefWithDataSourceId,
   getDataSourceId,
   isResourceSharingAvailable,
-  WORKFLOW_RESOURCE_TYPE,
+  SHAREABLE_WORKFLOW_RESOURCE_TYPE,
 } from '../../../utils/utils';
 
 export const columns = (actions: any[]) => {
@@ -73,7 +73,7 @@ export const columns = (actions: any[]) => {
               <div
                 data-resource-share-button
                 data-resource-id={workflow.id}
-                data-resource-type={WORKFLOW_RESOURCE_TYPE}
+                data-resource-type={SHAREABLE_WORKFLOW_RESOURCE_TYPE}
                 {...(workflow.name
                   ? { 'data-resource-name': workflow.name }
                   : {})}

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1232,3 +1232,26 @@ export function isKnownEmbeddingModel(
     embeddingUrlPatterns.some((p) => url.includes(p))
   );
 }
+
+/**
+ * Resource type registered by the flow-framework backend plugin with the
+ * security plugin's resource-sharing framework.
+ */
+export const WORKFLOW_RESOURCE_TYPE = 'workflow';
+
+/**
+ * Whether resource sharing is available for workflows, via the core
+ * capability registered by security-dashboards-plugin. False when that plugin
+ * is not installed, the feature is disabled, or the workflow type is not
+ * registered — no plugin dependency involved.
+ */
+export function isResourceSharingAvailable(): boolean {
+  try {
+    const caps = (getCore().application.capabilities as any)?.resourceSharing;
+    if (!caps?.enabled) return false;
+    const types: string = caps.availableTypes ?? '';
+    return types.split(',').includes(WORKFLOW_RESOURCE_TYPE);
+  } catch (e) {
+    return false;
+  }
+}

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1237,7 +1237,7 @@ export function isKnownEmbeddingModel(
  * Resource type registered by the flow-framework backend plugin with the
  * security plugin's resource-sharing framework.
  */
-export const WORKFLOW_RESOURCE_TYPE = 'workflow';
+export const SHAREABLE_WORKFLOW_RESOURCE_TYPE = 'workflow';
 
 /**
  * Whether resource sharing is available for workflows, via the core
@@ -1250,7 +1250,7 @@ export function isResourceSharingAvailable(): boolean {
     const caps = (getCore().application.capabilities as any)?.resourceSharing;
     if (!caps?.enabled) return false;
     const types: string = caps.availableTypes ?? '';
-    return types.split(',').includes(WORKFLOW_RESOURCE_TYPE);
+    return types.split(',').includes(SHAREABLE_WORKFLOW_RESOURCE_TYPE);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
### Description

Integrates the centralized share button from [security-dashboards-plugin PR #2491](https://github.com/opensearch-project/security-dashboards-plugin/pull/2491) via its dependency-free DOM-marker SPI.

**How it works**
- Renders empty marker elements (`data-resource-share-button` + resource id/type attributes); the security plugin mounts its Share/Update Access button + modal into them when installed and resource sharing is enabled
- UI chrome (Share column) is gated on the core `resourceSharing` capability (`enabled` + type present in `availableTypes`), so it is completely absent when the feature is off or the security plugin is missing
- No dependency on the security plugin: no manifest changes, no imports from it — markers are inert empty elements when unfulfilled

**Testing**: verified manually on OpenSearch 3.8.0 (staging) + OSD main with resource sharing enabled — share/update flows, `can_share: false` graying, and feature-off column hiding.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
