### PR TITLE
Install a locked pre-16 Cypress in the remote integration test workflow

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Install Cypress
         run: |
-          npm install cypress --save-dev
+          npm ci
         shell: bash
         working-directory: opensearch-dashboards-functional-test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add agentic memory support for conversational agents ([#883](https://github.com/opensearch-project/dashboards-flow-framework/pull/883))
 ### Bug Fixes
 ### Infrastructure
+- Pin Cypress to the functional-test lockfile version via `npm ci` in the remote integration test workflow ([#915](https://github.com/opensearch-project/dashboards-flow-framework/pull/915))
 - Add unit tests for utility functions to increase test coverage ([#862](https://github.com/opensearch-project/dashboards-flow-framework/pull/862))
 - Fix flaky tests by replacing singleton store with mock store ([#878](https://github.com/opensearch-project/dashboards-flow-framework/pull/878))
 - Clean up CI workflows: update actions, fix yarn version bug, remove dead code ([#861](https://github.com/opensearch-project/dashboards-flow-framework/pull/861))


### PR DESCRIPTION
### Description
The remote integration test workflow (`remote-integ-tests-workflow.yml`) checks out the functional-test repo and installs Cypress **unpinned** (`npm install cypress --save-dev`), so it pulled the latest published major. When Cypress **16.0.0** shipped — which **removed `Cypress.env()`** (the FT specs read e.g. `Cypress.env('openSearchUrl')`) — CI began installing it and the run failed with `Cypress.env() was removed`.

Use `npm ci` so the functional-test checkout uses its lockfile-pinned (pre-16) Cypress. This mirrors anomaly-detection-dashboards-plugin PR #1246. No test changes.

### Issues Resolved
Fixes the `Cypress.env() was removed` failure in the remote integration test workflow.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.