### PR TITLE
Gate resource-sharing Access column on per-data-source availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 - Integrate centralized resource-sharing share button for workflows ([#909](https://github.com/opensearch-project/dashboards-flow-framework/pull/909))
 ### Enhancements
+- Gate the resource-sharing Access column on per-data-source availability ([#914](https://github.com/opensearch-project/dashboards-flow-framework/pull/914))
 - Opt out of AnalyticEngine data sources ([#892](https://github.com/opensearch-project/dashboards-flow-framework/pull/892))
 - Update Inspect tab to Search ([#844](https://github.com/opensearch-project/dashboards-flow-framework/pull/844))
 - Add index alias support in agentic search UI ([#871](https://github.com/opensearch-project/dashboards-flow-framework/pull/871))

--- a/public/pages/workflows/workflow_list/columns.tsx
+++ b/public/pages/workflows/workflow_list/columns.tsx
@@ -15,11 +15,13 @@ import {
 import {
   constructHrefWithDataSourceId,
   getDataSourceId,
-  isResourceSharingAvailable,
   SHAREABLE_WORKFLOW_RESOURCE_TYPE,
 } from '../../../utils/utils';
 
-export const columns = (actions: any[]) => {
+export const columns = (
+  actions: any[],
+  resourceSharingAvailableTypes: string[] = []
+) => {
   const dataSourceId = getDataSourceId();
 
   return [
@@ -61,7 +63,7 @@ export const columns = (actions: any[]) => {
           ? toFormattedDate(lastUpdated)
           : EMPTY_FIELD_STRING,
     },
-    ...(isResourceSharingAvailable()
+    ...(resourceSharingAvailableTypes.includes(SHAREABLE_WORKFLOW_RESOURCE_TYPE)
       ? [
           {
             // Resource-sharing SPI marker column: the centralized Share button
@@ -69,20 +71,23 @@ export const columns = (actions: any[]) => {
             // resource sharing is enabled for workflows.
             name: 'Access',
             width: '5%',
-            render: (workflow: Workflow) => (
-              <div
-                data-resource-share-button
-                data-resource-id={workflow.id}
-                data-resource-type={SHAREABLE_WORKFLOW_RESOURCE_TYPE}
-                {...(workflow.name
-                  ? { 'data-resource-name': workflow.name }
-                  : {})}
-                data-resource-share-display="icon"
-                {...(dataSourceId
-                  ? { 'data-resource-data-source-id': dataSourceId }
-                  : {})}
-              />
-            ),
+            render: (workflow: Workflow) =>
+              resourceSharingAvailableTypes.includes(
+                SHAREABLE_WORKFLOW_RESOURCE_TYPE
+              ) ? (
+                <div
+                  data-resource-share-button
+                  data-resource-id={workflow.id}
+                  data-resource-type={SHAREABLE_WORKFLOW_RESOURCE_TYPE}
+                  {...(workflow.name
+                    ? { 'data-resource-name': workflow.name }
+                    : {})}
+                  data-resource-share-display="icon"
+                  {...(dataSourceId
+                    ? { 'data-resource-data-source-id': dataSourceId }
+                    : {})}
+                />
+              ) : null,
           },
         ]
       : []),

--- a/public/pages/workflows/workflow_list/workflow_list.tsx
+++ b/public/pages/workflows/workflow_list/workflow_list.tsx
@@ -38,7 +38,11 @@ import { MultiSelectFilter } from '../../../general_components';
 import { WORKFLOWS_TAB } from '../workflows';
 import { DeleteWorkflowModal } from './delete_workflow_modal';
 import { ResourceList } from './resource_list';
-import { isValidUiWorkflow } from '../../../utils';
+import {
+  getDataSourceId,
+  getResourceSharingAvailableTypes,
+  isValidUiWorkflow,
+} from '../../../utils';
 
 interface WorkflowListProps {
   setSelectedTabId: (tabId: WORKFLOWS_TAB) => void;
@@ -59,6 +63,24 @@ export function WorkflowList(props: WorkflowListProps) {
   const { workflows, loading } = useSelector(
     (state: AppState) => state.workflows
   );
+  const dataSourceId = getDataSourceId();
+
+  // Shareable resource types available on the currently selected data source.
+  // Probed async on mount and whenever the selected data source changes; used
+  // to gate the resource-sharing 'Access' column.
+  const [resourceSharingAvailableTypes, setResourceSharingAvailableTypes] =
+    useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    getResourceSharingAvailableTypes(dataSourceId).then((types) => {
+      if (!cancelled) {
+        setResourceSharingAvailableTypes(types);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSourceId]);
 
   // table filters. the list of filters depends on the datasource version, if applicable.
   const isPreV219 =
@@ -212,7 +234,7 @@ export function WorkflowList(props: WorkflowListProps) {
               items={filteredWorkflows}
               rowHeader="name"
               // @ts-ignore
-              columns={columns(tableActions)}
+              columns={columns(tableActions, resourceSharingAvailableTypes)}
               sorting={sorting}
               pagination={true}
               hasActions={true}

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1240,18 +1240,34 @@ export function isKnownEmbeddingModel(
 export const SHAREABLE_WORKFLOW_RESOURCE_TYPE = 'workflow';
 
 /**
- * Whether resource sharing is available for workflows, via the core
- * capability registered by security-dashboards-plugin. False when that plugin
- * is not installed, the feature is disabled, or the workflow type is not
- * registered — no plugin dependency involved.
+ * Fetch the shareable resource types available on the given data source (or
+ * the local cluster when no data source id is passed), via the routes
+ * registered by security-dashboards-plugin. Returns [] when that plugin is
+ * not installed, resource sharing is disabled on that source, or the request
+ * fails — no plugin dependency involved.
  */
-export function isResourceSharingAvailable(): boolean {
+export const getResourceSharingAvailableTypes = async (
+  resourceDataSourceId?: string
+): Promise<string[]> => {
   try {
-    const caps = (getCore().application.capabilities as any)?.resourceSharing;
-    if (!caps?.enabled) return false;
-    const types: string = caps.availableTypes ?? '';
-    return types.split(',').includes(SHAREABLE_WORKFLOW_RESOURCE_TYPE);
+    const http = getCore().http;
+    const query = resourceDataSourceId
+      ? { dataSourceId: resourceDataSourceId }
+      : {};
+    // Global gate: resource sharing must be enabled on the selected data source.
+    const info: any = await http.get('/api/v1/auth/dashboardsinfo', { query });
+    if (!info?.resource_sharing_enabled) {
+      return [];
+    }
+    // Per-type gate: the registered/protected shareable types on that source.
+    const typesResp: any = await http.get('/api/resource/types', { query });
+    const rawTypes = Array.isArray(typesResp)
+      ? typesResp
+      : (typesResp?.types ?? []);
+    return rawTypes
+      .map((entry: { type: string }) => entry?.type)
+      .filter((type: string | undefined): type is string => Boolean(type));
   } catch (e) {
-    return false;
+    return [];
   }
-}
+};

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1240,11 +1240,8 @@ export function isKnownEmbeddingModel(
 export const SHAREABLE_WORKFLOW_RESOURCE_TYPE = 'workflow';
 
 /**
- * Fetch the shareable resource types available on the given data source (or
- * the local cluster when no data source id is passed), via the routes
- * registered by security-dashboards-plugin. Returns [] when that plugin is
- * not installed, resource sharing is disabled on that source, or the request
- * fails — no plugin dependency involved.
+ * Resource-sharing types available on the given data source (feature flag +
+ * per-type list). Returns [] when disabled or on error.
  */
 export const getResourceSharingAvailableTypes = async (
   resourceDataSourceId?: string

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -1252,8 +1252,10 @@ export const getResourceSharingAvailableTypes = async (
       ? { dataSourceId: resourceDataSourceId }
       : {};
     // Global gate: resource sharing must be enabled on the selected data source.
-    const info: any = await http.get('/api/v1/auth/dashboardsinfo', { query });
-    if (!info?.resource_sharing_enabled) {
+    const info: any = await http.get('/api/v1/auth/resource_sharing_enabled', {
+      query,
+    });
+    if (!info?.enabled) {
       return [];
     }
     // Per-type gate: the registered/protected shareable types on that source.


### PR DESCRIPTION
### Description
Fast-follow to #909 (centralized resource-sharing share button). Gates the Access column on **per-data-source** resource-sharing availability instead of the local, synchronous Dashboards capability: it now checks BOTH the global `resource_sharing_enabled` feature flag and per-type membership, evaluated per selected data source, so the column correctly hides on data sources where resource sharing is disabled.

Depends on the security-dashboards-plugin data-source-aware `dashboardsinfo` route (opensearch-project/security-dashboards-plugin#2520).

### Testing
- Updated unit tests.
- Verified E2E on a multi-data-source setup (enabled vs disabled data source).
